### PR TITLE
Feilrettinger på vedtaksbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/service/dokumentbestilling/vedtak/AvsnittUtil.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/service/dokumentbestilling/vedtak/AvsnittUtil.kt
@@ -15,12 +15,12 @@ internal object AvsnittUtil {
 
     fun lagVedtaksbrevDeltIAvsnitt(vedtaksbrevsdata: HbVedtaksbrevsdata, hovedoverskrift: String): List<Avsnitt> {
         val resultat: MutableList<Avsnitt> = ArrayList()
-        Vedtaksbrevsfritekst.settInnMarkeringForFritekst(vedtaksbrevsdata)
-        resultat.add(lagOppsummeringsavsnitt(vedtaksbrevsdata, hovedoverskrift))
+        val vedtaksbrevsdataMedFriteksmarkeringer = Vedtaksbrevsfritekst.settInnMarkeringForFritekst(vedtaksbrevsdata)
+        resultat.add(lagOppsummeringsavsnitt(vedtaksbrevsdataMedFriteksmarkeringer, hovedoverskrift))
         if (vedtaksbrevsdata.felles.vedtaksbrevstype == Vedtaksbrevstype.ORDINÆR) {
-            resultat.addAll(lagPerioderavsnitt(vedtaksbrevsdata))
+            resultat.addAll(lagPerioderavsnitt(vedtaksbrevsdataMedFriteksmarkeringer))
         }
-        resultat.add(lagAvsluttendeAvsnitt(vedtaksbrevsdata))
+        resultat.add(lagAvsluttendeAvsnitt(vedtaksbrevsdataMedFriteksmarkeringer))
         return resultat
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/service/dokumentbestilling/vedtak/VedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/service/dokumentbestilling/vedtak/VedtaksbrevService.kt
@@ -295,12 +295,11 @@ class VedtaksbrevService(private val behandlingRepository: BehandlingRepository,
                ?: error("Det er ingen vurderinger utført på behandling $behandlingId. Vedtaksbrev kan ikke genereres")
     }
 
-    private fun finnVarsletDato(behandlingId: UUID): LocalDate {
+    private fun finnVarsletDato(behandlingId: UUID): LocalDate? {
         val varselbrevData = brevSporingRepository
                 .findFirstByBehandlingIdAndBrevtypeOrderBySporbarOpprettetTidDesc(behandlingId, Brevtype.VARSEL)
 
         return varselbrevData?.sporbar?.opprettetTid?.toLocalDate()
-               ?: error("Det finnes ikke varsel for behandling med id $behandlingId")
     }
 
     private fun finnVarsletBeløp(behandling: Behandling): BigDecimal? {

--- a/src/main/kotlin/no/nav/familie/tilbake/service/dokumentbestilling/vedtak/handlebars/dto/HbVarsel.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/service/dokumentbestilling/vedtak/handlebars/dto/HbVarsel.kt
@@ -4,5 +4,5 @@ import java.math.BigDecimal
 import java.time.LocalDate
 
 @Suppress("unused") // Handlebars
-class HbVarsel(private val varsletDato: LocalDate,
+class HbVarsel(private val varsletDato: LocalDate?,
                private val varsletBeløp: BigDecimal?)

--- a/src/main/resources/templates/nb/vedtak/vedtak_felles.hbs
+++ b/src/main/resources/templates/nb/vedtak/vedtak_felles.hbs
@@ -1,4 +1,4 @@
 {{#* inline "før-skatt"}}{{#if (not skalIkkeViseSkatt)}} før skatt{{/if}}{{/inline}}
 {{~#* inline "korrigert-total-beløp" ~}}
-{{#if erFeilutbetaltBeløpKorrigertNed}} Beløpet har blitt endret. Nytt feilutbetalt beløp utgjør {{kroner totaltFeilutbetaltBeløp}} kroner.{{/if}}
+{{#if erFeilutbetaltBeløpKorrigertNed}} Beløpet har blitt endret. Nytt feilutbetalt beløp utgjør {{kroner totaltFeilutbetaltBeløp}}.{{/if}}
 {{~/inline~}}

--- a/src/main/resources/templates/nn/vedtak/vedtak_felles.hbs
+++ b/src/main/resources/templates/nn/vedtak/vedtak_felles.hbs
@@ -1,4 +1,4 @@
 {{#* inline "før-skatt"}}{{#if (not skalIkkeViseSkatt)}} før skatt{{/if}}{{/inline}}
 {{~#* inline "korrigert-total-beløp" ~}}
-{{#if erFeilutbetaltBeløpKorrigertNed}} Beløpet har blitt endra. Nytt feilutbetalt beløp utgjør {{kroner totaltFeilutbetaltBeløp}} kroner.{{/if}}
+{{#if erFeilutbetaltBeløpKorrigertNed}} Beløpet har blitt endra. Nytt feilutbetalt beløp utgjør {{kroner totaltFeilutbetaltBeløp}}.{{/if}}
 {{~/inline~}}

--- a/src/test/kotlin/no/nav/familie/tilbake/service/dokumentbestilling/vedtak/AvsnittUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/service/dokumentbestilling/vedtak/AvsnittUtilTest.kt
@@ -69,6 +69,7 @@ class AvsnittUtilTest {
                                                                                      BigDecimal(23002),
                                                                                      BigDecimal(23002),
                                                                                      BigDecimal.ZERO),
+                                                     fritekstoppsummering = "Her finner du friteksten til oppsummeringen",
                                                      hjemmel = HbHjemmel("Folketrygdloven § 22-15"),
                                                      varsel = HbVarsel(varsletBeløp = BigDecimal(33001),
                                                                        varsletDato = LocalDate.of(2020, 4, 4)),
@@ -108,12 +109,16 @@ class AvsnittUtilTest {
         assertThat(resultat).hasSize(4)
         assertThat(resultat[0].avsnittstype).isEqualTo(Avsnittstype.OPPSUMMERING)
         assertThat(resultat[0].underavsnittsliste).hasSize(1)
+        assertThat(resultat[0].underavsnittsliste[0].fritekstTillatt).isTrue()
         assertThat(resultat[1].avsnittstype).isEqualTo(Avsnittstype.PERIODE)
-        assertThat(resultat[1].underavsnittsliste).hasSize(2)
+        assertThat(resultat[1].underavsnittsliste).hasSize(3)
+        resultat[1].underavsnittsliste.forEach { assertThat(it.fritekstTillatt).isTrue() }
         assertThat(resultat[2].avsnittstype).isEqualTo(Avsnittstype.PERIODE)
         assertThat(resultat[2].underavsnittsliste).hasSize(3)
+        resultat[2].underavsnittsliste.forEach { assertThat(it.fritekstTillatt).isTrue() }
         assertThat(resultat[3].avsnittstype).isEqualTo(Avsnittstype.TILLEGGSINFORMASJON)
         assertThat(resultat[3].underavsnittsliste).hasSize(6)
+        resultat[3].underavsnittsliste.forEach { assertThat(it.fritekstTillatt).isFalse() }
     }
 
 

--- a/src/test/kotlin/no/nav/familie/tilbake/service/dokumentbestilling/vedtak/VedtaksbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/service/dokumentbestilling/vedtak/VedtaksbrevServiceTest.kt
@@ -35,6 +35,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.io.File
 import java.time.LocalDate
 
 internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
@@ -102,7 +103,7 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
         kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
         vilkårsvurderingRepository.insert(Testdata.vilkår.copy(perioder = setOf(Testdata.vilkårsperiode.copy(godTro = null))))
         faktaRepository.insert(Testdata.faktaFeilutbetaling)
-        brevSporingRepository.insert(Testdata.brevsporing)
+//        brevSporingRepository.insert(Testdata.brevsporing)
 
         val personinfo = Personinfo("28056325874", LocalDate.now(), "Fiona")
 
@@ -139,9 +140,15 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
                                                       "Dette er en stor og gild oppsummeringstekst",
                                                       listOf(PeriodeMedTekstDto(Periode(LocalDate.now().minusDays(1),
                                                                                         LocalDate.now()),
-                                                                                faktaAvsnitt = "fakta")))
+                                                                                faktaAvsnitt = "Friktekst om fakta",
+                                                                                foreldelseAvsnitt = "Friktekst om foreldelse",
+                                                                                vilkårAvsnitt = "Friktekst om vilkår",
+                                                                                særligeGrunnerAvsnitt = "Friktekst om særligeGrunner",
+                                                                                særligeGrunnerAnnetAvsnitt = "Friktekst om særligeGrunnerAnnet")))
 
         val bytes = vedtaksbrevService.hentForhåndsvisningVedtaksbrevMedVedleggSomPdf(dto)
+        val file = File("Test.pdf")
+        file.writeBytes(bytes)
 
         PdfaValidator.validatePdf(bytes)
     }

--- a/src/test/resources/vedtaksbrev/OS_ikke_tilbakekreves_med_korrigert_beløp.txt
+++ b/src/test/resources/vedtaksbrev/OS_ikke_tilbakekreves_med_korrigert_beløp.txt
@@ -1,4 +1,4 @@
-Vi varslet deg 4. april 2020 om at du har fått 15 000 kroner for mye. Beløpet har blitt endret. Nytt feilutbetalt beløp utgjør 1 000 kroner kroner. Vi har behandlet saken din og du må ikke betale tilbake det feilutbetalte beløpet.
+Vi varslet deg 4. april 2020 om at du har fått 15 000 kroner for mye. Beløpet har blitt endret. Nytt feilutbetalt beløp utgjør 1 000 kroner. Vi har behandlet saken din og du må ikke betale tilbake det feilutbetalte beløpet.
 _Gjelder perioden fra og med 1. januar 2019 til og med 1. januar 2019
 foo bar baz
 


### PR DESCRIPTION
Varsel er ikke lenger påkrevd
kroner kroner er fjernet
Avsnitt og underavsnitt tillater fdritekst når de skal det.