### PR TITLE
Fjerner KONT fra Klassekode enum

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/domain/Kravgrunnlag431.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/domain/Kravgrunnlag431.kt
@@ -146,7 +146,6 @@ enum class Klassekode(val aktivitet: String) {
     EFBT("Barnetilsyn"),
     EFSP("Skolepenger"),
     KS("Kontantstøtte"),
-    KONT("Kontantstøtte"),
     TREK_KODER(""); // Felles klassekode for alle TREK klassetyper
 
     companion object {


### PR DESCRIPTION
Fjerner `KONT` fra `Klassekode`-enum da det viste seg å være riktig å bruke `KS` som klassekode for kontantstøtte.