### PR TITLE
fagsystemVedtak skal kunne vite om vedtakstypen er en sanksjon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <kotlin.version>1.7.21</kotlin.version>
         <felles.version>1.20221101085322_cc4d556</felles.version>
         <common-java-modules.version>2.2021.09.17_07.09-67428a6422cc</common-java-modules.version>
-        <kontrakter.version>2.0_20221122093344_b16e671</kontrakter.version>
+        <kontrakter.version>2.0_20221216093604_cfeaf82</kontrakter.version>
         <kotest.version>5.5.4</kotest.version>
         <token-validation-spring.version>2.1.7</token-validation-spring.version>
         <okhttp3.version>4.9.1</okhttp3.version><!-- Inntil videre nødvendig for token-validation-spring-test-->

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapper.kt
@@ -2,6 +2,7 @@ package no.nav.familie.tilbake.behandling
 
 import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
+import no.nav.familie.kontrakter.felles.klage.VedtakType
 import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingsresultatstype.DELVIS_TILBAKEBETALING
 import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingsresultatstype.FULL_TILBAKEBETALING
@@ -182,7 +183,8 @@ object BehandlingMapper {
                     behandlingstype = mapType(it).visningsnavn,
                     resultat = sisteResultat.type.navn,
                     vedtakstidspunkt = avsluttetDato.atStartOfDay(),
-                    fagsystemType = FagsystemType.TILBAKEKREVING
+                    fagsystemType = FagsystemType.TILBAKEKREVING,
+                    vedtakType = VedtakType.TILBAKEKREVING
                 )
             }
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapperTest.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
+import no.nav.familie.kontrakter.felles.klage.VedtakType
 import no.nav.familie.tilbake.behandling.BehandlingMapper.tilVedtakForFagsystem
 import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Behandlingsresultat
@@ -34,6 +35,7 @@ internal class BehandlingMapperTest {
             resultat[0].eksternBehandlingId shouldBe behandling.eksternBrukId.toString()
             resultat[0].vedtakstidspunkt shouldBe LocalDate.of(2021, 7, 13).atStartOfDay()
             resultat[0].fagsystemType shouldBe FagsystemType.TILBAKEKREVING
+            resultat[0].vedtakType shouldBe VedtakType.TILBAKEKREVING
         }
 
         @Test


### PR DESCRIPTION
En start på [denne oppgaven](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10592)

Tar i bruk `VedtakType` fra kontrakter, som kan være `SANKSJON_1_MND`

Har også endret kontrakter i `ef-sak` og `familie-klage`:
* https://github.com/navikt/familie-ef-sak/pull/1972
* https://github.com/navikt/familie-klage/pull/218