### PR TITLE
Vil bruke scale 6 for å beregne skatt på på samme måte som økonomi.

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/beregning/TilbakekrevingsberegningVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/beregning/TilbakekrevingsberegningVilkår.kt
@@ -88,7 +88,7 @@ internal object TilbakekrevingsberegningVilkår {
             if (periode.overlapper(grunnlagPeriodeMedSkattProsent.periode)) {
                 val delTilbakekrevesBeløp: BigDecimal = grunnlagPeriodeMedSkattProsent.tilbakekrevingsbeløp.multiply(andel)
                 val beregnetSkattBeløp = delTilbakekrevesBeløp.multiply(grunnlagPeriodeMedSkattProsent.skatteprosent)
-                    .divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP)
+                    .divide(BigDecimal.valueOf(100), 6, RoundingMode.HALF_UP)
                 skattBeløp = skattBeløp.add(beregnetSkattBeløp).setScale(0, RoundingMode.DOWN)
             }
         }


### PR DESCRIPTION
Hvorfor? 

Skatt i kravgrunnlag og vår beregnede skatt er i noen tilfeller blitt forskjellige (skiller 1 kr / mnd). Her ser vi at vi vil komme fram til samme resultat dersom vi bruker 6, ikke 4 desimaler når vi runder av beregnet skattebeløp.  

Vi har nå en del tasker som ligger på vent i "manuell oppfølging" - jeg er litt redd for at det kan bli rot dersom vi ikke gjør noe med disse snart. 

Vi jobber med en bedre fiks, men enn så lenge kan vi kanskje kjøre disse gjennom med denne?

Spørsmål: 
Kan sette tilbake til 4 desimaler etter at vi har rekjørt de taskene som ligger i manuell nå? 