### PR TITLE
Fikser feil saksbehandlersignatur ved forhåndsvisning av vedtaksbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/BrevmetadataUtil.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/BrevmetadataUtil.kt
@@ -88,7 +88,17 @@ class BrevmetadataUtil(
     }
 
     fun lagBrevmetadataForMottakerTilForhåndsvisning(
-        behandlingId: UUID
+        vedtaksbrevgrunnlag: Vedtaksbrevgrunnlag
+    ): Pair<Brevmetadata?, Brevmottager> {
+        return lagBrevmetadataForMottakerTilForhåndsvisning(
+            behandlingId = vedtaksbrevgrunnlag.behandling.id,
+            vedtaksbrevgrunnlag = vedtaksbrevgrunnlag
+        )
+    }
+
+    fun lagBrevmetadataForMottakerTilForhåndsvisning(
+        behandlingId: UUID,
+        vedtaksbrevgrunnlag: Vedtaksbrevgrunnlag? = null
     ): Pair<Brevmetadata?, Brevmottager> {
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         val fagsak = fagsakRepository.findByIdOrThrow(behandling.fagsakId)
@@ -114,12 +124,11 @@ class BrevmetadataUtil(
         }
         val metadata = genererMetadataForBrev(
             behandlingId = behandling.id,
+            vedtaksbrevgrunnlag = vedtaksbrevgrunnlag,
             brevmottager = brevmottager,
             manuellAdresseinfo = manuellAdresseinfo,
-            annenMottakersNavn = if (tilleggsmottaker != null) {
+            annenMottakersNavn = tilleggsmottaker?.let {
                 eksterneDataForBrevService.hentPerson(fagsak.bruker.ident, fagsak.fagsystem).navn
-            } else {
-                null
             }
         )
         return metadata to brevmottager

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevgeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevgeneratorService.kt
@@ -87,7 +87,7 @@ class VedtaksbrevgeneratorService(
         dto: HentForhåndvisningVedtaksbrevPdfDto
     ): Brevdata {
         val (brevmetadata, brevmottager) =
-            brevmetadataUtil.lagBrevmetadataForMottakerTilForhåndsvisning(vedtaksbrevgrunnlag.behandling.id)
+            brevmetadataUtil.lagBrevmetadataForMottakerTilForhåndsvisning(vedtaksbrevgrunnlag)
         val vedtaksbrevsdata = hentDataForVedtaksbrev(
             vedtaksbrevgrunnlag,
             dto.oppsummeringstekst,
@@ -116,7 +116,7 @@ class VedtaksbrevgeneratorService(
         vedtaksbrevgrunnlag: Vedtaksbrevgrunnlag
     ): HbVedtaksbrevsdata {
         val (brevmetadata, brevmottager) =
-            brevmetadataUtil.lagBrevmetadataForMottakerTilForhåndsvisning(vedtaksbrevgrunnlag.behandling.id)
+            brevmetadataUtil.lagBrevmetadataForMottakerTilForhåndsvisning(vedtaksbrevgrunnlag)
         val vedtaksbrevsdata = hentDataForVedtaksbrev(vedtaksbrevgrunnlag, brevmottager, brevmetadata)
         return vedtaksbrevsdata.vedtaksbrevsdata
     }


### PR DESCRIPTION
Med funksjonsbryteren for manuelle brevmottakere påskrudd, ble beslutters signatur vist to ganger, da genereringen av brevmetadata for forhåndsvisning manglet vedtaksbrevgrunnlaget.

Før:
![image](https://github.com/navikt/familie-tilbake/assets/47184872/8ed71035-d860-4107-8cae-96f897bb34fb)

Etter:
![image](https://github.com/navikt/familie-tilbake/assets/47184872/4ec22b5c-fdd7-4ec3-844d-c7193ad4c441)
