### PR TITLE
Avbryt build-workflow dersom ny kjøring av samme workflow startes på samme branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
+    paths-ignore:
+      - '.github/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Build
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
-    paths-ignore:
-      - '.github/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 env:
   IMAGE: ghcr.io/navikt/familie-tilbake:${{ github.sha }}
 jobs:


### PR DESCRIPTION
Se dokumentasjon av konfigurasjonen her: https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

> **Example: Only cancel in-progress jobs or runs for the current workflow**
> If you have multiple workflows in the same repository, concurrency group names must be unique across workflows to avoid canceling in-progress jobs or runs from other workflows. Otherwise, any previously in-progress or pending job will be canceled, regardless of the workflow.
> 
> To only cancel in-progress runs of the same workflow, you can use the github.workflow property to build the concurrency group:
> ```
> concurrency:
>   group: ${{ github.workflow }}-${{ github.ref }}
>   cancel-in-progress: true
> ```