### PR TITLE
Skal ikke prøve å lagre ned respons fra kafka for id pga. feil i PR 1102

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/HentFagsystemsbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/HentFagsystemsbehandlingService.kt
@@ -7,6 +7,7 @@ import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import no.nav.familie.tilbake.behandling.domain.HentFagsystemsbehandlingRequestSendt
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.integration.kafka.KafkaProducer
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -16,6 +17,7 @@ class HentFagsystemsbehandlingService(
     private val requestSendtRepository: HentFagsystemsbehandlingRequestSendtRepository,
     private val kafkaProducer: KafkaProducer
 ) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     @Transactional
     fun sendHentFagsystemsbehandlingRequest(
@@ -53,6 +55,11 @@ class HentFagsystemsbehandlingService(
         requestId: UUID,
         respons: String
     ) {
+        // TODO: Slett etter at det er kjørt i prod
+        if (requestId == UUID.fromString("7308c41f-cff3-4032-8414-959d603b00a2")) {
+            logger.info("Skal ikke lagre respons med id = $requestId.")
+            return
+        }
         val fagsystemsbehandlingRequestSendt = requestSendtRepository.findByIdOrThrow(requestId)
         requestSendtRepository.update(fagsystemsbehandlingRequestSendt.copy(respons = respons))
     }


### PR DESCRIPTION
Skal slettes etter at den er kjørt i prod.

Stopper lesing av kafka-melding som er introdusert av feil i #1102 og revertet i #1104 