### PR TITLE
Legger Forvaltingsinfo i en liste…

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.math.BigInteger
+import java.time.LocalDateTime
 import java.util.UUID
 import javax.validation.Valid
 
@@ -137,7 +138,7 @@ class ForvaltningController(private val forvaltningService: ForvaltningService) 
     fun hentForvaltningsinfo(
         @PathVariable ytelsestype: Ytelsestype,
         @PathVariable eksternFagsakId: String
-    ): Ressurs<Forvaltningsinfo> {
+    ): Ressurs<List<Forvaltningsinfo>> {
         return Ressurs.success(forvaltningService.hentForvaltningsinfo(ytelsestype, eksternFagsakId))
     }
 
@@ -158,4 +159,11 @@ class ForvaltningController(private val forvaltningService: ForvaltningService) 
     }
 }
 
-data class Forvaltningsinfo(val eksternKravgrunnlagId: BigInteger, val mottattXmlId: UUID?, val eksternId: String)
+data class Forvaltningsinfo(
+    val eksternKravgrunnlagId: BigInteger,
+    val kravgrunnlagId: UUID?,
+    val kravgrunnlagKravstatuskode: String?,
+    val mottattXmlId: UUID?,
+    val eksternId: String,
+    val opprettetTid: LocalDateTime
+)

--- a/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
@@ -342,7 +342,7 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
                     .first { it.ytelsestype == fagsak.ytelsestype }
             )
         )
-        val forvaltningsinfo = forvaltningService.hentForvaltningsinfo(fagsak.ytelsestype, fagsak.eksternFagsakId)
+        val forvaltningsinfo = forvaltningService.hentForvaltningsinfo(fagsak.ytelsestype, fagsak.eksternFagsakId).first()
         forvaltningsinfo.eksternKravgrunnlagId shouldBe kravgrunnlag.eksternKravgrunnlagId
         forvaltningsinfo.mottattXmlId.shouldBeNull()
         forvaltningsinfo.eksternId shouldBe kravgrunnlag.referanse
@@ -358,7 +358,7 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
                 ytelsestype = fagsak.ytelsestype
             )
         )
-        val forvaltningsinfo = forvaltningService.hentForvaltningsinfo(fagsak.ytelsestype, fagsak.eksternFagsakId)
+        val forvaltningsinfo = forvaltningService.hentForvaltningsinfo(fagsak.ytelsestype, fagsak.eksternFagsakId).first()
         forvaltningsinfo.eksternKravgrunnlagId shouldBe mottattXml.eksternKravgrunnlagId
         forvaltningsinfo.mottattXmlId shouldBe mottattXml.id
         forvaltningsinfo.eksternId shouldBe mottattXml.referanse


### PR DESCRIPTION
… da det har hendt en behandling har endt opp med 2 aktive kravgrunnlag samtidig, slik at det kastes en IncorrectResultSizeDataAccessException.

Utvider samtidig Forvaltningsinfo med litt ekstra info slik at det skal gå an å identifisere hvilket kravgrunnlag som er det gjeldende, og deretter deaktivere det andre utifra returnert UUID.