### PR TITLE
midlertidig purger kafka topic privat-tbk-hentfagsystemsbehandling-respons-topic i Prepod

### DIFF
--- a/.deploy/nais/kafka/hentfagsystemsbehandling_respons_topic.yaml
+++ b/.deploy/nais/kafka/hentfagsystemsbehandling_respons_topic.yaml
@@ -14,6 +14,8 @@ spec:
     replication: 3  # see min/max requirements
     retentionBytes: -1  # -1 means unlimited
     retentionHours: 1  # -1 means unlimited
+    retentionMs: 1000
+    segmentMs: 600000
   acl:
     - team: teamfamilie
       application: familie-tilbake #owner

--- a/.deploy/nais/kafka/hentfagsystemsbehandling_respons_topic.yaml
+++ b/.deploy/nais/kafka/hentfagsystemsbehandling_respons_topic.yaml
@@ -13,7 +13,7 @@ spec:
     partitions: 1
     replication: 3  # see min/max requirements
     retentionBytes: -1  # -1 means unlimited
-    retentionHours: 72  # -1 means unlimited
+    retentionHours: 1  # -1 means unlimited
   acl:
     - team: teamfamilie
       application: familie-tilbake #owner


### PR DESCRIPTION
setter retentionHours til 1 time for å purge uleste kafka meldingene. IKKE MERGE DEN.  BARE GYLDIG FOR PREPOD