### PR TITLE
Logger stønadstype ved warning på avvik mellom hentet kravgrunnlag og mottatt kravgrunnlag

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HåndterGamleKravgrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HåndterGamleKravgrunnlagService.kt
@@ -86,7 +86,7 @@ class HåndterGamleKravgrunnlagService(
         val mottattKravgrunnlag = KravgrunnlagUtil.unmarshalKravgrunnlag(mottattXml.melding)
         val diffs = KravgrunnlagUtil.sammenlignKravgrunnlag(mottattKravgrunnlag, hentetKravgrunnlag)
         if (diffs.isNotEmpty()) {
-            logger.warn("Det finnes avvik mellom hentet kravgrunnlag og mottatt kravgrunnlag. Avvikene er $diffs")
+            logger.warn("Det finnes avvik mellom hentet kravgrunnlag og mottatt kravgrunnlag for ${hentetKravgrunnlag.kodeFagomraade}. Avvikene er $diffs")
         }
         logger.info(
             "Kobler kravgrunnlag med kravgrunnlagId=${hentetKravgrunnlag.kravgrunnlagId} " +


### PR DESCRIPTION
**Hvorfor**
Var en del warnings på dette i prod i dag, så det kan være greit å se hvem som har ansvar for å følge opp uten å måtte søke opp callId for hver enkelt.