### PR TITLE
Legger til nytt behandlingssteg for manuell registrering av brevmottakere

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
         <spring.cloud-contract>4.0.1</spring.cloud-contract>
         <testcontainers.version>1.17.6</testcontainers.version>
         <tjenestespesifikasjoner.version>2612.db4dc68</tjenestespesifikasjoner.version>
-        <kafka.version>3.4.0</kafka.version>
         <prosessering-core.version>1.20230207133526_5430e48</prosessering-core.version>
     </properties>
 
@@ -208,7 +207,6 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
         </dependency>
 
         <!-- NAV interne avhengigheter-->
@@ -363,7 +361,6 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.13</artifactId>
             <scope>test</scope>
-            <version>${kafka.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/kotlin/no/nav/familie/tilbake/api/ManuellBrevmottakerController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/ManuellBrevmottakerController.kt
@@ -122,7 +122,7 @@ class ManuellBrevmottakerController(private val manuellBrevmottakerService: Manu
         AuditLoggerEvent.UPDATE,
         HenteParam.BEHANDLING_ID
     )
-    fun fjernManuelleBrevmottakere(@PathVariable("behandlingId") behandlingId: UUID): Ressurs<String> {
+    fun fjernBrevmottakerSteg(@PathVariable("behandlingId") behandlingId: UUID): Ressurs<String> {
         manuellBrevmottakerService.fjernManuelleBrevmottakereOgTilbakeførSteg(behandlingId)
         return Ressurs.success("OK")
     }

--- a/src/main/kotlin/no/nav/familie/tilbake/api/dto/BehandlingDto.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/dto/BehandlingDto.kt
@@ -37,7 +37,7 @@ data class BehandlingDto(
     val eksternFagsakId: String,
     val behandlingsårsakstype: Behandlingsårsakstype? = null,
     val støtterManuelleBrevmottakere: Boolean,
-    val harManuelleBrevmottakere: Boolean,
+    val harManuelleBrevmottakere: Boolean
 )
 
 data class BehandlingsstegsinfoDto(

--- a/src/main/kotlin/no/nav/familie/tilbake/api/dto/BehandlingDto.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/dto/BehandlingDto.kt
@@ -35,7 +35,9 @@ data class BehandlingDto(
     val behandlingsstegsinfo: List<BehandlingsstegsinfoDto>,
     val fagsystemsbehandlingId: String,
     val eksternFagsakId: String,
-    val behandlingsårsakstype: Behandlingsårsakstype? = null
+    val behandlingsårsakstype: Behandlingsårsakstype? = null,
+    val støtterManuelleBrevmottakere: Boolean,
+    val harManuelleBrevmottakere: Boolean,
 )
 
 data class BehandlingsstegsinfoDto(

--- a/src/main/kotlin/no/nav/familie/tilbake/api/dto/BehandlingsstegDto.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/dto/BehandlingsstegDto.kt
@@ -22,6 +22,7 @@ import javax.validation.constraints.Size
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
 @JsonSubTypes(
     JsonSubTypes.Type(value = BehandlingsstegVergeDto::class),
+    JsonSubTypes.Type(value = BehandlingsstegBrevmottakerDto::class),
     JsonSubTypes.Type(value = BehandlingsstegFaktaDto::class),
     JsonSubTypes.Type(value = BehandlingsstegForeldelseDto::class),
     JsonSubTypes.Type(value = BehandlingsstegVilkårsvurderingDto::class),
@@ -46,11 +47,28 @@ data class BehandlingsstegVergeDto(val verge: VergeDto) : BehandlingsstegDto() {
     }
 }
 
+@JsonTypeName(BehandlingsstegBrevmottakerDto.STEGNAVN)
+data class BehandlingsstegBrevmottakerDto(val brevmottakerstegDto: BrevmottakerstegDto) : BehandlingsstegDto() {
+
+    override fun getSteg(): String {
+        return STEGNAVN
+    }
+
+    companion object {
+        const val STEGNAVN = "BREVMOTTAKER"
+    }
+}
+
 data class VergeDto(
     val ident: String? = null,
     val orgNr: String? = null,
     val type: Vergetype,
     val navn: String,
+    @Size(max = 4000, message = "Begrunnelse er for lang")
+    val begrunnelse: String?
+)
+
+data class BrevmottakerstegDto(
     @Size(max = 4000, message = "Begrunnelse er for lang")
     val begrunnelse: String?
 )

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapper.kt
@@ -111,7 +111,7 @@ object BehandlingMapper {
             eksternFagsakId = eksternFagsakId,
             behandlingsårsakstype = behandling.sisteÅrsak?.type,
             harManuelleBrevmottakere = harManuelleBrevmottakere,
-            støtterManuelleBrevmottakere = støtterManuelleBrevmottakere,
+            støtterManuelleBrevmottakere = støtterManuelleBrevmottakere
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapper.kt
@@ -77,7 +77,9 @@ object BehandlingMapper {
         kanRevurderingOpprettes: Boolean,
         behandlingsstegsinfoer: List<Behandlingsstegsinfo>,
         varselSendt: Boolean,
-        eksternFagsakId: String
+        eksternFagsakId: String,
+        harManuelleBrevmottakere: Boolean,
+        støtterManuelleBrevmottakere: Boolean
     ): BehandlingDto {
         val resultat: Behandlingsresultat? = behandling.resultater.maxByOrNull {
             it.sporbar.endret.endretTid
@@ -107,7 +109,9 @@ object BehandlingMapper {
             behandlingsstegsinfo = tilBehandlingstegsinfoDto(behandlingsstegsinfoer),
             fagsystemsbehandlingId = behandling.aktivFagsystemsbehandling.eksternId,
             eksternFagsakId = eksternFagsakId,
-            behandlingsårsakstype = behandling.sisteÅrsak?.type
+            behandlingsårsakstype = behandling.sisteÅrsak?.type,
+            harManuelleBrevmottakere = harManuelleBrevmottakere,
+            støtterManuelleBrevmottakere = støtterManuelleBrevmottakere,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -193,8 +193,7 @@ class BehandlingService(
         val kanRevurderingOpprettes: Boolean =
             tilgangService.tilgangTilÅOppretteRevurdering(fagsak.fagsystem) && kanRevurderingOpprettes(behandling)
         val harManuelleBrevmottakere = manuellBrevmottakerRepository.findByBehandlingId(behandlingId).isNotEmpty()
-        val støtterManuelleBrevmottakere =
-            featureToggleService.isEnabled(FeatureToggleConfig.DSITRIBUER_TIL_MANUELLE_BREVMOTTAKERE)
+        val støtterManuelleBrevmottakere = true
 
         return BehandlingMapper.tilRespons(
             behandling,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -193,7 +193,8 @@ class BehandlingService(
         val kanRevurderingOpprettes: Boolean =
             tilgangService.tilgangTilÅOppretteRevurdering(fagsak.fagsystem) && kanRevurderingOpprettes(behandling)
         val harManuelleBrevmottakere = manuellBrevmottakerRepository.findByBehandlingId(behandlingId).isNotEmpty()
-        val støtterManuelleBrevmottakere = true
+        val støtterManuelleBrevmottakere =
+            featureToggleService.isEnabled(FeatureToggleConfig.DSITRIBUER_TIL_MANUELLE_BREVMOTTAKERE)
 
         return BehandlingMapper.tilRespons(
             behandling,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -194,7 +194,7 @@ class BehandlingService(
             tilgangService.tilgangTilÅOppretteRevurdering(fagsak.fagsystem) && kanRevurderingOpprettes(behandling)
         val harManuelleBrevmottakere = manuellBrevmottakerRepository.findByBehandlingId(behandlingId).isNotEmpty()
         val støtterManuelleBrevmottakere =
-            featureToggleService.isEnabled(FeatureToggleConfig.DSITRIBUER_TIL_MANUELLE_BREVMOTTAKERE)
+            featureToggleService.isEnabled(FeatureToggleConfig.DISTRIBUER_TIL_MANUELLE_BREVMOTTAKERE)
 
         return BehandlingMapper.tilRespons(
             behandling,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -192,6 +192,9 @@ class BehandlingService(
         val kanEndres: Boolean = kanBehandlingEndres(behandling, fagsak.fagsystem)
         val kanRevurderingOpprettes: Boolean =
             tilgangService.tilgangTilÅOppretteRevurdering(fagsak.fagsystem) && kanRevurderingOpprettes(behandling)
+        val harManuelleBrevmottakere = manuellBrevmottakerRepository.findByBehandlingId(behandlingId).isNotEmpty()
+        val støtterManuelleBrevmottakere =
+            featureToggleService.isEnabled(FeatureToggleConfig.DSITRIBUER_TIL_MANUELLE_BREVMOTTAKERE)
 
         return BehandlingMapper.tilRespons(
             behandling,
@@ -201,7 +204,9 @@ class BehandlingService(
             kanRevurderingOpprettes,
             behandlingsstegsinfoer,
             varselSendt,
-            fagsak.eksternFagsakId
+            fagsak.eksternFagsakId,
+            harManuelleBrevmottakere,
+            støtterManuelleBrevmottakere
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/VergeService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/VergeService.kt
@@ -70,7 +70,7 @@ class VergeService(
                 Aktør.SAKSBEHANDLER
             )
         }
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.VERGE,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Brevmottakersteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Brevmottakersteg.kt
@@ -24,7 +24,7 @@ class Brevmottakersteg(
     @Transactional
     override fun utførSteg(behandlingId: UUID) {
         logger.info("Behandling $behandlingId er på ${Behandlingssteg.BREVMOTTAKER} steg")
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.BREVMOTTAKER,
@@ -38,7 +38,7 @@ class Brevmottakersteg(
     override fun utførSteg(behandlingId: UUID, behandlingsstegDto: BehandlingsstegDto) {
         logger.info("Behandling $behandlingId er på ${Behandlingssteg.BREVMOTTAKER} steg")
         oppgaveTaskService.oppdaterAnsvarligSaksbehandlerOppgaveTask(behandlingId)
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(Behandlingssteg.BREVMOTTAKER, UTFØRT)
         )
@@ -48,7 +48,7 @@ class Brevmottakersteg(
     @Transactional
     override fun gjenopptaSteg(behandlingId: UUID) {
         logger.info("Behandling $behandlingId gjenopptar på ${Behandlingssteg.BREVMOTTAKER} steg")
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.BREVMOTTAKER,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Brevmottakersteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Brevmottakersteg.kt
@@ -1,0 +1,63 @@
+package no.nav.familie.tilbake.behandling.steg
+
+import no.nav.familie.tilbake.api.dto.BehandlingsstegDto
+import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
+import no.nav.familie.tilbake.behandlingskontroll.Behandlingsstegsinfo
+import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
+import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
+import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.AUTOUTFØRT
+import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.UTFØRT
+import no.nav.familie.tilbake.oppgave.OppgaveTaskService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class Brevmottakersteg(
+    private val behandlingskontrollService: BehandlingskontrollService,
+    private val oppgaveTaskService: OppgaveTaskService
+) : IBehandlingssteg {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    @Transactional
+    override fun utførSteg(behandlingId: UUID) {
+        logger.info("Behandling $behandlingId er på ${Behandlingssteg.BREVMOTTAKER} steg")
+        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+            behandlingId,
+            Behandlingsstegsinfo(
+                Behandlingssteg.BREVMOTTAKER,
+                AUTOUTFØRT
+            )
+        )
+        behandlingskontrollService.fortsettBehandling(behandlingId)
+    }
+
+    @Transactional
+    override fun utførSteg(behandlingId: UUID, behandlingsstegDto: BehandlingsstegDto) {
+        logger.info("Behandling $behandlingId er på ${Behandlingssteg.BREVMOTTAKER} steg")
+        oppgaveTaskService.oppdaterAnsvarligSaksbehandlerOppgaveTask(behandlingId)
+        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+            behandlingId,
+            Behandlingsstegsinfo(Behandlingssteg.BREVMOTTAKER, UTFØRT)
+        )
+        behandlingskontrollService.fortsettBehandling(behandlingId)
+    }
+
+    @Transactional
+    override fun gjenopptaSteg(behandlingId: UUID) {
+        logger.info("Behandling $behandlingId gjenopptar på ${Behandlingssteg.BREVMOTTAKER} steg")
+        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+            behandlingId,
+            Behandlingsstegsinfo(
+                Behandlingssteg.BREVMOTTAKER,
+                Behandlingsstegstatus.KLAR
+            )
+        )
+    }
+
+    override fun getBehandlingssteg(): Behandlingssteg {
+        return Behandlingssteg.BREVMOTTAKER
+    }
+}

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/FaktaFeilutbetalingssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/FaktaFeilutbetalingssteg.kt
@@ -69,7 +69,7 @@ class FaktaFeilutbetalingssteg(
     @Transactional
     override fun gjenopptaSteg(behandlingId: UUID) {
         logger.info("Behandling $behandlingId gjenopptar på ${Behandlingssteg.FAKTA} steg")
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.FAKTA,
@@ -88,7 +88,7 @@ class FaktaFeilutbetalingssteg(
     }
 
     private fun flyttBehandlingVidere(behandlingId: UUID) {
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.FAKTA,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Fattevedtakssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Fattevedtakssteg.kt
@@ -69,7 +69,7 @@ class Fattevedtakssteg(
                 behandling.ansvarligSaksbehandler
             )
         } else {
-            behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+            behandlingskontrollService.oppdaterBehandlingsstegStatus(
                 behandlingId,
                 Behandlingsstegsinfo(
                     Behandlingssteg.FATTE_VEDTAK,
@@ -93,7 +93,7 @@ class Fattevedtakssteg(
         totrinnService.oppdaterAnsvarligBeslutter(behandlingId)
         totrinnService.lagreFastTotrinnsvurderingerForAutomatiskSaksbehandling(behandlingId)
 
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.FATTE_VEDTAK,
@@ -112,7 +112,7 @@ class Fattevedtakssteg(
     @Transactional
     override fun gjenopptaSteg(behandlingId: UUID) {
         logger.info("Behandling $behandlingId gjenopptar på ${Behandlingssteg.FATTE_VEDTAK} steg")
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.FATTE_VEDTAK,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreldelsessteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreldelsessteg.kt
@@ -40,7 +40,7 @@ class Foreldelsessteg(
         if (!harGrunnlagForeldetPeriode(behandlingId)) {
             lagHistorikkinnslag(behandlingId, Aktør.VEDTAKSLØSNING)
 
-            behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+            behandlingskontrollService.oppdaterBehandlingsstegStatus(
                 behandlingId,
                 Behandlingsstegsinfo(
                     Behandlingssteg.FORELDELSE,
@@ -60,7 +60,7 @@ class Foreldelsessteg(
 
         lagHistorikkinnslag(behandlingId, Aktør.SAKSBEHANDLER)
 
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.FORELDELSE,
@@ -80,7 +80,7 @@ class Foreldelsessteg(
         foreldelseService.lagreFastForeldelseForAutomatiskSaksbehandling(behandlingId)
         lagHistorikkinnslag(behandlingId, Aktør.VEDTAKSLØSNING)
 
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.FORELDELSE,
@@ -93,7 +93,7 @@ class Foreldelsessteg(
     @Transactional
     override fun gjenopptaSteg(behandlingId: UUID) {
         logger.info("Behandling $behandlingId gjenopptar på ${Behandlingssteg.FORELDELSE} steg")
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.FORELDELSE,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreslåvedtakssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreslåvedtakssteg.kt
@@ -94,7 +94,7 @@ class Foreslåvedtakssteg(
     @Transactional
     override fun gjenopptaSteg(behandlingId: UUID) {
         logger.info("Behandling $behandlingId gjenopptar på ${Behandlingssteg.FORESLÅ_VEDTAK} steg")
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.FORESLÅ_VEDTAK,
@@ -109,7 +109,7 @@ class Foreslåvedtakssteg(
     }
 
     private fun flyttBehandlingVidere(behandlingId: UUID) {
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.FORESLÅ_VEDTAK,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Grunnlagssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Grunnlagssteg.kt
@@ -27,7 +27,7 @@ class Grunnlagssteg(
     override fun utførSteg(behandlingId: UUID) {
         logger.info("Behandling $behandlingId er på ${Behandlingssteg.GRUNNLAG} steg")
         if (kravgrunnlagRepository.existsByBehandlingIdAndAktivTrueAndSperretFalse(behandlingId)) {
-            behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+            behandlingskontrollService.oppdaterBehandlingsstegStatus(
                 behandlingId,
                 Behandlingsstegsinfo(
                     Behandlingssteg.GRUNNLAG,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/StegService.kt
@@ -27,10 +27,11 @@ class StegService(
 
         hentStegInstans(aktivtBehandlingssteg).utførSteg(behandlingId)
 
-        // Autoutfør verge steg om verge informasjon er kopiert fra fagsystem
+        // Autoutfør brevmottaker steg og verge steg om verge informasjon er kopiert fra fagsystem
         aktivtBehandlingssteg = hentAktivBehandlingssteg(behandlingId)
-        if (aktivtBehandlingssteg == Behandlingssteg.VERGE) {
-            hentStegInstans(aktivtBehandlingssteg).utførSteg(behandlingId)
+        when (aktivtBehandlingssteg) {
+            Behandlingssteg.BREVMOTTAKER, Behandlingssteg.VERGE -> hentStegInstans(aktivtBehandlingssteg).utførSteg(behandlingId)
+            else -> return
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/StegService.kt
@@ -111,10 +111,11 @@ class StegService(
 
         hentStegInstans(aktivtBehandlingssteg).gjenopptaSteg(behandlingId)
 
-        // Autoutfør verge steg om verge informasjon er kopiert fra fagsystem
+        // Autoutfør brevmottaker steg og verge steg om verge informasjon er kopiert fra fagsystem
         aktivtBehandlingssteg = hentAktivBehandlingssteg(behandlingId)
-        if (aktivtBehandlingssteg == Behandlingssteg.VERGE) {
-            hentStegInstans(aktivtBehandlingssteg).utførSteg(behandlingId)
+        when (aktivtBehandlingssteg) {
+            Behandlingssteg.BREVMOTTAKER, Behandlingssteg.VERGE -> hentStegInstans(aktivtBehandlingssteg).utførSteg(behandlingId)
+            else -> return
         }
     }
 
@@ -138,6 +139,7 @@ class StegService(
         if (aktivtBehandlingssteg !in setOf(
                 Behandlingssteg.VARSEL,
                 Behandlingssteg.GRUNNLAG,
+                Behandlingssteg.BREVMOTTAKER,
                 Behandlingssteg.VERGE,
                 Behandlingssteg.FAKTA,
                 Behandlingssteg.FORELDELSE,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Varselssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Varselssteg.kt
@@ -27,7 +27,7 @@ class Varselssteg(private val behandlingskontrollService: BehandlingskontrollSer
     @Transactional
     override fun gjenopptaSteg(behandlingId: UUID) {
         logger.info("Behandling $behandlingId gjenopptar på ${Behandlingssteg.VARSEL} steg")
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.VARSEL,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Vergessteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Vergessteg.kt
@@ -32,7 +32,7 @@ class Vergessteg(
         logger.info("Behandling $behandlingId er på ${Behandlingssteg.VERGE} steg")
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         if (behandling.harVerge) {
-            behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+            behandlingskontrollService.oppdaterBehandlingsstegStatus(
                 behandlingId,
                 Behandlingsstegsinfo(
                     Behandlingssteg.VERGE,
@@ -50,7 +50,7 @@ class Vergessteg(
 
         oppgaveTaskService.oppdaterAnsvarligSaksbehandlerOppgaveTask(behandlingId)
 
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(Behandlingssteg.VERGE, UTFØRT)
         )
@@ -60,7 +60,7 @@ class Vergessteg(
     @Transactional
     override fun gjenopptaSteg(behandlingId: UUID) {
         logger.info("Behandling $behandlingId gjenopptar på ${Behandlingssteg.VERGE} steg")
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.VERGE,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Vilkårsvurderingssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Vilkårsvurderingssteg.kt
@@ -44,7 +44,7 @@ class Vilkårsvurderingssteg(
 
             lagHistorikkinnslag(behandlingId, Aktør.VEDTAKSLØSNING)
 
-            behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+            behandlingskontrollService.oppdaterBehandlingsstegStatus(
                 behandlingId,
                 Behandlingsstegsinfo(VILKÅRSVURDERING, AUTOUTFØRT)
             )
@@ -68,7 +68,7 @@ class Vilkårsvurderingssteg(
 
         lagHistorikkinnslag(behandlingId, Aktør.SAKSBEHANDLER)
 
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(behandlingId, Behandlingsstegsinfo(VILKÅRSVURDERING, UTFØRT))
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(behandlingId, Behandlingsstegsinfo(VILKÅRSVURDERING, UTFØRT))
         behandlingskontrollService.fortsettBehandling(behandlingId)
     }
 
@@ -83,7 +83,7 @@ class Vilkårsvurderingssteg(
         vilkårsvurderingService.lagreFastVilkårForAutomatiskSaksbehandling(behandlingId)
         lagHistorikkinnslag(behandlingId, Aktør.VEDTAKSLØSNING)
 
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(VILKÅRSVURDERING, UTFØRT)
         )
@@ -93,7 +93,7 @@ class Vilkårsvurderingssteg(
     @Transactional
     override fun gjenopptaSteg(behandlingId: UUID) {
         logger.info("Behandling $behandlingId gjenopptar på $VILKÅRSVURDERING steg")
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 VILKÅRSVURDERING,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
@@ -412,6 +412,6 @@ class BehandlingskontrollService(
     }
 
     private fun sjekkOmBrevmottakerErstatterVergeForSekvens(sekvens: Int, behandlingId: UUID) =
-        sekvens == Behandlingssteg.BREVMOTTAKER.sekvens && behandlingsstegstilstandRepository
+        sekvens == Behandlingssteg.VERGE.sekvens && behandlingsstegstilstandRepository
             .findByBehandlingIdAndBehandlingssteg(behandlingId, Behandlingssteg.BREVMOTTAKER) != null
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
@@ -98,7 +98,7 @@ class BehandlingskontrollService(
             .filter { it.behandlingssteg !in listOf(Behandlingssteg.VARSEL, Behandlingssteg.GRUNNLAG) }
         alleIkkeVentendeSteg.forEach {
             log.info("Tilbakefører ${it.behandlingssteg} for behandling $behandlingId")
-            oppdaterBehandlingsstegsstaus(behandlingId, Behandlingsstegsinfo(it.behandlingssteg, TILBAKEFØRT))
+            oppdaterBehandlingsstegStatus(behandlingId, Behandlingsstegsinfo(it.behandlingssteg, TILBAKEFØRT))
         }
     }
 
@@ -110,9 +110,9 @@ class BehandlingskontrollService(
         if (behandledeSteg.sekvens < aktivtBehandlingssteg.sekvens) {
             for (i in aktivtBehandlingssteg.sekvens downTo behandledeSteg.sekvens + 1 step 1) {
                 val behandlingssteg = Behandlingssteg.fraSekvens(i, sjekkOmBrevmottakerErstatterVergeForSekvens(i, behandlingId))
-                oppdaterBehandlingsstegsstaus(behandlingId, Behandlingsstegsinfo(behandlingssteg, TILBAKEFØRT))
+                oppdaterBehandlingsstegStatus(behandlingId, Behandlingsstegsinfo(behandlingssteg, TILBAKEFØRT))
             }
-            oppdaterBehandlingsstegsstaus(behandlingId, Behandlingsstegsinfo(behandledeSteg, KLAR))
+            oppdaterBehandlingsstegStatus(behandlingId, Behandlingsstegsinfo(behandledeSteg, KLAR))
         }
     }
 
@@ -126,7 +126,7 @@ class BehandlingskontrollService(
         )
         when {
             eksisterendeVergeSteg != null -> {
-                oppdaterBehandlingsstegsstaus(behandlingId, Behandlingsstegsinfo(Behandlingssteg.VERGE, KLAR))
+                oppdaterBehandlingsstegStatus(behandlingId, Behandlingsstegsinfo(Behandlingssteg.VERGE, KLAR))
             }
             else -> {
                 opprettBehandlingsstegOgStatus(behandlingId, Behandlingsstegsinfo(Behandlingssteg.VERGE, KLAR))
@@ -141,7 +141,7 @@ class BehandlingskontrollService(
             behandlingId,
             Behandlingssteg.BREVMOTTAKER
         ) ?.apply {
-            oppdaterBehandlingsstegsstaus(behandlingId, Behandlingsstegsinfo(Behandlingssteg.BREVMOTTAKER, AUTOUTFØRT))
+            oppdaterBehandlingsstegStatus(behandlingId, Behandlingsstegsinfo(Behandlingssteg.BREVMOTTAKER, AUTOUTFØRT))
         } ?: opprettBehandlingsstegOgStatus(behandlingId, Behandlingsstegsinfo(Behandlingssteg.BREVMOTTAKER, AUTOUTFØRT))
     }
 
@@ -221,7 +221,7 @@ class BehandlingskontrollService(
     }
 
     @Transactional
-    fun oppdaterBehandlingsstegsstaus(behandlingId: UUID, behandlingsstegsinfo: Behandlingsstegsinfo) {
+    fun oppdaterBehandlingsstegStatus(behandlingId: UUID, behandlingsstegsinfo: Behandlingsstegsinfo) {
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         if (behandling.erAvsluttet && (
             behandlingsstegsinfo.behandlingssteg != Behandlingssteg.AVSLUTTET &&
@@ -289,7 +289,7 @@ class BehandlingskontrollService(
                 opprettBehandlingsstegOgStatus(behandlingId, behandlingsstegsinfo)
             }
             else -> {
-                oppdaterBehandlingsstegsstaus(behandlingId, behandlingsstegsinfo)
+                oppdaterBehandlingsstegStatus(behandlingId, behandlingsstegsinfo)
             }
         }
     }

--- a/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
@@ -136,15 +136,13 @@ class BehandlingskontrollService(
 
     @Transactional
     fun behandleBrevmottakerSteg(behandlingId: UUID) {
+        log.info("Aktiverer brevmottaker steg for behandling med id=$behandlingId")
         behandlingsstegstilstandRepository.findByBehandlingIdAndBehandlingssteg(
             behandlingId,
             Behandlingssteg.BREVMOTTAKER
         ) ?.apply {
             oppdaterBehandlingsstegsstaus(behandlingId, Behandlingsstegsinfo(Behandlingssteg.BREVMOTTAKER, AUTOUTFØRT))
-            log.info("Oppdaterte brevmottaker steg for behandling med id=$behandlingId")
-        } ?: opprettBehandlingsstegOgStatus(behandlingId, Behandlingsstegsinfo(Behandlingssteg.BREVMOTTAKER, AUTOUTFØRT)).also {
-            log.info("Opprettet brevmottaker steg for behandling med id=$behandlingId")
-        }
+        } ?: opprettBehandlingsstegOgStatus(behandlingId, Behandlingsstegsinfo(Behandlingssteg.BREVMOTTAKER, AUTOUTFØRT))
     }
 
     @Transactional
@@ -337,7 +335,7 @@ class BehandlingskontrollService(
                 behandlingssteg = sisteUtførteSteg,
                 harVerge = behandling.harVerge,
                 harManuelleBrevmottakere =
-                featureToggleService.isEnabled(FeatureToggleConfig.DSITRIBUER_TIL_MANUELLE_BREVMOTTAKERE) &&
+                featureToggleService.isEnabled(FeatureToggleConfig.DISTRIBUER_TIL_MANUELLE_BREVMOTTAKERE) &&
                     brevmottakerRepository.findByBehandlingId(behandling.id).isNotEmpty()
             ),
             KLAR

--- a/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
@@ -6,11 +6,11 @@ import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
+import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.AUTOUTFØRT
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.AVBRUTT
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.KLAR
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.TILBAKEFØRT
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.UTFØRT
-import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.AUTOUTFØRT
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.VENTER
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstilstand
 import no.nav.familie.tilbake.behandlingskontroll.domain.Venteårsak
@@ -110,7 +110,7 @@ class BehandlingskontrollService(
             oppdaterBehandlingsstegsstaus(behandlingId, Behandlingsstegsinfo(behandledeSteg, KLAR))
         }
     }
-    @Deprecated(message = "Verge-steget vil erstattes av det nye Brevmottaker-steget")
+
     @Transactional
     fun behandleVergeSteg(behandlingId: UUID) {
         tilbakeførBehandledeSteg(behandlingId)
@@ -131,7 +131,6 @@ class BehandlingskontrollService(
 
     @Transactional
     fun behandleBrevmottakerSteg(behandlingId: UUID) {
-        //tilbakeførBehandledeSteg(behandlingId)
         behandlingsstegstilstandRepository.findByBehandlingIdAndBehandlingssteg(
             behandlingId,
             Behandlingssteg.BREVMOTTAKER

--- a/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.A
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.KLAR
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.TILBAKEFØRT
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.UTFØRT
+import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.AUTOUTFØRT
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus.VENTER
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstilstand
 import no.nav.familie.tilbake.behandlingskontroll.domain.Venteårsak
@@ -109,7 +110,7 @@ class BehandlingskontrollService(
             oppdaterBehandlingsstegsstaus(behandlingId, Behandlingsstegsinfo(behandledeSteg, KLAR))
         }
     }
-
+    @Deprecated(message = "Verge-steget vil erstattes av det nye Brevmottaker-steget")
     @Transactional
     fun behandleVergeSteg(behandlingId: UUID) {
         tilbakeførBehandledeSteg(behandlingId)
@@ -125,6 +126,20 @@ class BehandlingskontrollService(
             else -> {
                 opprettBehandlingsstegOgStatus(behandlingId, Behandlingsstegsinfo(Behandlingssteg.VERGE, KLAR))
             }
+        }
+    }
+
+    @Transactional
+    fun behandleBrevmottakerSteg(behandlingId: UUID) {
+        //tilbakeførBehandledeSteg(behandlingId)
+        behandlingsstegstilstandRepository.findByBehandlingIdAndBehandlingssteg(
+            behandlingId,
+            Behandlingssteg.BREVMOTTAKER
+        ) ?.apply {
+            oppdaterBehandlingsstegsstaus(behandlingId, Behandlingsstegsinfo(Behandlingssteg.BREVMOTTAKER, AUTOUTFØRT))
+            log.info("Oppdaterte brevmottaker steg for behandling med id=$behandlingId")
+        } ?: opprettBehandlingsstegOgStatus(behandlingId, Behandlingsstegsinfo(Behandlingssteg.BREVMOTTAKER, AUTOUTFØRT)).also {
+            log.info("Opprettet brevmottaker steg for behandling med id=$behandlingId")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/domain/Behandlingsstegstilstand.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/domain/Behandlingsstegstilstand.kt
@@ -34,6 +34,7 @@ enum class Behandlingssteg(
 
     VARSEL(1, false, false, Behandlingsstatus.UTREDES, "Vurdere om varsel om tilbakekreving skal sendes til søker"),
     GRUNNLAG(2, false, false, Behandlingsstatus.UTREDES, "Mottat kravgrunnlag fra økonomi for tilbakekrevingsrevurdering"),
+    BREVMOTTAKER(3, true, false, Behandlingsstatus.UTREDES, "Registrere brevmottakere manuelt. Erstatter Verge-steget"),
     VERGE(3, true, false, Behandlingsstatus.UTREDES, "Fakta om verge"),
     FAKTA(4, true, true, Behandlingsstatus.UTREDES, "Fakta om Feilutbetaling"),
     FORELDELSE(5, true, true, Behandlingsstatus.UTREDES, "Vurder om feilutbetalte perioder er foreldet"),

--- a/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/domain/Behandlingsstegstilstand.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/domain/Behandlingsstegstilstand.kt
@@ -52,8 +52,10 @@ enum class Behandlingssteg(
 
     companion object {
 
-        fun finnNesteBehandlingssteg(behandlingssteg: Behandlingssteg, harVerge: Boolean): Behandlingssteg {
-            val nesteBehandlingssteg = fraSekvens(behandlingssteg.sekvens + 1)
+        fun finnNesteBehandlingssteg(
+            behandlingssteg: Behandlingssteg, harVerge: Boolean, harManuelleBrevmottakere: Boolean
+        ): Behandlingssteg {
+            val nesteBehandlingssteg = fraSekvens(behandlingssteg.sekvens + 1, harManuelleBrevmottakere)
             if (nesteBehandlingssteg == VERGE && !harVerge) {
                 // Hvis behandling opprettes ikke med verge, kan behandlingen flyttes til neste steg
                 return fraSekvens(nesteBehandlingssteg.sekvens + 1)
@@ -61,10 +63,13 @@ enum class Behandlingssteg(
             return nesteBehandlingssteg
         }
 
-        fun fraSekvens(sekvens: Int): Behandlingssteg {
+        fun fraSekvens(sekvens: Int, brevmottakerErstatterVerge: Boolean = false): Behandlingssteg {
             for (behandlingssteg in values()) {
                 if (sekvens == behandlingssteg.sekvens) {
-                    return behandlingssteg
+                    return when (behandlingssteg) {
+                        BREVMOTTAKER, VERGE -> if (brevmottakerErstatterVerge) BREVMOTTAKER else VERGE
+                        else -> behandlingssteg
+                    }
                 }
             }
             throw IllegalArgumentException("Behandlingssteg finnes ikke med sekvens=$sekvens")

--- a/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/domain/Behandlingsstegstilstand.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/domain/Behandlingsstegstilstand.kt
@@ -35,6 +35,7 @@ enum class Behandlingssteg(
     VARSEL(1, false, false, Behandlingsstatus.UTREDES, "Vurdere om varsel om tilbakekreving skal sendes til søker"),
     GRUNNLAG(2, false, false, Behandlingsstatus.UTREDES, "Mottat kravgrunnlag fra økonomi for tilbakekrevingsrevurdering"),
     BREVMOTTAKER(3, true, false, Behandlingsstatus.UTREDES, "Registrere brevmottakere manuelt. Erstatter Verge-steget"),
+    @Deprecated("Erstattes av BREVMOTTAKER")
     VERGE(3, true, false, Behandlingsstatus.UTREDES, "Fakta om verge"),
     FAKTA(4, true, true, Behandlingsstatus.UTREDES, "Fakta om Feilutbetaling"),
     FORELDELSE(5, true, true, Behandlingsstatus.UTREDES, "Vurder om feilutbetalte perioder er foreldet"),

--- a/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
@@ -88,7 +88,7 @@ class FeatureToggleConfig(
 
         const val SETT_PRIORITET_PÅ_OPPGAVER = "familie.tilbake.prioritet-oppgaver"
 
-        const val DSITRIBUER_TIL_MANUELLE_BREVMOTTAKERE = "familie-tilbake.manuelle-brev"
+        const val DISTRIBUER_TIL_MANUELLE_BREVMOTTAKERE = "familie-tilbake.manuelle-brev"
 
         private val logger = LoggerFactory.getLogger(FeatureToggleConfig::class.java)
     }

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/task/PubliserJournalpostTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/task/PubliserJournalpostTask.kt
@@ -10,7 +10,7 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.familie.tilbake.config.FeatureToggleConfig.Companion.DSITRIBUER_TIL_MANUELLE_BREVMOTTAKERE
+import no.nav.familie.tilbake.config.FeatureToggleConfig.Companion.DISTRIBUER_TIL_MANUELLE_BREVMOTTAKERE
 import no.nav.familie.tilbake.config.FeatureToggleService
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerService
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.toManuelleAdresser
@@ -42,7 +42,7 @@ class PubliserJournalpostTask(
         val journalpostId = task.metadata.getProperty("journalpostId")
         val behandlingId = UUID.fromString(task.payload)
 
-        if (featureToggleService.isEnabled(DSITRIBUER_TIL_MANUELLE_BREVMOTTAKERE)) {
+        if (featureToggleService.isEnabled(DISTRIBUER_TIL_MANUELLE_BREVMOTTAKERE)) {
             val brevmottakere = manuellBrevmottakerService.hentBrevmottakere(behandlingId)
 
             val dødsboAdresser = brevmottakere.filter { it.type == MottakerType.DØDSBO }

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerService.kt
@@ -30,7 +30,7 @@ class ManuellBrevmottakerService(
     private val manuellBrevmottakerRepository: ManuellBrevmottakerRepository,
     private val historikkService: HistorikkService,
     private val behandlingRepository: BehandlingRepository,
-    private val behandlingskontrollService: BehandlingskontrollService,
+    private val behandlingskontrollService: BehandlingskontrollService
 ) {
 
     @Transactional
@@ -93,9 +93,10 @@ class ManuellBrevmottakerService(
         validerStegopprettelse(behandling)
         behandlingskontrollService.behandleBrevmottakerSteg(behandlingId)
     }
+
     @Transactional
     fun fjernManuelleBrevmottakereOgTilbakeførSteg(behandlingId: UUID) {
-        hentBrevmottakere(behandlingId).forEach{manuellBrevmottaker ->
+        hentBrevmottakere(behandlingId).forEach { manuellBrevmottaker ->
             manuellBrevmottakerRepository.deleteById(manuellBrevmottaker.id)
             historikkService.lagHistorikkinnslag(
                 behandlingId = behandlingId,
@@ -131,7 +132,6 @@ class ManuellBrevmottakerService(
             )
         }
     }
-
 }
 
 private fun findAdresseType(brevmottaker: ManuellBrevmottaker): AdresseType {

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerService.kt
@@ -7,10 +7,18 @@ import no.nav.familie.kontrakter.felles.dokdist.ManuellAdresse
 import no.nav.familie.kontrakter.felles.historikkinnslag.Aktør
 import no.nav.familie.kontrakter.felles.tilbakekreving.MottakerType.BRUKER_MED_UTENLANDSK_ADRESSE
 import no.nav.familie.tilbake.api.dto.ManuellBrevmottakerRequestDto
+import no.nav.familie.tilbake.behandling.BehandlingRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
+import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
+import no.nav.familie.tilbake.behandlingskontroll.Behandlingsstegsinfo
+import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
+import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
+import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.domene.ManuellBrevmottaker
 import no.nav.familie.tilbake.historikkinnslag.HistorikkService
 import no.nav.familie.tilbake.historikkinnslag.TilbakekrevingHistorikkinnslagstype
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -20,19 +28,22 @@ import kotlin.jvm.optionals.getOrNull
 @Service
 class ManuellBrevmottakerService(
     private val manuellBrevmottakerRepository: ManuellBrevmottakerRepository,
-    private val historikkService: HistorikkService
+    private val historikkService: HistorikkService,
+    private val behandlingRepository: BehandlingRepository,
+    private val behandlingskontrollService: BehandlingskontrollService,
 ) {
 
     @Transactional
-    fun leggTilBrevmottaker(behandlingId: UUID, manuellBrevmottakerRequestDto: ManuellBrevmottakerRequestDto) {
+    fun leggTilBrevmottaker(behandlingId: UUID, manuellBrevmottakerRequestDto: ManuellBrevmottakerRequestDto): UUID {
         val manuellBrevmottaker = ManuellBrevmottakerMapper.tilDomene(behandlingId, manuellBrevmottakerRequestDto)
-        manuellBrevmottakerRepository.insert(manuellBrevmottaker)
+        val id = manuellBrevmottakerRepository.insert(manuellBrevmottaker).id
         historikkService.lagHistorikkinnslag(
             behandlingId = behandlingId,
             historikkinnslagstype = TilbakekrevingHistorikkinnslagstype.BREVMOTTAKER_LAGT_TIL,
             aktør = Aktør.SAKSBEHANDLER,
             opprettetTidspunkt = LocalDateTime.now()
         )
+        return id
     }
 
     fun hentBrevmottakere(behandlingId: UUID) = manuellBrevmottakerRepository.findByBehandlingId(behandlingId)
@@ -75,6 +86,52 @@ class ManuellBrevmottakerService(
             opprettetTidspunkt = LocalDateTime.now()
         )
     }
+
+    @Transactional
+    fun opprettBrevmottakerSteg(behandlingId: UUID) {
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
+        validerStegopprettelse(behandling)
+        behandlingskontrollService.behandleBrevmottakerSteg(behandlingId)
+    }
+    @Transactional
+    fun fjernManuelleBrevmottakereOgTilbakeførSteg(behandlingId: UUID) {
+        hentBrevmottakere(behandlingId).forEach{manuellBrevmottaker ->
+            manuellBrevmottakerRepository.deleteById(manuellBrevmottaker.id)
+            historikkService.lagHistorikkinnslag(
+                behandlingId = behandlingId,
+                historikkinnslagstype = TilbakekrevingHistorikkinnslagstype.BREVMOTTAKER_FJERNET,
+                aktør = Aktør.SAKSBEHANDLER,
+                opprettetTidspunkt = LocalDateTime.now()
+            )
+        }
+
+        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+            behandlingId,
+            Behandlingsstegsinfo(
+                Behandlingssteg.BREVMOTTAKER,
+                Behandlingsstegstatus.TILBAKEFØRT
+            )
+        )
+        behandlingskontrollService.fortsettBehandling(behandlingId)
+    }
+
+    private fun validerStegopprettelse(behandling: Behandling) {
+        if (behandling.erSaksbehandlingAvsluttet) {
+            throw Feil(
+                "Behandling med id=${behandling.id} er allerede ferdig behandlet.",
+                frontendFeilmelding = "Behandling med id=${behandling.id} er allerede ferdig behandlet.",
+                httpStatus = HttpStatus.BAD_REQUEST
+            )
+        }
+        if (behandlingskontrollService.erBehandlingPåVent(behandling.id)) {
+            throw Feil(
+                "Behandling med id=${behandling.id} er på vent.",
+                frontendFeilmelding = "Behandling med id=${behandling.id} er på vent.",
+                httpStatus = HttpStatus.BAD_REQUEST
+            )
+        }
+    }
+
 }
 
 private fun findAdresseType(brevmottaker: ManuellBrevmottaker): AdresseType {

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerService.kt
@@ -94,7 +94,7 @@ class ManuellBrevmottakerService(
             fjernBrevmottakerOgLagHistorikkinnslag(manuellBrevmottaker.id, behandlingId)
         }
 
-        behandlingskontrollService.oppdaterBehandlingsstegsstaus(
+        behandlingskontrollService.oppdaterBehandlingsstegStatus(
             behandlingId,
             Behandlingsstegsinfo(
                 Behandlingssteg.BREVMOTTAKER,

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerService.kt
@@ -78,13 +78,7 @@ class ManuellBrevmottakerService(
         if (manuellBrevmottakere.none { it.id == manuellBrevmottakerId }) {
             throw Feil("Finnes ikke brevmottakere med id=$manuellBrevmottakerId for behandlingId=$behandlingId")
         }
-        manuellBrevmottakerRepository.deleteById(manuellBrevmottakerId)
-        historikkService.lagHistorikkinnslag(
-            behandlingId = behandlingId,
-            historikkinnslagstype = TilbakekrevingHistorikkinnslagstype.BREVMOTTAKER_FJERNET,
-            aktør = Aktør.SAKSBEHANDLER,
-            opprettetTidspunkt = LocalDateTime.now()
-        )
+        fjernBrevmottakerOgLagHistorikkinnslag(manuellBrevmottakerId, behandlingId)
     }
 
     @Transactional
@@ -97,13 +91,7 @@ class ManuellBrevmottakerService(
     @Transactional
     fun fjernManuelleBrevmottakereOgTilbakeførSteg(behandlingId: UUID) {
         hentBrevmottakere(behandlingId).forEach { manuellBrevmottaker ->
-            manuellBrevmottakerRepository.deleteById(manuellBrevmottaker.id)
-            historikkService.lagHistorikkinnslag(
-                behandlingId = behandlingId,
-                historikkinnslagstype = TilbakekrevingHistorikkinnslagstype.BREVMOTTAKER_FJERNET,
-                aktør = Aktør.SAKSBEHANDLER,
-                opprettetTidspunkt = LocalDateTime.now()
-            )
+            fjernBrevmottakerOgLagHistorikkinnslag(manuellBrevmottaker.id, behandlingId)
         }
 
         behandlingskontrollService.oppdaterBehandlingsstegsstaus(
@@ -114,6 +102,16 @@ class ManuellBrevmottakerService(
             )
         )
         behandlingskontrollService.fortsettBehandling(behandlingId)
+    }
+
+    private fun fjernBrevmottakerOgLagHistorikkinnslag(manuellBrevmottakerId: UUID, behandlingId: UUID) {
+        manuellBrevmottakerRepository.deleteById(manuellBrevmottakerId)
+        historikkService.lagHistorikkinnslag(
+            behandlingId = behandlingId,
+            historikkinnslagstype = TilbakekrevingHistorikkinnslagstype.BREVMOTTAKER_FJERNET,
+            aktør = Aktør.SAKSBEHANDLER,
+            opprettetTidspunkt = LocalDateTime.now()
+        )
     }
 
     private fun validerStegopprettelse(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/tilbake/iverksettvedtak/task/AvsluttBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/iverksettvedtak/task/AvsluttBehandlingTask.kt
@@ -53,7 +53,7 @@ class AvsluttBehandlingTask(
         )
 
         behandlingskontrollService
-            .oppdaterBehandlingsstegsstaus(
+            .oppdaterBehandlingsstegStatus(
                 behandlingId,
                 Behandlingsstegsinfo(
                     behandlingssteg = Behandlingssteg.AVSLUTTET,

--- a/src/main/kotlin/no/nav/familie/tilbake/iverksettvedtak/task/SendØkonomiTilbakekrevingsvedtakTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/iverksettvedtak/task/SendØkonomiTilbakekrevingsvedtakTask.kt
@@ -36,7 +36,7 @@ class SendØkonomiTilbakekrevingsvedtakTask(
         iverksettelseService.sendIverksettVedtak(behandlingId)
 
         behandlingskontrollService
-            .oppdaterBehandlingsstegsstaus(
+            .oppdaterBehandlingsstegStatus(
                 behandlingId,
                 Behandlingsstegsinfo(
                     behandlingssteg = Behandlingssteg.IVERKSETT_VEDTAK,

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/task/PubliserJournalpostTaskDistribuererTilRettAdresseTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/task/PubliserJournalpostTaskDistribuererTilRettAdresseTest.kt
@@ -17,7 +17,7 @@ import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
-import no.nav.familie.tilbake.config.FeatureToggleConfig.Companion.DSITRIBUER_TIL_MANUELLE_BREVMOTTAKERE
+import no.nav.familie.tilbake.config.FeatureToggleConfig.Companion.DISTRIBUER_TIL_MANUELLE_BREVMOTTAKERE
 import no.nav.familie.tilbake.config.FeatureToggleService
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerRepository
@@ -73,7 +73,7 @@ class PubliserJournalpostTaskDistribuererTilRettAdresseTest : OppslagSpringRunne
             PubliserJournalpostTask(integrasjonerClient, manuellBrevmottakerService, featureToggleService, taskService)
 
         every {
-            featureToggleService.isEnabled(DSITRIBUER_TIL_MANUELLE_BREVMOTTAKERE)
+            featureToggleService.isEnabled(DISTRIBUER_TIL_MANUELLE_BREVMOTTAKERE)
         } returns true
 
         every {

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
@@ -1,7 +1,9 @@
 package no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker
 
 import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -18,30 +20,47 @@ import no.nav.familie.tilbake.api.dto.ManuellBrevmottakerRequestDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
 import no.nav.familie.tilbake.behandling.domain.Behandling
+import no.nav.familie.tilbake.behandling.domain.Behandlingsstatus
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
+import no.nav.familie.tilbake.behandlingskontroll.BehandlingsstegstilstandRepository
+import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
+import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
+import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstilstand
+import no.nav.familie.tilbake.behandlingskontroll.domain.Venteårsak
+import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.domene.ManuellBrevmottaker
 import no.nav.familie.tilbake.historikkinnslag.HistorikkService
 import no.nav.familie.tilbake.historikkinnslag.TilbakekrevingHistorikkinnslagstype
+import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.UUID
 
 class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var manuellBrevmottakerRepository: ManuellBrevmottakerRepository
     private val mockHistorikkService: HistorikkService = mockk(relaxed = true)
-    private val mockBehandlingRepository: BehandlingRepository = mockk(relaxed = true)
-    private val mockBehandlingskontrollService: BehandlingskontrollService = mockk(relaxed = true)
 
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
     @Autowired
     private lateinit var behandlingRepository: BehandlingRepository
+
+    @Autowired
+    private lateinit var behandlingskontrollService: BehandlingskontrollService
+
+    @Autowired
+    private lateinit var behandlingsstegstilstandRepository: BehandlingsstegstilstandRepository
+
+    @Autowired
+    private lateinit var kravgrunnlagRepository: KravgrunnlagRepository
 
     private lateinit var behandling: Behandling
     private lateinit var manuellBrevmottakerService: ManuellBrevmottakerService
@@ -64,7 +83,7 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
         fagsakRepository.insert(Testdata.fagsak)
         behandling = behandlingRepository.insert(Testdata.behandling)
 
-        manuellBrevmottakerService = ManuellBrevmottakerService(manuellBrevmottakerRepository, mockHistorikkService, mockBehandlingRepository, mockBehandlingskontrollService)
+        manuellBrevmottakerService = ManuellBrevmottakerService(manuellBrevmottakerRepository, mockHistorikkService, behandlingRepository, behandlingskontrollService)
 
         every {
             mockHistorikkService.lagHistorikkinnslag(
@@ -177,6 +196,57 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
         }
     }
 
+    @Test
+    fun `opprettBrevmottakerSteg skal opprette og autoutføre behandlingssteg BREVMOTTAKER`() {
+        manuellBrevmottakerService.opprettBrevmottakerSteg(behandling.id)
+        val behandlingsstegstilstand = behandlingsstegstilstandRepository.findByBehandlingId(behandling.id)
+        behandlingsstegstilstand.shouldHaveSingleElement {
+            it.behandlingssteg == Behandlingssteg.BREVMOTTAKER &&
+                    it.behandlingsstegsstatus == Behandlingsstegstatus.AUTOUTFØRT
+        }
+    }
+
+    @Test
+    fun `opprettBrevmottakerSteg skal ikke opprette steg når behandling er avsluttet`() {
+        behandlingRepository.update(behandling.copy(status = Behandlingsstatus.AVSLUTTET))
+
+        val exception = shouldThrow<RuntimeException> { manuellBrevmottakerService.opprettBrevmottakerSteg(behandling.id) }
+        exception.message shouldBe "Behandling med id=${behandling.id} er allerede ferdig behandlet."
+    }
+
+    @Test
+    fun `opprettBrevmottakerSteg skal ikke opprette steg når behandling er på vent`() {
+        val behandling = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
+        lagBehandlingsstegstilstand(behandling.id, Behandlingssteg.FAKTA, Behandlingsstegstatus.KLAR)
+
+        behandlingskontrollService.settBehandlingPåVent(
+            behandling.id,
+            Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG,
+            LocalDate.now().plusWeeks(4)
+        )
+
+        val exception = shouldThrow<RuntimeException> { manuellBrevmottakerService.opprettBrevmottakerSteg(behandling.id) }
+        exception.message shouldBe "Behandling med id=${behandling.id} er på vent."
+    }
+
+    @Test
+    fun `fjernManuelleBrevmottakereOgTilbakeførSteg skal fjerne brevmottakere og tilbakeføre steget`() {
+        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        lagBehandlingsstegstilstand(behandling.id, Behandlingssteg.FAKTA, Behandlingsstegstatus.KLAR)
+
+        manuellBrevmottakerService.opprettBrevmottakerSteg(behandling.id)
+        manuellBrevmottakerService.leggTilBrevmottaker(behandling.id, manuellBrevmottakerRequestDto)
+        manuellBrevmottakerService.hentBrevmottakere(behandling.id).shouldHaveSize(1)
+
+        manuellBrevmottakerService.fjernManuelleBrevmottakereOgTilbakeførSteg(behandling.id)
+        manuellBrevmottakerService.hentBrevmottakere(behandling.id).shouldHaveSize(0)
+
+        behandlingsstegstilstandRepository.findByBehandlingId(behandling.id).shouldHaveSingleElement {
+            it.behandlingssteg == Behandlingssteg.BREVMOTTAKER &&
+                    it.behandlingsstegsstatus == Behandlingsstegstatus.TILBAKEFØRT
+        }
+    }
+
     private fun assertEqualsManuellBrevmottaker(a: ManuellBrevmottaker, b: ManuellBrevmottakerRequestDto) {
         a.id.shouldNotBeNull()
         a.orgNr shouldBe b.organisasjonsnummer
@@ -188,5 +258,19 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
         a.postnummer shouldBe b.manuellAdresseInfo?.postnummer
         a.poststed shouldBe b.manuellAdresseInfo?.poststed
         a.landkode shouldBe b.manuellAdresseInfo?.landkode
+    }
+
+    private fun lagBehandlingsstegstilstand(
+        behandlingId: UUID,
+        behandlingssteg: Behandlingssteg,
+        behandlingsstegstatus: Behandlingsstegstatus
+    ) {
+        behandlingsstegstilstandRepository.insert(
+            Behandlingsstegstilstand(
+                behandlingId = behandlingId,
+                behandlingssteg = behandlingssteg,
+                behandlingsstegsstatus = behandlingsstegstatus
+            )
+        )
     }
 }

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
@@ -18,6 +18,7 @@ import no.nav.familie.tilbake.api.dto.ManuellBrevmottakerRequestDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
 import no.nav.familie.tilbake.behandling.domain.Behandling
+import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.domene.ManuellBrevmottaker
 import no.nav.familie.tilbake.historikkinnslag.HistorikkService
@@ -33,6 +34,8 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var manuellBrevmottakerRepository: ManuellBrevmottakerRepository
     private val mockHistorikkService: HistorikkService = mockk(relaxed = true)
+    private val mockBehandlingRepository: BehandlingRepository = mockk(relaxed = true)
+    private val mockBehandlingskontrollService: BehandlingskontrollService = mockk(relaxed = true)
 
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
@@ -61,7 +64,7 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
         fagsakRepository.insert(Testdata.fagsak)
         behandling = behandlingRepository.insert(Testdata.behandling)
 
-        manuellBrevmottakerService = ManuellBrevmottakerService(manuellBrevmottakerRepository, mockHistorikkService)
+        manuellBrevmottakerService = ManuellBrevmottakerService(manuellBrevmottakerRepository, mockHistorikkService, mockBehandlingRepository, mockBehandlingskontrollService)
 
         every {
             mockHistorikkService.lagHistorikkinnslag(


### PR DESCRIPTION
Fikser også et par av funksjonene i ManuellBrevmottakerController som ikke var tatt i bruk og testet enda, samt legger til to nye for aktivering/deaktivering av det nye steget.

Hører sammen med denne frontend-PR'en: https://github.com/navikt/familie-tilbake-frontend/pull/1348