### PR TITLE
Liten forbedring av oppgavepatching

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
@@ -32,8 +32,7 @@ class OppdaterAnsvarligSaksbehandlerTask(
         val oppgave = oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandlingId)
         val prioritet = oppgavePrioritetService.utledOppgaveprioritet(behandlingId, oppgave)
 
-
-        if(oppgave.tilordnetRessurs != behandling.ansvarligSaksbehandler && oppgave.prioritet !=  prioritet){
+        if (oppgave.tilordnetRessurs != behandling.ansvarligSaksbehandler || oppgave.prioritet != prioritet) {
             oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
         }
     }

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
@@ -32,7 +32,10 @@ class OppdaterAnsvarligSaksbehandlerTask(
         val oppgave = oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandlingId)
         val prioritet = oppgavePrioritetService.utledOppgaveprioritet(behandlingId, oppgave)
 
-        oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
+
+        if(oppgave.tilordnetRessurs != behandling.ansvarligSaksbehandler && oppgave.prioritet !=  prioritet){
+            oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
+        }
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTaskTest.kt
@@ -1,0 +1,98 @@
+package no.nav.familie.tilbake.oppgave
+
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
+import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.tilbake.behandling.BehandlingRepository
+import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
+import no.nav.familie.tilbake.common.repository.findByIdOrThrow
+import no.nav.familie.tilbake.config.PropertyName
+import no.nav.familie.tilbake.data.Testdata
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.Properties
+
+internal class OppdaterAnsvarligSaksbehandlerTaskTest {
+
+    private val behandlingRepository: BehandlingRepository = mockk(relaxed = true)
+    private val fagsakRepository: FagsakRepository = mockk(relaxed = true)
+    private val mockOppgaveService: OppgaveService = mockk(relaxed = true)
+    private val oppgavePrioritetService = mockk<OppgavePrioritetService>()
+    private val behandling: Behandling = Testdata.behandling
+
+    private val oppdaterAnsvarligSaksbehandlerTask =
+        OppdaterAnsvarligSaksbehandlerTask(mockOppgaveService, behandlingRepository, oppgavePrioritetService)
+
+    @BeforeEach
+    fun init() {
+        clearMocks(mockOppgaveService)
+        every { fagsakRepository.findByIdOrThrow(Testdata.fagsak.id) } returns Testdata.fagsak
+        every { behandlingRepository.findByIdOrThrow(Testdata.behandling.id) } returns Testdata.behandling
+        every { oppgavePrioritetService.utledOppgaveprioritet(any(), any()) } returns OppgavePrioritet.NORM
+    }
+
+    @Test
+    fun `doTask skal oppdatere oppgave når prioritet endret`() {
+        val oppgave = Oppgave(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = OppgavePrioritet.NORM)
+
+        every { oppgavePrioritetService.utledOppgaveprioritet(any(), any()) } returns OppgavePrioritet.HOY
+        every { mockOppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandling.id) } returns oppgave
+
+        oppdaterAnsvarligSaksbehandlerTask.doTask(lagTask())
+
+        verify {
+            mockOppgaveService.patchOppgave(
+                oppgave.copy(
+                    tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = OppgavePrioritet.HOY
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `doTask skal oppdatere oppgave når saksbehandler endret`() {
+        val oppgave = Oppgave(tilordnetRessurs = "TIDLIGERE saksbehandler", prioritet = OppgavePrioritet.NORM)
+        every { oppgavePrioritetService.utledOppgaveprioritet(any(), any()) } returns OppgavePrioritet.NORM
+        every { mockOppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandling.id) } returns oppgave
+
+        oppdaterAnsvarligSaksbehandlerTask.doTask(lagTask())
+
+        verify(atLeast = 1) {
+            mockOppgaveService.patchOppgave(
+                oppgave.copy(
+                    tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = OppgavePrioritet.NORM
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Skal ikke oppdatere oppgave når ingenting er endret`() {
+        val oppgave = Oppgave(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = OppgavePrioritet.NORM)
+
+        every { oppgavePrioritetService.utledOppgaveprioritet(any(), any()) } returns OppgavePrioritet.NORM
+        every { mockOppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandling.id) } returns oppgave
+
+        oppdaterAnsvarligSaksbehandlerTask.doTask(lagTask())
+
+        verify(exactly = 0) { mockOppgaveService.patchOppgave(any()) }
+    }
+
+    private fun lagTask(opprettetAv: String? = null): Task {
+        return Task(type = OppdaterAnsvarligSaksbehandlerTask.TYPE,
+            payload = behandling.id.toString(),
+            properties = Properties().apply {
+                setProperty("oppgavetype", Oppgavetype.BehandleSak.name)
+                setProperty(PropertyName.ENHET, "enhet")
+                if (opprettetAv != null) {
+                    setProperty("opprettetAv", opprettetAv)
+                }
+            })
+    }
+}


### PR DESCRIPTION
En liten forbedring?

Dersom noen raser gjennom saksbehandling kan vi få flere oppgaver av typer "oppdater ansvarlig saksbehandler" som plukkes samtidig. Da kan en av disse få en 409 - (oppgaven er i feil versjon). 

Dette pleier stort sett ordne seg når man re-kjører og henter oppgave på nytt, men i noen tilfeller rekker saksbehandler å ferdigstille behandling/oppgave før vi får kjørt på nytt. Da feiler tasken med "oppgave finnes ikke". 

Med denne endringen vil vi ikke forsøke oppdatere/patche oppgave dersom saksbehandler og prioritet er uendret. 
