### PR TITLE
Støtte for å endre enhet når det er mappe registrert på oppgaven

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -406,7 +406,7 @@ class BehandlingService(
 
         oppgaveTaskService.oppdaterEnhetOppgaveTask(
             behandlingId = behandlingId,
-            beskrivelse = "Endret tildelt enhet: " + enhet.enhetId,
+            beskrivelse = "Endret tildelt enhet: " + byttEnhetDto.enhet,
             enhetId = byttEnhetDto.enhet
         )
     }

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/familie/IntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/familie/IntegrasjonerClient.kt
@@ -76,6 +76,11 @@ class IntegrasjonerClient(
         .pathSegment(IntegrasjonerConfig.PATH_OPPGAVE, oppgave.id!!.toString(), "oppdater")
         .build()
         .toUri()
+    private fun tilordneOppgaveNyEnhetUri(oppgaveId: Long, nyEnhet: String, fjernMappeFraOppgave: Boolean) = UriComponentsBuilder.fromUri(integrasjonerConfig.integrasjonUri)
+        .pathSegment(IntegrasjonerConfig.PATH_OPPGAVE, oppgaveId.toString(), "enhet", nyEnhet)
+        .queryParam("fjernMappeFraOppgave", fjernMappeFraOppgave)
+        .build()
+        .toUri()
 
     private val finnoppgaverUri = UriComponentsBuilder.fromUri(integrasjonerConfig.integrasjonUri)
         .pathSegment(IntegrasjonerConfig.PATH_OPPGAVE, "/v4")
@@ -173,6 +178,11 @@ class IntegrasjonerClient(
     fun patchOppgave(patchOppgave: Oppgave): OppgaveResponse {
         val uri = patchOppgaveUri(patchOppgave)
         return patchForEntity<Ressurs<OppgaveResponse>>(uri, patchOppgave).getDataOrThrow()
+    }
+
+    internal fun tilordneOppgaveNyEnhet(oppgaveId: Long, nyEnhet: String, fjernMappeFraOppgave: Boolean): OppgaveResponse {
+        val uri = tilordneOppgaveNyEnhetUri(oppgaveId, nyEnhet, fjernMappeFraOppgave)
+        return patchForEntity<Ressurs<OppgaveResponse>>(uri, Any()).getDataOrThrow()
     }
 
     fun finnOppgaver(finnOppgaveRequest: FinnOppgaveRequest): FinnOppgaveResponseDto {

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/familie/IntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/familie/IntegrasjonerClient.kt
@@ -25,6 +25,7 @@ import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.familie.tilbake.config.IntegrasjonerConfig
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.http.HttpHeaders
 import org.springframework.retry.annotation.Backoff
 import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
@@ -182,7 +183,7 @@ class IntegrasjonerClient(
 
     internal fun tilordneOppgaveNyEnhet(oppgaveId: Long, nyEnhet: String, fjernMappeFraOppgave: Boolean): OppgaveResponse {
         val uri = tilordneOppgaveNyEnhetUri(oppgaveId, nyEnhet, fjernMappeFraOppgave)
-        return patchForEntity<Ressurs<OppgaveResponse>>(uri, Any()).getDataOrThrow()
+        return patchForEntity<Ressurs<OppgaveResponse>>(uri, "", HttpHeaders().medContentTypeJsonUTF8()).getDataOrThrow()
     }
 
     fun finnOppgaver(finnOppgaveRequest: FinnOppgaveRequest): FinnOppgaveResponseDto {
@@ -224,4 +225,10 @@ class IntegrasjonerClient(
 
         return postForEntity<Ressurs<List<Journalpost>>>(hentJournalpostUri(), journalposterForBrukerRequest).getDataOrThrow()
     }
+}
+
+fun HttpHeaders.medContentTypeJsonUTF8(): HttpHeaders {
+    this.add("Content-Type", "application/json;charset=UTF-8")
+    this.acceptCharset = listOf(Charsets.UTF_8)
+    return this
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterEnhetOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterEnhetOppgaveTask.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.tilbake.oppgave
 
+import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -31,11 +32,17 @@ class OppdaterEnhetOppgaveTask(private val oppgaveService: OppgaveService) : Asy
         val oppgave = oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandlingId)
         val nyBeskrivelse = LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd.MM.yy hh:mm")) + ":" +
             beskrivelse + System.lineSeparator() + oppgave.beskrivelse
-        var patchetOppgave = oppgave.copy(tildeltEnhetsnr = enhetId, beskrivelse = nyBeskrivelse)
+        var patchetOppgave = oppgave.copy(beskrivelse = nyBeskrivelse)
         if (!saksbehandler.isNullOrEmpty() && saksbehandler != Constants.BRUKER_ID_VEDTAKSLØSNINGEN) {
             patchetOppgave = patchetOppgave.copy(tilordnetRessurs = saksbehandler)
         }
         oppgaveService.patchOppgave(patchetOppgave)
+
+        if (oppgave.tema == Tema.ENF) {
+            oppgaveService.tilordneOppgaveNyEnhet(oppgave.id!!, enhetId, false) // ENF bruker generelle mapper
+        } else {
+            oppgaveService.tilordneOppgaveNyEnhet(oppgave.id!!, enhetId, true) // KON og BAR bruker mapper som hører til enhetene
+        }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
@@ -163,6 +163,10 @@ class OppgaveService(
         return integrasjonerClient.patchOppgave(patchOppgave)
     }
 
+    fun tilordneOppgaveNyEnhet(oppgaveId: Long, nyEnhet: String, fjernMappeFraOppgave: Boolean): OppgaveResponse {
+        return integrasjonerClient.tilordneOppgaveNyEnhet(oppgaveId, nyEnhet, fjernMappeFraOppgave)
+    }
+
     fun ferdigstillOppgave(behandlingId: UUID, oppgavetype: Oppgavetype?) {
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         val fagsak = fagsakRepository.findByIdOrThrow(behandling.fagsakId)

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/HentFagsystemsbehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/HentFagsystemsbehandlingTaskTest.kt
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.domain.Pageable
 import java.util.UUID
 
 internal class HentFagsystemsbehandlingTaskTest : OppslagSpringRunnerTest() {


### PR DESCRIPTION
For kontantstøtte og barnetrygd så nullstilles mappen ved flytting av oppgaven, siden mappeId tilhører enheten. Ingen endring for Enslig forsørger. De skal ha gått over til å bruke felles mapper.

Flytting skjer med 2 kall mot oppgave, hvor den ene oppdaterer data som beskrivelse, saksbehandler, mens selve enhetbytte skjer med å kalle endepunkt som ble tatt i bruk i ba-sak, som støtter å flytte med og uten mappe.

![Screenshot 2022-11-14 at 14 37 02](https://user-images.githubusercontent.com/1121978/201674162-8ca9d022-8065-4ed7-8fa9-74dd34ff1e50.png)
