### PR TITLE
TEA-3532 Tillatt å opprette flere behandlinger på samme eksternFagsakId med forskjellige ytelsestype. 

### DIFF
--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -8,6 +8,7 @@ env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-tilbake:${{ github.sha }}
 jobs:
   deploy-to-dev:
+    if: github.event.pull_request.draft == false
     name: Bygg app/image, push til github, deploy til dev-fss
     runs-on: ubuntu-latest
     steps:

--- a/src/main/resources/db/migration/V2__altered_fagsak.sql
+++ b/src/main/resources/db/migration/V2__altered_fagsak.sql
@@ -1,3 +1,4 @@
 DROP INDEX fagsak_ekstern_fagsak_id_idx;
+DROP INDEX fagsak_ytelsestype_idx;
 
 CREATE UNIQUE INDEX ON fagsak (ekstern_fagsak_id, ytelsestype);

--- a/src/main/resources/db/migration/V2__altered_fagsak.sql
+++ b/src/main/resources/db/migration/V2__altered_fagsak.sql
@@ -1,0 +1,3 @@
+DROP INDEX fagsak_ekstern_fagsak_id_idx;
+
+CREATE UNIQUE INDEX ON fagsak (ekstern_fagsak_id, ytelsestype);

--- a/src/main/resources/db/migration/V2__altered_fagsak.sql
+++ b/src/main/resources/db/migration/V2__altered_fagsak.sql
@@ -2,3 +2,9 @@ DROP INDEX fagsak_ekstern_fagsak_id_idx;
 DROP INDEX fagsak_ytelsestype_idx;
 
 CREATE UNIQUE INDEX ON fagsak (ekstern_fagsak_id, ytelsestype);
+
+ALTER TABLE fagsak
+    ALTER COLUMN ekstern_fagsak_id SET NOT NULL;
+
+ALTER TABLE fagsak
+    ALTER COLUMN bruker_ident SET NOT NULL;

--- a/src/test/kotlin/no/nav/familie/tilbake/DatabaseChangesTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/DatabaseChangesTest.kt
@@ -10,7 +10,7 @@ class DatabaseChangesTest {
     companion object {
 
         // Denne knekker bygg med høyere db-versjon enn main. Oppdater kun når du er klar for å merge db-endringer.
-        const val MERGED_DB_VERSION = 1
+        const val MERGED_DB_VERSION = 2
     }
 
     /**


### PR DESCRIPTION
**Stoppet å deployere i prepod for draft pull request