### PR TITLE
Lagt inn støtte for deploy til gcp

### DIFF
--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -48,3 +48,9 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-fss
           RESOURCE: app-preprod.yaml
+      - name: Deploy til dev-gcp
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: app-dev-gcp.yaml

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -63,3 +63,9 @@ jobs:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: mvn -B --no-transfer-progress package verify sonar:sonar --settings .m2/maven-settings.xml  -DtrimStackTrace=false --file pom.xml -Dchangelist= -Dsha1=-$TIMESTAMP-$(echo $GITHUB_SHA | cut -c1-7)
+      - name: Deploy til prod-gcp
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: app-prod-gcp.yaml

--- a/app-dev-gcp.yaml
+++ b/app-dev-gcp.yaml
@@ -1,0 +1,85 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: familie-tilbake
+  namespace: teamfamilie
+  labels:
+    team: teamfamilie
+
+spec:
+  image: {{ image }}
+  port: 8030
+  liveness:
+    path: /internal/status/isAlive
+    initialDelay: 30
+    failureThreshold: 10
+  readiness:
+    path: /internal/status/isAlive
+    initialDelay: 30
+    failureThreshold: 10
+  prometheus:
+    enabled: true
+    path: /internal/prometheus
+  vault:
+    enabled: false
+  gcp: # Database
+    sqlInstances:
+      - type: POSTGRES_13
+        name: familie-tilbake
+        autoBackupTime: "03:00"
+        databases:
+          - name: familie-tilbake
+            envVarPrefix: DB
+  azure:
+    application:
+      claims:
+        extra:
+          - "NAVident"
+        groups:
+          - id: d21e00a4-969d-4b28-8782-dc818abfae65 # 0000-GA-Barnetrygd
+          - id: 9449c153-5a1e-44a7-84c6-7cc7a8867233 # 0000-GA-Barnetrygd-Beslutter
+          - id: 93a26831-9866-4410-927b-74ff51a9107c # 0000-GA-Barnetrygd-Veileder
+          - id: ee5e0b5e-454c-4612-b931-1fe363df7c2c # 0000-GA-Enslig-Forsorger-Saksbehandler
+          - id: 01166863-22f1-4e16-9785-d7a05a22df74 # 0000-GA-Enslig-Forsorger-Beslutter
+          - id: 19dcbfde-4cdb-4c64-a1ea-ac9802b03339 # 0000-GA-Enslig-Forsorger-Veileder
+          - id: 928636f4-fd0d-4149-978e-a6fb68bb19de # 0000-GA-STDAPPS - tilgang til prosessering
+      enabled: true
+      tenant: trygdeetaten.no
+  accessPolicy:
+    inbound:
+      rules:
+        - application: familie-ba-sak
+          namespace: teamfamilie
+        - application: familie-ef-sak
+          namespace: default
+        - application: familie-ks-sak
+          namespace: default
+        - application: familie-tilbake-frontend
+          namespace: teamfamilie
+          cluster: dev-gcp
+        - application: ida
+          namespace: default
+          cluster: prod-fss
+        - application: familie-prosessering
+          namespace: teamfamilie
+          cluster: dev-gcp
+  replicas:
+    min: 2
+    max: 4
+    cpuThresholdPercentage: 50
+  resources:
+    limits:
+      memory: 1024Mi
+      cpu: "1"
+    requests:
+      memory: 512Mi
+      cpu: 500m
+  ingresses:
+    - https://familie-tilbake.dev.intern.nav.no
+  secureLogs:
+    enabled: true
+  env:
+    - name: SPRING_PROFILES_ACTIVE
+      value: preprod-gcp
+  kafka:
+    pool: nav-dev

--- a/app-prod-gcp.yaml
+++ b/app-prod-gcp.yaml
@@ -1,0 +1,82 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: familie-tilbake
+  namespace: teamfamilie
+  labels:
+    team: teamfamilie
+
+spec:
+  image: {{ image }}
+  port: 8030
+  liveness:
+    path: /internal/status/isAlive
+    initialDelay: 30
+    failureThreshold: 10
+  readiness:
+    path: /internal/status/isAlive
+    initialDelay: 30
+    failureThreshold: 10
+  prometheus:
+    enabled: true
+    path: /internal/prometheus
+  vault:
+    enabled: false
+  gcp: # Database
+    sqlInstances:
+      - type: POSTGRES_13
+        name: familie-tilbake
+        diskAutoresize: true
+        highAvailability: true
+        autoBackupTime: "03:00"
+        databases:
+          - name: familie-tilbake
+            envVarPrefix: DB
+  azure:
+    application:
+      claims:
+        extra:
+          - "NAVident"
+        groups:
+          - id: 847e3d72-9dc1-41c3-80ff-f5d4acdd5d46 # 0000-GA-Barnetrygd
+          - id: 7a271f87-39fb-468b-a9ee-6cf3c070f548 # 0000-GA-Barnetrygd-Beslutter
+          - id: 199c2b39-e535-4ae8-ac59-8ccbee7991ae # 0000-GA-Barnetrygd-Veileder
+          - id: e40090eb-c2fb-400e-b412-e9084019a73b # 0000-GA-Kontantstøtte
+          - id: 54cd86b8-2e23-48b2-8852-b05b5827bb0f # 0000-GA-Kontantstøtte-Veileder
+          - id: 87190cf3-b278-457d-8ab7-1a5c55a9edd7 # Group_87190cf3-b278-457d-8ab7-1a5c55a9edd7 tilgang til prosessering
+      enabled: true
+  accessPolicy:
+    inbound:
+      rules:
+        - application: familie-ba-sak
+          namespace: teamfamilie
+        - application: familie-ef-sak
+          namespace: default
+        - application: familie-ks-sak
+          namespace: default
+        - application: familie-tilbake-frontend
+          namespace: teamfamilie
+          cluster: prod-gcp
+        - application: familie-prosessering
+          namespace: teamfamilie
+          cluster: gcp-prod
+  replicas:
+    min: 2
+    max: 4
+    cpuThresholdPercentage: 50
+  resources:
+    limits:
+      memory: 1024Mi
+      cpu: "1"
+    requests:
+      memory: 512Mi
+      cpu: 500m
+  secureLogs:
+    enabled: true
+  ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
+    - https://familie-tilbake.intern.nav.no
+  env:
+    - name: SPRING_PROFILES_ACTIVE
+      value: prod-gcp
+  kafka:
+    pool: nav-prod

--- a/src/main/kotlin/no/nav/familie/tilbake/config/FlywayConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/FlywayConfig.kt
@@ -1,14 +1,10 @@
 package no.nav.familie.tilbake.config
 
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer
-import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.context.annotation.Bean
 
-@ConfigurationProperties("spring.cloud.vault.database")
-@ConditionalOnProperty(name = ["spring.cloud.vault.enabled"])
 @ConstructorBinding
 data class FlywayConfig(private val role: String) {
 

--- a/src/main/resources/application-preprod-gcp.yaml
+++ b/src/main/resources/application-preprod-gcp.yaml
@@ -1,0 +1,48 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/familie-tilbake
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+no.nav.security.jwt:
+  issuer.azuread:
+    discoveryurl: https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration
+    accepted_audience: ${AZURE_APP_CLIENT_ID}
+    proxyurl: http://webproxy-nais.nav.no:8088
+    cookie_name: azure_token
+
+
+oppdrag.mq:
+  queuemanager: MQ1LSC02
+  kravgrunnlag: QA.Q1_FAMILIE_TILBAKE.KRAVGRUNNLAG
+  channel: Q1_FAMILIE_TILBAKE
+  hostname: b27apvl176.preprod.local
+  port: 1413
+  user: ${MQ_SRVBRUKER}
+  password: ${MQ_PASSWORD}
+  enabled: true
+
+rolle:
+  barnetrygd:
+    veileder: "93a26831-9866-4410-927b-74ff51a9107c"
+    saksbehandler: "d21e00a4-969d-4b28-8782-dc818abfae65"
+    beslutter: "9449c153-5a1e-44a7-84c6-7cc7a8867233"
+  enslig:
+    veileder: "19dcbfde-4cdb-4c64-a1ea-ac9802b03339"
+    saksbehandler: "ee5e0b5e-454c-4612-b931-1fe363df7c2c"
+    beslutter: "01166863-22f1-4e16-9785-d7a05a22df74"
+  kontantstøtte:
+    veileder: ""
+    saksbehandler: ""
+    beslutter: ""
+
+
+
+FAMILIE_INTEGRASJONER_URL: http://familie-integrasjoner-q1.teamfamilie
+SECURITYTOKENSERVICE_URL: https://sts-q1.preprod.local/SecurityTokenServiceProvider/
+
+AZUREAD_DISCOVERY_URL: https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration
+AZUREAD_TOKEN_ENDPOINT_URL: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
+PDL_URL: http://pdl-api-q1.pdl
+ACCEPTED_CLIENTS: ${BA_SAK_CLIENT_ID}, ${EF_SAK_CLIENT_ID}, ${FAMILIE_TILBAKE_FRONTEND_CLIENT_ID}
+FORELDELSE_ANTALL_MÅNED: 3
+OPPRETTELSE_DAGER_BEGRENSNING: 2

--- a/src/main/resources/application-prod-gcp.yaml
+++ b/src/main/resources/application-prod-gcp.yaml
@@ -1,0 +1,43 @@
+no.nav.security.jwt:
+  issuer.azuread:
+    discoveryurl: https://login.microsoftonline.com/navno.onmicrosoft.com/v2.0/.well-known/openid-configuration
+    accepted_audience: ${AZURE_APP_CLIENT_ID}
+    cookie_name: azure_token
+
+ACCEPTED_CLIENTS: ${BA_SAK_CLIENT_ID}, ${EF_SAK_CLIENT_ID}, ${FAMILIE_TILBAKE_FRONTEND_CLIENT_ID}
+
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/familie-tilbake
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+SECURITYTOKENSERVICE_URL: https://sts.adeo.no/SecurityTokenServiceProvider/
+PDL_URL: https://pdl-api.nais.adeo.no
+
+oppdrag.mq:
+  queuemanager: MPLSC02
+  kravgrunnlag: QA.P_FAMILIE_TILBAKE.KRAVGRUNNLAG
+  channel: P_FAMILIE_TILBAKE
+  hostname: a01apvl063.adeo.no
+  port: 1414
+  user: ${MQ_SRVBRUKER}
+  password: ${MQ_PASSWORD}
+  enabled: false
+
+rolle:
+  barnetrygd:
+    veileder: "199c2b39-e535-4ae8-ac59-8ccbee7991ae"
+    saksbehandler: "847e3d72-9dc1-41c3-80ff-f5d4acdd5d46"
+    beslutter: "7a271f87-39fb-468b-a9ee-6cf3c070f548"
+  enslig:
+    veileder: ""
+    saksbehandler: ""
+    beslutter: ""
+  kontantstøtte:
+    veileder: "54cd86b8-2e23-48b2-8852-b05b5827bb0f"
+    saksbehandler: "e40090eb-c2fb-400e-b412-e9084019a73b"
+    beslutter: "e40090eb-c2fb-400e-b412-e9084019a73b"
+
+
+FAMILIE_INTEGRASJONER_URL: https://familie-integrasjoner.nais.adeo.no


### PR DESCRIPTION
Her er første versjon for deploy til gcp. 
familie-tilbake vil i en periode kjøre i både fss og gcp frem til vi ser at allt virker i gcp.

må flytte noen secrets fra vault til gcp før appen er klar til å deployes