### PR TITLE
Skal legge med behandlingsnummer header ved kall til PDL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <kotlin.version>1.8.21</kotlin.version>
         <felles.version>1.20221202080911_bcf8f33</felles.version>
         <common-java-modules.version>2.2021.09.17_07.09-67428a6422cc</common-java-modules.version>
-        <kontrakter.version>3.0_20230509152247_36d24db</kontrakter.version>
+        <kontrakter.version>3.0_20230523132455_9170af0</kontrakter.version>
         <kotest.version>5.6.1</kotest.version>
         <token-validation-spring.version>2.1.9</token-validation-spring.version>
         <okhttp3.version>4.9.1</okhttp3.version><!-- Inntil videre nødvendig for token-validation-spring-test-->

--- a/pom.xml
+++ b/pom.xml
@@ -24,13 +24,14 @@
         <kotlin.version>1.8.21</kotlin.version>
         <felles.version>1.20221202080911_bcf8f33</felles.version>
         <common-java-modules.version>2.2021.09.17_07.09-67428a6422cc</common-java-modules.version>
-        <kontrakter.version>2.0_20230313155154_f9438bd</kontrakter.version>
+        <kontrakter.version>3.0_20230509152247_36d24db</kontrakter.version>
         <kotest.version>5.6.1</kotest.version>
         <token-validation-spring.version>2.1.9</token-validation-spring.version>
         <okhttp3.version>4.9.1</okhttp3.version><!-- Inntil videre nødvendig for token-validation-spring-test-->
         <com.openhtmltopdf.version>1.0.10</com.openhtmltopdf.version>
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version><!-- Kan ikke oppgradere til 3.* p.g.a. av plugin maven-jaxb2-plugin -->
         <jaxb-impl.version>2.3.8</jaxb-impl.version><!-- Kan ikke oppgradere til 3.* p.g.a. av plugin maven-jaxb2-plugin -->
+        <jaxb-adapters.version>1.1.3</jaxb-adapters.version>
         <mockk.version>1.13.5</mockk.version>
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>
@@ -107,6 +108,11 @@
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.migesok</groupId>
+            <artifactId>jaxb-java-time-adapters</artifactId>
+            <version>${jaxb-adapters.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlBaseResponse.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlBaseResponse.kt
@@ -1,12 +1,17 @@
 package no.nav.familie.tilbake.integration.pdl.internal
 
-open class PdlBaseResponse(open val errors: List<PdlError>?) {
+open class PdlBaseResponse(open val errors: List<PdlError>?, open val extensions: PdlExtensions?) {
 
     fun harFeil(): Boolean {
         return errors != null && errors!!.isNotEmpty()
     }
-
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
+    }
     fun errorMessages(): String {
         return errors?.joinToString { it -> it.message } ?: ""
     }
 }
+
+data class PdlExtensions(val warnings: List<PdlWarning>?)
+data class PdlWarning(val details: Any?, val id: String?, val message: String?, val query: String?)

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlHentIdenterResponse.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlHentIdenterResponse.kt
@@ -2,9 +2,10 @@ package no.nav.familie.tilbake.integration.pdl.internal
 
 data class PdlHentIdenterResponse(
     val data: Data,
+    override val extensions: PdlExtensions?,
     override val errors: List<PdlError>?
 ) :
-    PdlBaseResponse(errors)
+    PdlBaseResponse(errors, extensions)
 
 data class Data(val pdlIdenter: PdlIdenter?)
 

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlHentPersonResponse.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlHentPersonResponse.kt
@@ -5,17 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class PdlHentPersonResponse<T>(
     val data: T,
-    val errors: List<PdlError>?
-) {
-
-    fun harFeil(): Boolean {
-        return errors != null && errors.isNotEmpty()
-    }
-
-    fun errorMessages(): String {
-        return errors?.joinToString { it -> it.message } ?: ""
-    }
-}
+    override val errors: List<PdlError>?,
+    override val extensions: PdlExtensions?
+) : PdlBaseResponse(errors, extensions)
 
 data class PdlPerson(val person: PdlPersonData?)
 
@@ -31,10 +23,10 @@ data class PdlFødselsDato(@JsonProperty("foedselsdato") val fødselsdato: Strin
 
 data class PdlError(
     val message: String,
-    val extensions: PdlExtensions?
+    val extensions: PdlErrorExtensions?
 )
 
-data class PdlExtensions(val code: String?)
+data class PdlErrorExtensions(val code: String?)
 
 data class PdlNavn(
     val fornavn: String,

--- a/src/test/kotlin/no/nav/familie/tilbake/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/config/PdlClientConfig.kt
@@ -44,6 +44,7 @@ class PdlClientConfig {
         every { pdlClient.hentIdenter(any(), any()) } answers {
             PdlHentIdenterResponse(
                 data = Data(PdlIdenter(identer = listOf(IdentInformasjon("123", "AKTORID")))),
+                extensions = null,
                 errors = listOf()
             )
         }


### PR DESCRIPTION
Hvorfor ?

PDL gjør endringer mot en mere fingranulert tilgangsstyring, og ønsker at konsumentene skal legge på en header med behandlingsnummer fra enhetskatalogen. Vi ønsker også å logge advarsler fra PDL, og ikke bare feil.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12402