### PR TITLE
Reverter forrige endring som utvidet nyeste g-periode for å unngå tes…

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/common/Grunnbeløp.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/common/Grunnbeløp.kt
@@ -2,8 +2,6 @@ package no.nav.familie.tilbake.common
 
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.YearMonth
 
 object Grunnbeløpsperioder {
 
@@ -32,7 +30,7 @@ data class Grunnbeløp(
 private val grunnbeløpsperioder: List<Grunnbeløp> =
     listOf(
         Grunnbeløp(
-            periode = Månedsperiode("2022-05" to "2023-05"), // Setter ikke MAX for å unngå at grunnbeløpet ikke er oppdatert for neste periode
+            periode = Månedsperiode("2022-05" to "2023-04"), // Setter ikke MAX for å unngå at grunnbeløpet ikke er oppdatert for neste periode
             grunnbeløp = 111_477.toBigDecimal(),
             perMnd = 9_290.toBigDecimal(),
             gjennomsnittPerÅr = 109_784.toBigDecimal()

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevServiceTest.kt
@@ -121,12 +121,28 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
 
         fagsak = fagsakRepository.insert(Testdata.fagsak)
         behandling = behandlingRepository.insert(Testdata.behandling)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        val kravgrunnlagsperiode432 = Testdata.kravgrunnlag431.perioder.first().copy(periode = Månedsperiode(YearMonth.of(2023, 3), YearMonth.of(2023, 4)))
+        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431.copy(perioder = setOf(kravgrunnlagsperiode432)))
         vilkårsvurderingRepository.insert(
             Testdata.vilkårsvurdering
-                .copy(perioder = setOf(Testdata.vilkårsperiode.copy(godTro = null)))
+                .copy(perioder = setOf(Testdata.vilkårsperiode.copy(periode = Månedsperiode(YearMonth.of(2023, 3), YearMonth.of(2023, 4)), godTro = null)))
         )
-        faktaRepository.insert(Testdata.faktaFeilutbetaling)
+        faktaRepository.insert(
+            Testdata.faktaFeilutbetaling.copy(
+                perioder = setOf(
+                    FaktaFeilutbetalingsperiode(
+                        periode = Månedsperiode("2020-04" to "2022-08"),
+                        hendelsestype = Hendelsestype.ANNET,
+                        hendelsesundertype = Hendelsesundertype.ANNET_FRITEKST
+                    ),
+                    FaktaFeilutbetalingsperiode(
+                        periode = Månedsperiode("2023-03" to "2023-04"),
+                        hendelsestype = Hendelsestype.ANNET,
+                        hendelsesundertype = Hendelsesundertype.ANNET_FRITEKST
+                    )
+                )
+            )
+        )
 
         val personinfo = Personinfo("28056325874", LocalDate.now(), "Fiona")
 


### PR DESCRIPTION
…tfeil. Etter diskusjoner har vi kommet frem til at det er bedre at dersom en tilbakekreving med periode mai eller senere feiler til vi har nytt g-beløp fastsatt. Endrer derfor testene til å bruke en satt periode hvor vi har et g-beløp i stedet for dagens dato

[Reverter denne PR'n](https://github.com/navikt/familie-tilbake/pull/1078)
