### PR TITLE
Vis til kontantstøtteloven i varselbrev for KONTANTSTØTTE

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/innhentdokumentasjon/handlebars/dto/InnhentDokumentasjonsbrevsdokument.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/innhentdokumentasjon/handlebars/dto/InnhentDokumentasjonsbrevsdokument.kt
@@ -24,8 +24,13 @@ data class InnhentDokumentasjonsbrevsdokument(
     val annenMottagersNavn: String? = BrevmottagerUtil.getannenMottagersNavn(brevmetadata)
 
     @Suppress("unused") // Handlebars
-    val isRentepliktig
-        get() = ytelsestype != Ytelsestype.BARNETRYGD
+    val isRentepliktig = ytelsestype != Ytelsestype.BARNETRYGD && ytelsestype != Ytelsestype.KONTANTSTØTTE
+
+    @Suppress("unused") // Handlebars
+    val isBarnetrygd = ytelsestype == Ytelsestype.BARNETRYGD
+
+    @Suppress("unused") // Handlebars
+    val isKontantstøtte = ytelsestype == Ytelsestype.KONTANTSTØTTE
 
     init {
         if (finnesVerge) {

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/varsel/handlebars/dto/Varselbrevsdokument.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/varsel/handlebars/dto/Varselbrevsdokument.kt
@@ -38,12 +38,16 @@ data class Varselbrevsdokument(
     val annenMottagersNavn: String? = BrevmottagerUtil.getannenMottagersNavn(brevmetadata)
 
     @Suppress("unused") // Handlebars
-    val isYtelseMedSkatt
-        get() = ytelsestype == Ytelsestype.OVERGANGSSTØNAD
+    val isYtelseMedSkatt = ytelsestype == Ytelsestype.OVERGANGSSTØNAD
 
     @Suppress("unused") // Handlebars
-    val isRentepliktig
-        get() = ytelsestype != Ytelsestype.BARNETRYGD
+    val isRentepliktig = ytelsestype != Ytelsestype.BARNETRYGD && ytelsestype != Ytelsestype.KONTANTSTØTTE
+
+    @Suppress("unused") // Handlebars
+    val isBarnetrygd = ytelsestype == Ytelsestype.BARNETRYGD
+
+    @Suppress("unused") // Handlebars
+    val isKontantstøtte = ytelsestype == Ytelsestype.KONTANTSTØTTE
 
     @Suppress("unused") // Handlebars
     val isFinnesVerge

--- a/src/main/resources/templates/nb/innhentdokumentasjon/innhent_dokumentasjon.hbs
+++ b/src/main/resources/templates/nb/innhentdokumentasjon/innhent_dokumentasjon.hbs
@@ -4,7 +4,7 @@ _{{#if gjelderDødsfall}}Dere{{else}}Du{{/if}} må sende oss
 _Saken blir behandlet etter frist har gått ut
 Hvis vi ikke får opplysningene innen {{{dato fristdato}}}, behandler vi saken med de opplysningene vi har.
 
-Dette går fram av {{#if rentepliktig}}folketrygdloven § 21-3{{else}}barnetrygdloven §§ 17 og 18{{/if}}.
+Dette går fram av {{#if isBarnetrygd}}barnetrygdloven §§ 17 og 18{{else if isKontantstøtte}}kontantstøtteloven §§ 12 og 13{{else}}folketrygdloven § 21-3{{/if}}.
 {{#if gjelderDødsfall}}
 _Rett til uttalelse
 Dere kan sende uttalelsen til oss i posten. Adressen finner dere på nav.no/ettersendelser.

--- a/src/main/resources/templates/nb/varsel/varsel_slutt.hbs
+++ b/src/main/resources/templates/nb/varsel/varsel_slutt.hbs
@@ -27,7 +27,7 @@ Selv om det er NAV som er skyld i feilutbetalingen, kan vi likevel kreve at {{#i
 Hvis {{#if gjelderDødsfall}}dere{{else}}du{{/if}} må betale tilbake, og {{#if gjelderDødsfall}}dere{{else}}du{{/if}} har gitt oss feil eller mangelfull informasjon, kan vi kreve at {{#if gjelderDødsfall}}dere{{else}}du{{/if}} betaler et rentetillegg på ti prosent av beløpet.
 
 {{/if}}
-Dette går fram av {{#if rentepliktig}}folketrygdloven §§ 22-15 og 22-17a{{else}}barnetrygdloven §13{{/if}}.
+Dette går fram av {{#if isBarnetrygd}}barnetrygdloven § 13{{else if isKontantstøtte}}kontantstøtteloven § 11{{else}}folketrygdloven §§ 22-15 og 22-17a{{/if}}.
 {{#if gjelderDødsfall}}
 _Rett til uttalelse
 Dere kan sende uttalelsen til oss i posten. Adressen finner dere på nav.no/ettersendelser.

--- a/src/main/resources/templates/nn/innhentdokumentasjon/innhent_dokumentasjon.hbs
+++ b/src/main/resources/templates/nn/innhentdokumentasjon/innhent_dokumentasjon.hbs
@@ -4,7 +4,7 @@ _{{#if gjelderDødsfall}}De{{else}}Du{{/if}} må sende oss
 _Saka blir behandlet etter frist har gått ut
 Dersom vi ikkje får opplysningane innan {{{dato fristdato}}}, behandlar vi saka med dei opplysningane vi har.
 
-Dette går fram av {{#if rentepliktig}}folketrygdlova § 21-3{{else}}barnetrygdlova §§ 17 og 18{{/if}}.
+Dette går fram av {{#if isBarnetrygd}}barnetrygdlova §§ 17 og 18{{else if isKontantstøtte}}kontantstøttelova §§ 12 og 13{{else}}folketrygdlova § 21-3{{/if}}.
 {{#if gjelderDødsfall}}
 _Rett til uttale
 De kan sende uttalen til oss i posten. Adressa finn de på nav.no/ettersendelser.

--- a/src/main/resources/templates/nn/varsel/varsel_slutt.hbs
+++ b/src/main/resources/templates/nn/varsel/varsel_slutt.hbs
@@ -27,7 +27,7 @@ Sjølv om det er NAV som er skuld i feilutbetalinga, kan vi likevel krevje at {{
 Dersom {{#if gjelderDødsfall}}de{{else}}du{{/if}} må betale tilbake, og {{#if gjelderDødsfall}}de{{else}}du{{/if}} har gitt oss feil eller mangelfull informasjon, kan vi krevje at {{#if gjelderDødsfall}}de{{else}}du{{/if}} betaler eit rentetillegg på ti prosent av beløpet {{#if gjelderDødsfall}}de{{else}}du{{/if}} skuldar.
 
 {{/if}}
-Dette går fram av {{#if rentepliktig}}folketrygdlova §§ 22-15 og 22-17a{{else}}barnetrygdlova §13{{/if}}.
+Dette går fram av {{#if isBarnetrygd}}barnetrygdlova § 13{{else if isKontantstøtte}}kontantstøttelova § 11{{else}}folketrygdlova §§ 22-15 og 22-17a{{/if}}.
 {{#if gjelderDødsfall}}
 _Rett til uttale
 De kan sende uttalen til oss i posten. Adressa finn de på nav.no/ettersendelser.

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/varsel/TekstformatererVarselbrevTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/varsel/TekstformatererVarselbrevTest.kt
@@ -93,6 +93,18 @@ class TekstformatererVarselbrevTest {
     }
 
     @Test
+    fun `lagVarselbrevsfritekst skal generere varseltekst for enkelt periode kontantstøtte`() {
+        val metadata = metadata.copy(ytelsestype = Ytelsestype.KONTANTSTØTTE)
+        val varselbrevsdokument = varselbrevsdokument.copy(
+            brevmetadata = metadata,
+            feilutbetaltePerioder = lagFeilutbetalingerMedKunEnPeriode()
+        )
+        val generertBrev = TekstformatererVarselbrev.lagFritekst(varselbrevsdokument, false)
+        val fasit = les("/varselbrev/KS_en_periode.txt")
+        generertBrev shouldBe fasit
+    }
+
+    @Test
     fun `lagVarselbrevsoverskrift skal generere varselbrevsoverskrift`() {
         val overskrift = TekstformatererVarselbrev.lagVarselbrevsoverskrift(metadata, false)
         val fasit = "NAV vurderer om du må betale tilbake overgangsstønad"

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/varsel/VarselbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/varsel/VarselbrevServiceTest.kt
@@ -62,7 +62,7 @@ internal class VarselbrevServiceTest : OppslagSpringRunnerTest() {
         val forhåndsvisVarselbrevRequest =
             ForhåndsvisVarselbrevRequest(
                 "Dette er et varsel!",
-                Ytelsestype.KONTANTSTØTTE,
+                Ytelsestype.BARNETRYGD,
                 "1570",
                 "Bodø",
                 "321321",

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/varsel/VarselbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/varsel/VarselbrevServiceTest.kt
@@ -62,7 +62,7 @@ internal class VarselbrevServiceTest : OppslagSpringRunnerTest() {
         val forhåndsvisVarselbrevRequest =
             ForhåndsvisVarselbrevRequest(
                 "Dette er et varsel!",
-                Ytelsestype.BARNETRYGD,
+                Ytelsestype.KONTANTSTØTTE,
                 "1570",
                 "Bodø",
                 "321321",
@@ -80,7 +80,8 @@ internal class VarselbrevServiceTest : OppslagSpringRunnerTest() {
                 Fagsystem.EF,
                 "321654",
                 Testdata.fagsak.bruker.ident,
-                null
+                null,
+                fagsystemsbehandlingId = "123"
             )
 
         val bytes = varselbrevService.hentForhåndsvisningVarselbrev(forhåndsvisVarselbrevRequest)

--- a/src/test/resources/varselbrev/BA_en_periode.txt
+++ b/src/test/resources/varselbrev/BA_en_periode.txt
@@ -19,7 +19,7 @@ om feilen kan skyldes NAV-*
 
 Selv om det er NAV som er skyld i feilutbetalingen, kan vi likevel kreve at du betaler tilbake pengene.
 
-Dette går fram av barnetrygdloven §13.
+Dette går fram av barnetrygdloven § 13.
 _Slik uttaler du deg
 Du kan sende uttalelsen din ved å logge deg inn på nav.no/beskjedtilnav og velge «Send beskjed til NAV». Du kan også sende uttalelsen din til oss i posten. Adressen finner du på
 nav.no/ettersendelser.

--- a/src/test/resources/varselbrev/KS_en_periode.txt
+++ b/src/test/resources/varselbrev/KS_en_periode.txt
@@ -1,0 +1,39 @@
+Du har fått 595 959 kroner for mye utbetalt i kontantstøtte fra og med 3. mars 2019 til og med 3. mars 2020.
+
+Før vi avgjør om du skal betale tilbake, kan du uttale deg innen 4. april 2020.
+_Dette har skjedd
+Kontantstøtten din ble endret 18. desember 2019, og endringen har ført til at du har fått utbetalt for mye.
+
+Dette er fritekst skrevet av saksbehandler.
+_Dette legger vi vekt på i vurderingen vår
+For å avgjøre om vi kan kreve tilbake, tar vi først stilling til de tre øverste punktene i denne listen. Hvis resultatet blir at vi kan kreve tilbake, vurderer vi om du skal betale tilbake hele eller deler av beløpet.
+
+Vi legger vekt på
+
+*-om du forstod eller burde forstått at beløpet du fikk utbetalt var feil
+om du har gitt riktig informasjon til NAV
+om du har gitt all informasjon til NAV i rett tid
+hvor lang tid det har gått siden kontantstøtten ble feilutbetalt
+hvor stort det feilutbetalte beløpet er
+om feilen kan skyldes NAV-*
+
+Selv om det er NAV som er skyld i feilutbetalingen, kan vi likevel kreve at du betaler tilbake pengene.
+
+Dette går fram av kontantstøtteloven § 11.
+_Slik uttaler du deg
+Du kan sende uttalelsen din ved å logge deg inn på nav.no/beskjedtilnav og velge «Send beskjed til NAV». Du kan også sende uttalelsen din til oss i posten. Adressen finner du på
+nav.no/ettersendelser.
+_Du har rett til innsyn
+På nav.no/dittnav kan du se dokumentene i saken din.
+_Har du spørsmål?
+Du finner mer informasjon på nav.no/kontantstotte.
+
+På nav.no/kontakt kan du chatte eller skrive til oss.
+
+Hvis du ikke finner svar på nav.no kan du ringe oss på telefon 55 55 33 33, hverdager 09.00-15.00.
+
+
+Med vennlig hilsen
+NAV Familie- og pensjonsytelser Skien
+
+Bob


### PR DESCRIPTION
Favro: [NAV-12218](https://favro.com/organization/98c34fb974ce445eac854de0/077068028bffba85055cca2d?card=NAV-12218)

Legger til henvisning til kontantstøtteloven/-lova i varselbrev 

Resultat for hhv skolepenger, barnetrygd og kontantstøtte:
[test-skolepenger.pdf](https://github.com/navikt/familie-tilbake/files/11231031/test-skolepenger.pdf)
[test-barnetrygd.pdf](https://github.com/navikt/familie-tilbake/files/11231032/test-barnetrygd.pdf)
[test-kontantstøtte.pdf](https://github.com/navikt/familie-tilbake/files/11231033/test-kontantstotte.pdf)
