### PR TITLE
securelog via fil

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,9 +3,21 @@
     <property name="ROOT_LOG_LEVEL" value="INFO"/>
 
     <!-- Logger for sensitive data -->
-    <appender name="secureLoggerRestAppender" class="no.nav.familie.log.appender.SecureLoggerRestAppender"/>
+    <appender name="secureLog" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
     <logger name="secureLogger" level="INFO" additivity="false">
-        <appender-ref ref="secureLoggerRestAppender"/>
+        <appender-ref ref="secureLog"/>
     </logger>
 
     <!-- Spesiell håndtering av loggeren no.nav.log.LogFilter for å forhindre logging av isAlive-sjekker o.l. -->


### PR DESCRIPTION
LinkerD lukker ofte forbindelsene for tidlig når vi gjør en shutdown, noe som fører til at noen logevents til securelogs kanforsvinne. Går over til å bruke default mekanisme for securelogs.

