### PR TITLE
Fikset datorformat i brev og feil dato på varsel

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/VarselService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/VarselService.kt
@@ -10,7 +10,9 @@ class VarselService(val behandlingRepository: BehandlingRepository) {
 
     fun lagre(behandlingId: UUID, varseltekst: String, varselbeløp: Long) {
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
-        val copy = behandling.copy(varsler = behandling.varsler + Varsel(varseltekst = varseltekst, varselbeløp = varselbeløp))
+        val varsler = behandling.varsler.map { it.copy(aktiv = false) } +
+                      Varsel(varseltekst = varseltekst, varselbeløp = varselbeløp)
+        val copy = behandling.copy(varsler = varsler.toSet())
         behandlingRepository.update(copy)
     }
 }

--- a/src/main/resources/templates/nn/varsel/korrigert_varsel.hbs
+++ b/src/main/resources/templates/nn/varsel/korrigert_varsel.hbs
@@ -1,5 +1,5 @@
 {{~#* inline "førSkatt"}}{{#if ytelseMedSkatt}} før skatt{{/if}}{{~/inline~}}
-Vi varsla deg {{varsletDato}} om at du hadde fått utbetalt {{kroner varsletBeløp}} for mykje i {{ytelsesnavnUbestemt}}{{> førSkatt}}.
+Vi varsla deg {{dato varsletDato}} om at du hadde fått utbetalt {{kroner varsletBeløp}} for mykje i {{ytelsesnavnUbestemt}}{{> førSkatt}}.
 
 Riktig beløp som er utbetalt for mykje er {{kroner beløp}}{{> førSkatt}}.
 


### PR DESCRIPTION
Feil dato skyldtes at varsler ikke ble satt inaktive når nye ble opprettet.