### PR TITLE
Chore: Logg ekstern fagsakId når oppgave ikke finnes

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
@@ -72,7 +72,7 @@ class OppgaveService(
                     "Fant ingen oppgave for behandling ${behandling.eksternBrukId} på fagsak ${fagsak.eksternFagsakId}, " +
                         "$finnOppgaveRequest, $finnOppgaveResponse"
                 )
-                throw Feil("Fant ingen oppgave for behandling ${behandling.eksternBrukId} på fagsak ${fagsak.eksternFagsakId}")
+                throw Feil("Fant ingen oppgave for behandling ${behandling.eksternBrukId} på fagsak ${fagsak.eksternFagsakId}. Oppgaven kan være manuelt lukket.")
             }
 
             else -> {

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
@@ -72,7 +72,7 @@ class OppgaveService(
                     "Fant ingen oppgave for behandling ${behandling.eksternBrukId} på fagsak ${fagsak.eksternFagsakId}, " +
                         "$finnOppgaveRequest, $finnOppgaveResponse"
                 )
-                throw Feil("Fant ingen oppgave for behandling ${behandling.eksternBrukId}")
+                throw Feil("Fant ingen oppgave for behandling ${behandling.eksternBrukId} på fagsak ${fagsak.eksternFagsakId}")
             }
 
             else -> {

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
@@ -69,7 +69,7 @@ class OppgaveService(
 
             finnOppgaveResponse.oppgaver.isEmpty() -> {
                 secureLogger.error(
-                    "Fant ingen oppgave for behandling ${behandling.eksternBrukId}, " +
+                    "Fant ingen oppgave for behandling ${behandling.eksternBrukId} på fagsak ${fagsak.eksternFagsakId}, " +
                         "$finnOppgaveRequest, $finnOppgaveResponse"
                 )
                 throw Feil("Fant ingen oppgave for behandling ${behandling.eksternBrukId}")


### PR DESCRIPTION
Logger ekstern fagsakId når oppgave ikke finnes for behandling.

Dette gjør at utviklere slipper å søke opp i databasen for å finne fagsaken til behandlingen.

Ser forsåvidt at fagsakId'en logges ut som saksnummer sendt til dvh, men det er veldig vanskelig å finne frem til hvis man ikke vet at det er samme id. 