### PR TITLE
Skal hente fagsystembehandling på nytt i egen transaksjon.

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/HentFagsystemsbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/HentFagsystemsbehandlingService.kt
@@ -8,6 +8,7 @@ import no.nav.familie.tilbake.behandling.domain.HentFagsystemsbehandlingRequestS
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.integration.kafka.KafkaProducer
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
@@ -16,7 +17,6 @@ class HentFagsystemsbehandlingService(
     private val requestSendtRepository: HentFagsystemsbehandlingRequestSendtRepository,
     private val kafkaProducer: KafkaProducer
 ) {
-
 
     @Transactional
     fun sendHentFagsystemsbehandlingRequest(
@@ -27,17 +27,36 @@ class HentFagsystemsbehandlingService(
         val eksisterendeRequestSendt =
             requestSendtRepository.findByEksternFagsakIdAndYtelsestypeAndEksternId(eksternFagsakId, ytelsestype, eksternId)
         if (eksisterendeRequestSendt == null) {
-            val requestSendt =
-                requestSendtRepository.insert(
-                    HentFagsystemsbehandlingRequestSendt(
-                        eksternFagsakId = eksternFagsakId,
-                        ytelsestype = ytelsestype,
-                        eksternId = eksternId
-                    )
-                )
-            val request = HentFagsystemsbehandlingRequest(eksternFagsakId, ytelsestype, eksternId)
-            kafkaProducer.sendHentFagsystemsbehandlingRequest(requestSendt.id, request)
+            opprettOgSendHentFagsystembehandlingRequest(eksternFagsakId, ytelsestype, eksternId)
         }
+    }
+
+    private fun opprettOgSendHentFagsystembehandlingRequest(
+        eksternFagsakId: String,
+        ytelsestype: Ytelsestype,
+        eksternId: String
+    ) {
+        val requestSendt = requestSendtRepository.insert(
+            HentFagsystemsbehandlingRequestSendt(
+                eksternFagsakId = eksternFagsakId,
+                ytelsestype = ytelsestype,
+                eksternId = eksternId
+            )
+        )
+
+        val request = HentFagsystemsbehandlingRequest(eksternFagsakId, ytelsestype, eksternId)
+        kafkaProducer.sendHentFagsystemsbehandlingRequest(requestSendt.id, request)
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun slettOgSendNyHentFagsystembehandlingRequest(
+        requestSendtId: UUID,
+        eksternFagsakId: String,
+        ytelsestype: Ytelsestype,
+        eksternId: String
+    ) {
+        fjernHentFagsystemsbehandlingRequest(requestSendtId)
+        opprettOgSendHentFagsystembehandlingRequest(eksternFagsakId, ytelsestype, eksternId)
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/task/OpprettBehandlingManueltTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/task/OpprettBehandlingManueltTask.kt
@@ -59,8 +59,14 @@ class OpprettBehandlingManueltTask(
         val hentFagsystemsbehandlingRespons = hentFagsystemsbehandlingService.lesRespons(respons)
         val feilMelding = hentFagsystemsbehandlingRespons.feilMelding
         if (feilMelding != null) {
+            hentFagsystemsbehandlingService.slettOgSendNyHentFagsystembehandlingRequest(
+                requestSendtId = requestSendt.id,
+                eksternFagsakId = eksternFagsakId,
+                ytelsestype = ytelsestype,
+                eksternId = eksternId
+            )
             throw Feil(
-                "Noen gikk galt mens henter fagsystemsbehandling fra fagsystem. " +
+                "Noe gikk galt ved henting av fagsystemsbehandling fra fagsystem. Legger ny melding på topic. Task må rekjøres. " +
                     "Feiler med $feilMelding"
             )
         }

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/task/OpprettBehandlingManuellTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/task/OpprettBehandlingManuellTaskTest.kt
@@ -38,6 +38,7 @@ import no.nav.familie.tilbake.integration.kafka.KafkaProducer
 import no.nav.familie.tilbake.kravgrunnlag.task.FinnKravgrunnlagTask
 import no.nav.familie.tilbake.kravgrunnlag.ØkonomiXmlMottattRepository
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -209,6 +210,44 @@ internal class OpprettBehandlingManuellTaskTest : OppslagSpringRunnerTest() {
     }
 
     @Test
+    fun `doTask hente fagsystembehandling på nytt dersom det ga feilmelding forrige kjøring`() {
+        val task = lagTask()
+        opprettBehandlingManueltTask.preCondition(task)
+
+        val nySlotId = mutableListOf<UUID>()
+
+        val feiletRequestSendt = requestSendtRepository
+            .findByEksternFagsakIdAndYtelsestypeAndEksternId(
+                eksternFagsakId,
+                ytelsestype,
+                eksternId
+            )
+        val respons = lagHentFagsystemsbehandlingRespons(feilmelding = "Feilmelding")
+        feiletRequestSendt?.let { requestSendtRepository.update(it.copy(respons = objectMapper.writeValueAsString(respons))) }
+
+        val exception = shouldThrow<RuntimeException> { opprettBehandlingManueltTask.doTask(task) }
+        exception.message shouldBe "Noe gikk galt ved henting av fagsystemsbehandling fra fagsystem. Legger ny melding på topic. Task må rekjøres. Feiler med Feilmelding"
+
+        val nyRequestSendt = requestSendtRepository
+            .findByEksternFagsakIdAndYtelsestypeAndEksternId(
+                eksternFagsakId,
+                ytelsestype,
+                eksternId
+            )
+
+        verify(exactly = 2) {
+            spyKafkaProducer.sendHentFagsystemsbehandlingRequest(
+                capture(nySlotId),
+                any()
+            )
+        }
+
+        assertThat(feiletRequestSendt?.id).isNotEqualTo(nyRequestSendt?.id)
+        assertThat(nySlotId[0]).isEqualTo(feiletRequestSendt?.id)
+        assertThat(nySlotId[1]).isEqualTo(nyRequestSendt?.id)
+    }
+
+    @Test
     fun `doTask skal opprette behandling for institusjon når responsen har mottatt fra fagsystem og finnes kravgrunnlag`() {
         opprettBehandlingManueltTask.preCondition(lagTask())
 
@@ -265,7 +304,10 @@ internal class OpprettBehandlingManuellTaskTest : OppslagSpringRunnerTest() {
         )
     }
 
-    private fun lagHentFagsystemsbehandlingRespons(erInstitusjon: Boolean = false): HentFagsystemsbehandlingRespons {
+    private fun lagHentFagsystemsbehandlingRespons(
+        erInstitusjon: Boolean = false,
+        feilmelding: String? = null
+    ): HentFagsystemsbehandlingRespons {
         var institusjon = if (erInstitusjon) Institusjon(organisasjonsnummer = "987654321") else null
         val fagsystemsbehandling = HentFagsystemsbehandling(
             eksternFagsakId = eksternFagsakId,
@@ -284,6 +326,6 @@ internal class OpprettBehandlingManuellTaskTest : OppslagSpringRunnerTest() {
             ),
             institusjon = institusjon
         )
-        return HentFagsystemsbehandlingRespons(hentFagsystemsbehandling = fagsystemsbehandling)
+        return HentFagsystemsbehandlingRespons(hentFagsystemsbehandling = fagsystemsbehandling, feilMelding = feilmelding)
     }
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨ 

Vi har en `opprettBehandlingManuelt ` task som feiler i familie-tilbake pga. en nettverksfeil ved henting av behandling fra fagsystem i pre condition.

Ved manuell opprettelse av behandling legger familie-tilbake ut en melding på en kafka topic for å få behandlingen fra aktuelt fagsystem i pre-condition til tasken. Dersom responsen på denne meldingen er en feil kastes det en exception og tasken feiler. Ved re-kjøring legges det ikke ut en ny melding på topic og man havner i en evig ond sirkel 😢.

Det finnes en forvaltningsrutinge for å hente på nytt, men vi mener at tasken burde kunne håndtere dette selv.

###  Hva har vi gjort? 🤓 

Hvis respons fra fagsystem inneholder en feilmelding legges det ut en ny melding på topic før det kastes en feil. Om man da re-kjører tasken vil man ha en ny respons fra fagsystemet som forhåpentligvis ikke inneholder en feilmelding. 

Dette skal skje i en egen transaksjon slik at når det rulles tilbake pga. feilmelding som kastes i tasken skal det fortsatt opprettes en ny rad i databasen med id-en som er sendt til kafka.

### Mulige spørsmål / forklaring av tanker underveis

- Kan vi droppe pre-condition og gjøre alt i doTask? Tror ikke det fordi kafka er asynkront og vi får et svar uansett.
- Kan vi oppdatere i stedet for å slette og legge inn ny i databasen? Dette gjøres for å få en unik key i kafka-melding.

Co-authored-by: eirarset <eirik.arseth@nav.no>