### PR TITLE
Skal ikke lengre bruke forvaltningsrutine for å hente fagsystemsbehandling på nytt

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
@@ -78,20 +78,6 @@ class ForvaltningController(private val forvaltningService: ForvaltningService) 
         return Ressurs.success("OK")
     }
 
-    @Operation(summary = "Hent fagsysytemsbehandlingsinformasjon fra fagsystem via Kafka")
-    @PostMapping(
-        path = ["/fagsystemsbehandling/v1"],
-        produces = [MediaType.APPLICATION_JSON_VALUE]
-    )
-    @Rolletilgangssjekk(Behandlerrolle.FORVALTER, "Henter fagsystemsbehandling fra fagsystem via kafka", AuditLoggerEvent.UPDATE)
-    fun hentFagsystemsbehandling(
-        @Valid @RequestBody
-        hentFagsystemsbehandlingRequest: HentFagsystemsbehandlingRequestDto
-    ): Ressurs<String> {
-        forvaltningService.hentFagsystemsbehandling(hentFagsystemsbehandlingRequest)
-        return Ressurs.success("OK")
-    }
-
     @Operation(summary = "Flytt behandling tilbake til fakta")
     @PutMapping(
         path = ["/behandling/{behandlingId}/flytt-behandling/v1"],

--- a/src/main/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningService.kt
@@ -121,21 +121,6 @@ class ForvaltningService(
     }
 
     @Transactional
-    fun hentFagsystemsbehandling(hentFagsystemsbehandlingRequest: HentFagsystemsbehandlingRequestDto) {
-        val ytelsestype = hentFagsystemsbehandlingRequest.ytelsestype
-        val eksternFagsakId = hentFagsystemsbehandlingRequest.eksternFagsakId
-        val eksternId = hentFagsystemsbehandlingRequest.eksternId
-
-        val sendtRequest =
-            hentFagsystemsbehandlingService.hentFagsystemsbehandlingRequestSendt(eksternFagsakId, ytelsestype, eksternId)
-        // fjern eksisterende sendte request slik at ny request kan sendes
-        if (sendtRequest != null) {
-            hentFagsystemsbehandlingService.fjernHentFagsystemsbehandlingRequest(sendtRequest.id)
-        }
-        hentFagsystemsbehandlingService.sendHentFagsystemsbehandlingRequest(eksternFagsakId, ytelsestype, eksternId)
-    }
-
-    @Transactional
     fun flyttBehandlingsstegTilbakeTilFakta(behandlingId: UUID) {
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         sjekkOmBehandlingErAvsluttet(behandling)

--- a/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
@@ -221,29 +221,6 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    fun `hentFagsystemsbehandling skal sende request til fagsystem for å hente fagsystemsbehandling`() {
-        val eksternFagsakId = Testdata.fagsak.eksternFagsakId
-        val ytelsestype = Testdata.fagsak.ytelsestype
-        val eksternId = behandling.aktivFagsystemsbehandling.eksternId
-        // finnes en eksisterende request
-        val requestSendt = requestSendtRepository.insert(
-            HentFagsystemsbehandlingRequestSendt(
-                eksternFagsakId = eksternFagsakId,
-                ytelsestype = ytelsestype,
-                eksternId = eksternId
-            )
-        )
-        val hentFagsystemsbehandlingRequestDto = HentFagsystemsbehandlingRequestDto(ytelsestype, eksternFagsakId, eksternId)
-        forvaltningService.hentFagsystemsbehandling(hentFagsystemsbehandlingRequestDto)
-        requestSendtRepository.findByIdOrNull(requestSendt.id).shouldBeNull()
-        requestSendtRepository.findByEksternFagsakIdAndYtelsestypeAndEksternId(
-            eksternFagsakId,
-            ytelsestype,
-            eksternId
-        ).shouldNotBeNull()
-    }
-
-    @Test
     fun `flyttBehandlingsstegTilbakeTilFakta skal ikke flytte behandlingssteg når behandling er avsluttet`() {
         behandlingRepository.update(
             behandlingRepository.findByIdOrThrow(behandling.id)


### PR DESCRIPTION
 **Hvorfor?**
Etter https://github.com/navikt/familie-tilbake/pull/1110 trenger man ikke lengre å bruke forvaltningsrutinen for å hente fagsystembehandling på nytt. Det skal nå være nok å rekjøre tasken.
