### PR TITLE
Fix: eksternReferanseId til dokarkiv ble den samme ved 2 manuelle mottakere

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/DistribusjonshåndteringService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/DistribusjonshåndteringService.kt
@@ -17,6 +17,8 @@ import no.nav.familie.tilbake.dokumentbestilling.felles.BrevmetadataUtil
 import no.nav.familie.tilbake.dokumentbestilling.felles.Brevmottager
 import no.nav.familie.tilbake.dokumentbestilling.felles.Brevmottager.BRUKER
 import no.nav.familie.tilbake.dokumentbestilling.felles.Brevmottager.INSTITUSJON
+import no.nav.familie.tilbake.dokumentbestilling.felles.Brevmottager.MANUELL_BRUKER
+import no.nav.familie.tilbake.dokumentbestilling.felles.Brevmottager.MANUELL_TILLEGGSMOTTAKER
 import no.nav.familie.tilbake.dokumentbestilling.felles.Brevmottager.VERGE
 import no.nav.familie.tilbake.dokumentbestilling.felles.domain.Brevtype
 import no.nav.familie.tilbake.dokumentbestilling.felles.pdf.Brevdata
@@ -117,8 +119,10 @@ class ManuellBrevmottakerType(val mottaker: ManuellBrevmottaker): Brevmottaker
 
 val Brevmottaker?.navn: String?
     get() = if (this is ManuellBrevmottakerType) mottaker.navn else null
-val Brevmottaker?.somBrevmottager: Brevmottager
-    get() = (this as? BrevmottagerType)?.mottaker ?: Brevmottager.MANUELL
+val Brevmottaker.somBrevmottager: Brevmottager
+    get() = (this as? BrevmottagerType)?.mottaker ?: (this as ManuellBrevmottakerType).run {
+        if (mottaker.erTilleggsmottaker) MANUELL_TILLEGGSMOTTAKER else MANUELL_BRUKER
+    }
 val Brevmottaker?.manuellAdresse: Adresseinfo?
     get() = if (this is ManuellBrevmottakerType)
         Adresseinfo(

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/DistribusjonshåndteringService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/DistribusjonshåndteringService.kt
@@ -115,7 +115,7 @@ class DistribusjonshåndteringService(
 sealed interface Brevmottaker
 
 class BrevmottagerType(val mottaker: Brevmottager) : Brevmottaker
-class ManuellBrevmottakerType(val mottaker: ManuellBrevmottaker): Brevmottaker
+class ManuellBrevmottakerType(val mottaker: ManuellBrevmottaker) : Brevmottaker
 
 val Brevmottaker?.navn: String?
     get() = if (this is ManuellBrevmottakerType) mottaker.navn else null
@@ -124,11 +124,11 @@ val Brevmottaker.somBrevmottager: Brevmottager
         if (mottaker.erTilleggsmottaker) MANUELL_TILLEGGSMOTTAKER else MANUELL_BRUKER
     }
 val Brevmottaker?.manuellAdresse: Adresseinfo?
-    get() = if (this is ManuellBrevmottakerType)
+    get() = if (this is ManuellBrevmottakerType) {
         Adresseinfo(
             ident = mottaker.ident.orEmpty(),
             mottagernavn = mottaker.navn,
-            manuellAdresse = if (mottaker.hasManuellAdresse())
+            manuellAdresse = if (mottaker.hasManuellAdresse()) {
                 ManuellAdresse(
                     adresseType = when (mottaker.landkode) {
                         "NO" -> AdresseType.norskPostadresse
@@ -138,7 +138,12 @@ val Brevmottaker?.manuellAdresse: Adresseinfo?
                     adresselinje2 = mottaker.adresselinje2,
                     postnummer = mottaker.postnummer,
                     poststed = mottaker.poststed,
-                    land = mottaker.landkode!!,
-                ) else null,
-        ) else null
-
+                    land = mottaker.landkode!!
+                )
+            } else {
+                null
+            }
+        )
+    } else {
+        null
+    }

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/BrevmetadataUtil.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/BrevmetadataUtil.kt
@@ -36,7 +36,7 @@ class BrevmetadataUtil(
         vedtaksbrevgrunnlag: Vedtaksbrevgrunnlag? = null,
         brevmottager: Brevmottager = Brevmottager.BRUKER,
         manuellAdresseinfo: Adresseinfo? = null,
-        annenMottakersNavn: String? = null,
+        annenMottakersNavn: String? = null
     ): Brevmetadata? {
         require(brevmottager != brevmottager.MANUELL || manuellAdresseinfo != null) {
             "For en manuelt registrert brevmottaker kan ikke manuellAdresseinfo være null"
@@ -88,7 +88,7 @@ class BrevmetadataUtil(
     }
 
     fun lagBrevmetadataForMottakerTilForhåndsvisning(
-        behandlingId: UUID,
+        behandlingId: UUID
     ): Pair<Brevmetadata?, Brevmottager> {
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         val fagsak = fagsakRepository.findByIdOrThrow(behandling.fagsakId)
@@ -118,7 +118,9 @@ class BrevmetadataUtil(
             manuellAdresseinfo = manuellAdresseinfo,
             annenMottakersNavn = if (tilleggsmottaker != null) {
                 eksterneDataForBrevService.hentPerson(fagsak.bruker.ident, fagsak.fagsystem).navn
-            } else null
+            } else {
+                null
+            }
         )
         return metadata to brevmottager
     }

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/BrevmetadataUtil.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/BrevmetadataUtil.kt
@@ -34,12 +34,12 @@ class BrevmetadataUtil(
     fun genererMetadataForBrev(
         behandlingId: UUID,
         vedtaksbrevgrunnlag: Vedtaksbrevgrunnlag? = null,
-        brevmottager: Brevmottager = Brevmottager.MANUELL,
+        brevmottager: Brevmottager = Brevmottager.BRUKER,
         manuellAdresseinfo: Adresseinfo? = null,
         annenMottakersNavn: String? = null,
     ): Brevmetadata? {
-        require(brevmottager != Brevmottager.MANUELL || manuellAdresseinfo != null) {
-            "For en manuelt registrert brevmottaker (Brevmottager.MANUELL) kan ikke manuellAdresseinfo være null"
+        require(brevmottager != brevmottager.MANUELL || manuellAdresseinfo != null) {
+            "For en manuelt registrert brevmottaker kan ikke manuellAdresseinfo være null"
         }
 
         val behandling: Behandling by lazy { behandlingRepository.findByIdOrThrow(behandlingId) }
@@ -141,3 +141,10 @@ class BrevmetadataUtil(
         }
     }
 }
+
+private val Brevmottager.MANUELL
+    get() = when (this) {
+        Brevmottager.MANUELL_BRUKER,
+        Brevmottager.MANUELL_TILLEGGSMOTTAKER -> this
+        else -> null
+    }

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/Brevmottager.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/Brevmottager.kt
@@ -4,5 +4,6 @@ enum class Brevmottager {
     BRUKER,
     VERGE,
     INSTITUSJON,
-    MANUELL,
+    MANUELL_BRUKER,
+    MANUELL_TILLEGGSMOTTAKER
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/BrevmottagerUtil.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/BrevmottagerUtil.kt
@@ -9,8 +9,9 @@ import no.nav.familie.tilbake.behandling.domain.Verge as DomainVerge
 object BrevmottagerUtil {
 
     fun getAnnenMottagersNavn(brevmetadata: Brevmetadata): String? {
-        if (brevmetadata.annenMottakersNavn != null)
+        if (brevmetadata.annenMottakersNavn != null) {
             return brevmetadata.annenMottakersNavn
+        }
 
         val mottagernavn: String = brevmetadata.mottageradresse.mottagernavn
         val brukernavn = brevmetadata.sakspartsnavn

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/pdf/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/pdf/JournalføringService.kt
@@ -105,7 +105,9 @@ class JournalføringService(
         val adresseinfo: Adresseinfo = brevmetadata.mottageradresse
         val mottagerIdent = adresseinfo.ident.takeIf { it.isNotBlank() }
         return when (mottager) {
-            Brevmottager.BRUKER, Brevmottager.MANUELL -> AvsenderMottaker(
+            Brevmottager.BRUKER,
+            Brevmottager.MANUELL_BRUKER,
+            Brevmottager.MANUELL_TILLEGGSMOTTAKER-> AvsenderMottaker(
                 id = mottagerIdent,
                 idType = utledIdType(mottagerIdent),
                 navn = adresseinfo.mottagernavn

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/henleggelse/HenleggelsesbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/henleggelse/HenleggelsesbrevService.kt
@@ -34,7 +34,7 @@ class HenleggelsesbrevService(
     private val pdfBrevService: PdfBrevService,
     private val organisasjonService: OrganisasjonService,
     private val distribusjonshåndteringService: DistribusjonshåndteringService,
-    private val brevmetadataUtil: BrevmetadataUtil,
+    private val brevmetadataUtil: BrevmetadataUtil
 ) {
 
     fun sendHenleggelsebrev(behandlingId: UUID, fritekst: String?, brevmottager: Brevmottager? = null) {

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/henleggelse/HenleggelsesbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/henleggelse/HenleggelsesbrevService.kt
@@ -120,38 +120,42 @@ class HenleggelsesbrevService(
             )
         }
 
-        val personinfo: Personinfo = eksterneDataForBrevService.hentPerson(fagsak.bruker.ident, fagsak.fagsystem)
-        val adresseinfo: Adresseinfo = eksterneDataForBrevService.hentAdresse(
-            personinfo,
-            brevmottager,
-            behandling.aktivVerge,
-            fagsak.fagsystem
-        )
         val ansvarligSaksbehandler = if (behandling.ansvarligSaksbehandler == Constants.BRUKER_ID_VEDTAKSLØSNINGEN) {
             SIGNATUR_AUTOMATISK_HENLEGGELSESBREV
         } else {
             eksterneDataForBrevService.hentPåloggetSaksbehandlernavnMedDefault(behandling.ansvarligSaksbehandler)
         }
-        val vergenavn: String = BrevmottagerUtil.getVergenavn(behandling.aktivVerge, adresseinfo)
-        val gjelderDødsfall = personinfo.dødsdato != null
 
-        val metadata = forhåndsgenerertMetadata ?: Brevmetadata(
-            sakspartId = personinfo.ident,
-            sakspartsnavn = personinfo.navn,
-            finnesVerge = behandling.harVerge,
-            vergenavn = vergenavn,
-            mottageradresse = adresseinfo,
-            behandlendeEnhetId = behandling.behandlendeEnhet,
-            behandlendeEnhetsNavn = behandling.behandlendeEnhetsNavn,
-            ansvarligSaksbehandler = ansvarligSaksbehandler,
-            saksnummer = fagsak.eksternFagsakId,
-            språkkode = fagsak.bruker.språkkode,
-            ytelsestype = fagsak.ytelsestype,
-            gjelderDødsfall = gjelderDødsfall,
-            institusjon = fagsak.institusjon?.let {
-                organisasjonService.mapTilInstitusjonForBrevgenerering(it.organisasjonsnummer)
-            }
-        )
+        val metadata = forhåndsgenerertMetadata ?: run {
+            val personinfo: Personinfo = eksterneDataForBrevService.hentPerson(fagsak.bruker.ident, fagsak.fagsystem)
+            val adresseinfo: Adresseinfo = eksterneDataForBrevService.hentAdresse(
+                personinfo,
+                brevmottager,
+                behandling.aktivVerge,
+                fagsak.fagsystem
+            )
+
+            val vergenavn: String = BrevmottagerUtil.getVergenavn(behandling.aktivVerge, adresseinfo)
+            val gjelderDødsfall = personinfo.dødsdato != null
+
+            Brevmetadata(
+                sakspartId = personinfo.ident,
+                sakspartsnavn = personinfo.navn,
+                finnesVerge = behandling.harVerge,
+                vergenavn = vergenavn,
+                mottageradresse = adresseinfo,
+                behandlendeEnhetId = behandling.behandlendeEnhet,
+                behandlendeEnhetsNavn = behandling.behandlendeEnhetsNavn,
+                ansvarligSaksbehandler = ansvarligSaksbehandler,
+                saksnummer = fagsak.eksternFagsakId,
+                språkkode = fagsak.bruker.språkkode,
+                ytelsestype = fagsak.ytelsestype,
+                gjelderDødsfall = gjelderDødsfall,
+                institusjon = fagsak.institusjon?.let {
+                    organisasjonService.mapTilInstitusjonForBrevgenerering(it.organisasjonsnummer)
+                }
+            )
+        }
 
         return Henleggelsesbrevsdokument(
             metadata.copy(

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/domene/ManuellBrevmottaker.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/domene/ManuellBrevmottaker.kt
@@ -41,4 +41,6 @@ data class ManuellBrevmottaker(
                 landkode.isNullOrBlank()
             )
     }
+
+    val erTilleggsmottaker get() = type == MottakerType.VERGE || type == MottakerType.FULLMEKTIG
 }

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DistribusjonshåndteringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DistribusjonshåndteringServiceTest.kt
@@ -180,13 +180,14 @@ class DistribusjonshåndteringServiceTest {
 
     @Test
     fun `skal journalføre og sende brev med samme brødtekst til både manuell bruker og manuell tilleggsmottaker`() {
-        val behandlingMedManuelleBrevmottakere = behandling.copy(id = UUID.randomUUID(), verger = emptySet())
+        val behandlingId = UUID.randomUUID()
+        val behandlingMedManuelleBrevmottakere = behandling.copy(id = behandlingId, verger = emptySet())
 
-        every { behandlingRepository.findById(any()) } returns Optional.of(behandlingMedManuelleBrevmottakere)
-        every { manuelleBrevmottakerRepository.findByBehandlingId(any()) } returns listOf(
+        every { behandlingRepository.findById(behandlingId) } returns Optional.of(behandlingMedManuelleBrevmottakere)
+        every { manuelleBrevmottakerRepository.findByBehandlingId(behandlingId) } returns listOf(
             ManuellBrevmottaker(
                 type = MottakerType.BRUKER_MED_UTENLANDSK_ADRESSE,
-                behandlingId = behandlingMedManuelleBrevmottakere.id,
+                behandlingId = behandlingId,
                 navn = personinfoBruker.navn,
                 adresselinje1 = "adresselinje1",
                 postnummer = "postnummer",
@@ -195,7 +196,7 @@ class DistribusjonshåndteringServiceTest {
             ),
             ManuellBrevmottaker(
                 type = MottakerType.VERGE,
-                behandlingId = behandlingMedManuelleBrevmottakere.id,
+                behandlingId = behandlingId,
                 navn = verge.navn,
                 ident = verge.ident
             )
@@ -203,7 +204,7 @@ class DistribusjonshåndteringServiceTest {
 
         every { featureToggleService.isEnabled(FeatureToggleConfig.KONSOLIDERT_HÅNDTERING_AV_BREVMOTTAKERE) } returns true
 
-        val task = SendHenleggelsesbrevTask.opprettTask(this.behandling.id, fagsak.fagsystem, "fritekst")
+        val task = SendHenleggelsesbrevTask.opprettTask(behandlingId, fagsak.fagsystem, "fritekst")
         val brevdata = mutableListOf<Brevdata>()
         val eksternReferanseIdVedJournalføring = mutableListOf<String>()
 

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DistribusjonshåndteringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DistribusjonshåndteringServiceTest.kt
@@ -43,7 +43,7 @@ class DistribusjonshåndteringServiceTest {
     private val fagsakRepository: FagsakRepository = mockk()
     private val manuelleBrevmottakerRepository: ManuellBrevmottakerRepository = mockk(relaxed = true)
     private val journalføringService: JournalføringService = mockk(relaxed = true)
-    private val featureToggleService: FeatureToggleService = mockk(relaxed = true)
+    private val featureToggleService: FeatureToggleService = mockk()
     private val eksterneDataForBrevService: EksterneDataForBrevService = mockk()
     private val vedtaksbrevgrunnlagService: VedtaksbrevgunnlagService = mockk()
 
@@ -110,6 +110,7 @@ class DistribusjonshåndteringServiceTest {
         every { eksterneDataForBrevService.hentSaksbehandlernavn(any()) } returns behandling.ansvarligSaksbehandler
         every { eksterneDataForBrevService.hentPåloggetSaksbehandlernavnMedDefault(any()) } returns behandling.ansvarligSaksbehandler
         every { brevsporingService.finnSisteVarsel(any()) } returns Testdata.brevsporing
+        every { featureToggleService.isEnabled(any()) } returns false
     }
 
     @Test
@@ -202,6 +203,7 @@ class DistribusjonshåndteringServiceTest {
             )
         )
 
+        every { featureToggleService.isEnabled(FeatureToggleConfig.DISTRIBUER_TIL_MANUELLE_BREVMOTTAKERE) } returns true
         every { featureToggleService.isEnabled(FeatureToggleConfig.KONSOLIDERT_HÅNDTERING_AV_BREVMOTTAKERE) } returns true
 
         val task = SendHenleggelsesbrevTask.opprettTask(behandlingId, fagsak.fagsystem, "fritekst")

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/henleggelse/HenleggelsesbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/henleggelse/HenleggelsesbrevServiceTest.kt
@@ -158,9 +158,9 @@ class HenleggelsesbrevServiceTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    fun `brevmetadataUtil skal lage lik metadata som HeleggelsesbrevService selv`(){
+    fun `brevmetadataUtil skal lage lik metadata som HeleggelsesbrevService selv`() {
         every { featureToggleService.isEnabled(FeatureToggleConfig.KONSOLIDERT_HÅNDTERING_AV_BREVMOTTAKERE) } returns
-                true andThen false
+            true andThen false
 
         val brevdata = mutableListOf<Brevdata>()
 
@@ -169,13 +169,13 @@ class HenleggelsesbrevServiceTest : OppslagSpringRunnerTest() {
 
         verify(exactly = 2) {
             spyPdfBrevService.genererForhåndsvisning(
-                capture(brevdata),
+                capture(brevdata)
             )
         }
 
         brevdata shouldHaveSize 2
         brevdata.first().metadata.copy(annenMottakersNavn = null) shouldBeEqualToComparingFields
-                brevdata.last().metadata // gammel flyt setter ikke annenMottakersNavn i metadata. Utledes lokalt for hvert brev
+            brevdata.last().metadata // gammel flyt setter ikke annenMottakersNavn i metadata. Utledes lokalt for hvert brev
         brevdata.first().brevtekst shouldBeEqual brevdata.last().brevtekst
     }
 


### PR DESCRIPTION
La også til en enhetstest som verifiserer løsningen. Oppdaget og fikset da samtidig en unødvendig henting av data på nytt i HenleggelsesbrevService når metadata er forhåndsgenerert av BrevmetadataUtil