### PR TITLE
setter test scope på token-validation-spring-test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,7 @@
             <groupId>no.nav.security</groupId>
             <artifactId>token-validation-spring-test</artifactId>
             <version>${nav.security.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.mockk</groupId>


### PR DESCRIPTION
Setter test scope på token-validation-spring-test for å unngå å få med `mock-oauth2-server-0.3.3.jar!/logback.xml `med i classpath for prod.