### PR TITLE
Bruk READER_TOKEN i stedet for GitHub App

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -73,11 +73,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-jar-docker
     steps:
-      - uses: navikt/github-app-token-generator@v1.1
-        id: get-token
-        with:
-          private-key: ${{ secrets.REPO_CLONER_PRIVATE_KEY }}
-          app-id: ${{ secrets.REPO_CLONER_APP_ID }}
       - name: Login to Github Package Registry
         env:
           DOCKER_USERNAME: x-access-token
@@ -96,7 +91,7 @@ jobs:
         with:
           ref: "main"
           repository: navikt/familie-tilbake-e2e
-          token: ${{ steps.get-token.outputs.token }}
+          token: ${{ secrets.READER_TOKEN }}
           path: tilbake-e2e
       - name: Setter riktig familie-tilbake versjon i e2e tester
         if: "!contains(github.event.head_commit.message, 'e2e skip')"

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -40,17 +40,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push Docker image
         run: docker push $IMAGE
-      - uses: navikt/github-app-token-generator@v1.1
-        id: get-token
-        with:
-          private-key: ${{ secrets.REPO_CLONER_PRIVATE_KEY }}
-          app-id: ${{ secrets.REPO_CLONER_APP_ID }}
       - name: Checkout e2e tests
         uses: actions/checkout@v2
         with:
           ref: "main"
           repository: navikt/familie-tilbake-e2e
-          token: ${{ steps.get-token.outputs.token }}
+          token: ${{ secrets.READER_TOKEN }}
           path: tilbake-e2e
       - name: Setter riktig familie-tilbake versjon i e2e tester
         run: sed -i 's/familie-tilbake:latest/familie-tilbake:'$GITHUB_SHA'/g' tilbake-e2e/e2e/docker-compose.yml


### PR DESCRIPTION
Vi har rullet ut en ny org-wide secret som kan brukes for å sjekke ut andre repos og hente pakker i en workflow. Denne PRen bytter derfor ut installation tokens med den nye secreten.
