### PR TITLE
NAV-13827 - validering at manuelle brevmottakere ikke er tillatt for fortrolig bruker

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/ValiderBrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/ValiderBrevmottakerService.kt
@@ -3,8 +3,6 @@ package no.nav.familie.tilbake.behandling
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerService
 import no.nav.familie.tilbake.person.PersonService
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -14,7 +12,6 @@ class ValiderBrevmottakerService(
     private val fagsakService: FagsakService,
     private val personService: PersonService
 ) {
-    private val logger: Logger = LoggerFactory.getLogger(this.javaClass)
     fun validerAtBehandlingIkkeInneholderStrengtFortroligPersonMedManuelleBrevmottakere(behandlingId: UUID, fagsakId: UUID) {
         val manuelleBrevmottakere = manuellBrevmottakerService.hentBrevmottakere(behandlingId).takeIf { it.isNotEmpty() } ?: return
         val fagsak = fagsakService.hentFagsak(fagsakId)
@@ -23,7 +20,6 @@ class ValiderBrevmottakerService(
         val personIdenter = listOfNotNull(bruker.ident)
         if (personIdenter.isEmpty()) return
         val strengtFortroligePersonIdenter = personService.hentIdenterMedStrengtFortroligAdressebeskyttelse(personIdenter, fagsystem)
-        logger.info("strengtFortroligePersonIdenter ${strengtFortroligePersonIdenter.size}")
         if (strengtFortroligePersonIdenter.isNotEmpty()) {
             val melding =
                 "Behandlingen (id: $behandlingId) inneholder person med strengt fortrolig adressebeskyttelse og kan ikke kombineres med manuelle brevmottakere (${manuelleBrevmottakere.size} stk)."

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/ValiderBrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/ValiderBrevmottakerService.kt
@@ -3,6 +3,8 @@ package no.nav.familie.tilbake.behandling
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerService
 import no.nav.familie.tilbake.person.PersonService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -12,6 +14,7 @@ class ValiderBrevmottakerService(
     private val fagsakService: FagsakService,
     private val personService: PersonService
 ) {
+    private val logger: Logger = LoggerFactory.getLogger(this.javaClass)
     fun validerAtBehandlingIkkeInneholderStrengtFortroligPersonMedManuelleBrevmottakere(behandlingId: UUID, fagsakId: UUID) {
         val manuelleBrevmottakere = manuellBrevmottakerService.hentBrevmottakere(behandlingId).takeIf { it.isNotEmpty() } ?: return
         val fagsak = fagsakService.hentFagsak(fagsakId)
@@ -20,6 +23,7 @@ class ValiderBrevmottakerService(
         val personIdenter = listOfNotNull(bruker.ident)
         if (personIdenter.isEmpty()) return
         val strengtFortroligePersonIdenter = personService.hentIdenterMedStrengtFortroligAdressebeskyttelse(personIdenter, fagsystem)
+        logger.info("strengtFortroligePersonIdenter ${strengtFortroligePersonIdenter.size}")
         if (strengtFortroligePersonIdenter.isNotEmpty()) {
             val melding =
                 "Behandlingen (id: $behandlingId) inneholder person med strengt fortrolig adressebeskyttelse og kan ikke kombineres med manuelle brevmottakere (${manuelleBrevmottakere.size} stk)."

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/StegService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.kontrakter.felles.Regelverk
 import no.nav.familie.tilbake.api.dto.BehandlingsstegDto
 import no.nav.familie.tilbake.api.dto.BehandlingsstegFatteVedtaksstegDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
+import no.nav.familie.tilbake.behandling.ValiderBrevmottakerService
 import no.nav.familie.tilbake.behandling.domain.Saksbehandlingstype
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
@@ -18,7 +19,8 @@ import java.util.UUID
 class StegService(
     val steg: List<IBehandlingssteg>,
     val behandlingRepository: BehandlingRepository,
-    val behandlingskontrollService: BehandlingskontrollService
+    val behandlingskontrollService: BehandlingskontrollService,
+    val validerBrevmottakerService: ValiderBrevmottakerService
 ) {
 
     @Transactional
@@ -51,6 +53,9 @@ class StegService(
         }
 
         var aktivtBehandlingssteg: Behandlingssteg = hentAktivBehandlingssteg(behandlingId)
+        if (Behandlingssteg.FORESLÅ_VEDTAK == aktivtBehandlingssteg) {
+            validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligPersonMedManuelleBrevmottakere(behandlingId = behandling.id, fagsakId = behandling.fagsakId)
+        }
         // Behandling kan ikke tilbakeføres når er på FatteVedtak/IverksetteVedtak steg
         if (Behandlingssteg.FATTE_VEDTAK == aktivtBehandlingssteg || Behandlingssteg.IVERKSETT_VEDTAK == aktivtBehandlingssteg) {
             if (behandlingsstegDto is BehandlingsstegFatteVedtaksstegDto) {

--- a/src/main/kotlin/no/nav/familie/tilbake/config/PdlConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/PdlConfig.kt
@@ -17,6 +17,7 @@ class PdlConfig(@Value("\${PDL_URL}") pdlUrl: URI) {
 
         val hentEnkelPersonQuery = graphqlQuery("hentperson-enkel")
         val hentIdenterQuery = graphqlQuery("hentIdenter")
+        val hentAdressebeskyttelseBolkQuery = graphqlQuery("hent-adressebeskyttelse-bolk")
 
         private fun graphqlQuery(pdlResource: String) = PdlConfig::class.java.getResource("/pdl/$pdlResource.graphql")
             .readText()

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/PdlClient.kt
@@ -5,12 +5,17 @@ import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.config.PdlConfig
+import no.nav.familie.tilbake.integration.pdl.internal.PdlAdressebeskyttelsePerson
+import no.nav.familie.tilbake.integration.pdl.internal.PdlBolkResponse
 import no.nav.familie.tilbake.integration.pdl.internal.PdlHentIdenterResponse
 import no.nav.familie.tilbake.integration.pdl.internal.PdlHentPersonResponse
 import no.nav.familie.tilbake.integration.pdl.internal.PdlPerson
+import no.nav.familie.tilbake.integration.pdl.internal.PdlPersonBolkRequest
+import no.nav.familie.tilbake.integration.pdl.internal.PdlPersonBolkRequestVariables
 import no.nav.familie.tilbake.integration.pdl.internal.PdlPersonRequest
 import no.nav.familie.tilbake.integration.pdl.internal.PdlPersonRequestVariables
 import no.nav.familie.tilbake.integration.pdl.internal.Personinfo
+import no.nav.familie.tilbake.integration.pdl.internal.feilsjekkOgReturnerData
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -84,6 +89,21 @@ class PdlClient(
             message = "Feil mot pdl: ${response.errorMessages()}",
             frontendFeilmelding = "Fant ikke identer for person $personIdent: ${response.errorMessages()}",
             httpStatus = HttpStatus.NOT_FOUND
+        )
+    }
+
+    fun hentAdressebeskyttelseBolk(personIdentList: List<String>, fagsystem: Fagsystem): Map<String, PdlAdressebeskyttelsePerson> {
+        val pdlRequest = PdlPersonBolkRequest(
+            variables = PdlPersonBolkRequestVariables(personIdentList),
+            query = PdlConfig.hentAdressebeskyttelseBolkQuery
+        )
+        val pdlResponse = postForEntity<PdlBolkResponse<PdlAdressebeskyttelsePerson>>(
+            pdlConfig.pdlUri,
+            pdlRequest,
+            httpHeaders(mapTilTema(fagsystem))
+        )
+        return feilsjekkOgReturnerData(
+            pdlResponse = pdlResponse
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlAdressebeskyttelsePerson.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlAdressebeskyttelsePerson.kt
@@ -1,0 +1,5 @@
+package no.nav.familie.tilbake.integration.pdl.internal
+
+import no.nav.familie.kontrakter.felles.personopplysning.Adressebeskyttelse
+
+class PdlAdressebeskyttelsePerson(val adressebeskyttelse: List<Adressebeskyttelse>)

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlBolkResponse.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlBolkResponse.kt
@@ -1,0 +1,15 @@
+package no.nav.familie.tilbake.integration.pdl.internal
+
+data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlError>?, val extensions: PdlExtensions?) {
+
+    fun errorMessages(): String {
+        return errors?.joinToString { it -> it.message } ?: ""
+    }
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
+    }
+}
+
+data class PersonBolk<T>(val personBolk: List<PersonDataBolk<T>>)
+
+data class PersonDataBolk<T>(val ident: String, val code: String, val person: T?)

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlPersonRequest.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlPersonRequest.kt
@@ -4,3 +4,8 @@ data class PdlPersonRequest(
     val variables: PdlPersonRequestVariables,
     val query: String
 )
+
+data class PdlPersonBolkRequest(
+    val variables: PdlPersonBolkRequestVariables,
+    val query: String
+)

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlPersonRequestVariables.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlPersonRequestVariables.kt
@@ -1,3 +1,5 @@
 package no.nav.familie.tilbake.integration.pdl.internal
 
 data class PdlPersonRequestVariables(var ident: String)
+
+data class PdlPersonBolkRequestVariables(var identer: List<String>)

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlUtil.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/pdl/internal/PdlUtil.kt
@@ -1,0 +1,26 @@
+package no.nav.familie.tilbake.integration.pdl.internal
+
+import no.nav.familie.tilbake.common.exceptionhandler.Feil
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
+val logger: Logger = LoggerFactory.getLogger("PdlUtil")
+
+inline fun <reified T : Any> feilsjekkOgReturnerData(pdlResponse: PdlBolkResponse<T>): Map<String, T> {
+    if (pdlResponse.data == null) {
+        secureLogger.error("Data fra pdl er null ved bolkoppslag av ${T::class} fra PDL: ${pdlResponse.errorMessages()}")
+        throw Feil("Data er null fra PDL -  ${T::class}. Se secure logg for detaljer.")
+    }
+
+    val feil = pdlResponse.data.personBolk.filter { it.code != "ok" }.associate { it.ident to it.code }
+    if (feil.isNotEmpty()) {
+        secureLogger.error("Feil ved henting av ${T::class} fra PDL: $feil")
+        throw Feil("Feil ved henting av ${T::class} fra PDL. Se secure logg for detaljer.")
+    }
+    if (pdlResponse.harAdvarsel()) {
+        logger.warn("Advarsel ved henting av ${T::class} fra PDL. Se securelogs for detaljer.")
+        secureLogger.warn("Advarsel ved henting av ${T::class} fra PDL: ${pdlResponse.extensions?.warnings}")
+    }
+    return pdlResponse.data.personBolk.associateBy({ it.ident }, { it.person!! })
+}

--- a/src/main/kotlin/no/nav/familie/tilbake/person/PersonService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/person/PersonService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.tilbake.person
 
 import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.tilbake.behandling.FagsakRepository
 import no.nav.familie.tilbake.behandling.event.EndretPersonIdentEventPublisher
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
@@ -24,6 +25,16 @@ class PersonService(
             endretPersonIdentEventPublisher.fireEvent(personInfo.ident, fagsak.id)
         }
         return personInfo
+    }
+
+    fun hentIdenterMedStrengtFortroligAdressebeskyttelse(personIdenter: List<String>, fagsystem: Fagsystem): List<String> {
+        val adresseBeskyttelseBolk = pdlClient.hentAdressebeskyttelseBolk(personIdenter, fagsystem)
+        return adresseBeskyttelseBolk.filter { (_, person) ->
+            person.adressebeskyttelse.any { adressebeskyttelse ->
+                adressebeskyttelse.gradering == ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG ||
+                    adressebeskyttelse.gradering == ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG_UTLAND
+            }
+        }.map { it.key }
     }
 
     fun hentAktørId(personIdent: String, fagsystem: Fagsystem): List<String> {

--- a/src/main/kotlin/no/nav/familie/tilbake/person/PersonService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/person/PersonService.kt
@@ -7,8 +7,6 @@ import no.nav.familie.tilbake.behandling.event.EndretPersonIdentEventPublisher
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.integration.pdl.PdlClient
 import no.nav.familie.tilbake.integration.pdl.internal.Personinfo
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -17,7 +15,6 @@ class PersonService(
     private val fagsakRepository: FagsakRepository,
     private val endretPersonIdentEventPublisher: EndretPersonIdentEventPublisher
 ) {
-    private val logger: Logger = LoggerFactory.getLogger(this.javaClass)
 
     fun hentPersoninfo(personIdent: String, fagsystem: Fagsystem): Personinfo {
         val personInfo = pdlClient.hentPersoninfo(personIdent, fagsystem)
@@ -32,7 +29,6 @@ class PersonService(
 
     fun hentIdenterMedStrengtFortroligAdressebeskyttelse(personIdenter: List<String>, fagsystem: Fagsystem): List<String> {
         val adresseBeskyttelseBolk = pdlClient.hentAdressebeskyttelseBolk(personIdenter, fagsystem)
-        logger.info("personIdenter fra pdl ${personIdenter.size}")
         return adresseBeskyttelseBolk.filter { (_, person) ->
             person.adressebeskyttelse.any { adressebeskyttelse ->
                 adressebeskyttelse.gradering == ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG ||

--- a/src/main/kotlin/no/nav/familie/tilbake/person/PersonService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/person/PersonService.kt
@@ -7,6 +7,8 @@ import no.nav.familie.tilbake.behandling.event.EndretPersonIdentEventPublisher
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.integration.pdl.PdlClient
 import no.nav.familie.tilbake.integration.pdl.internal.Personinfo
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -15,6 +17,7 @@ class PersonService(
     private val fagsakRepository: FagsakRepository,
     private val endretPersonIdentEventPublisher: EndretPersonIdentEventPublisher
 ) {
+    private val logger: Logger = LoggerFactory.getLogger(this.javaClass)
 
     fun hentPersoninfo(personIdent: String, fagsystem: Fagsystem): Personinfo {
         val personInfo = pdlClient.hentPersoninfo(personIdent, fagsystem)
@@ -29,6 +32,7 @@ class PersonService(
 
     fun hentIdenterMedStrengtFortroligAdressebeskyttelse(personIdenter: List<String>, fagsystem: Fagsystem): List<String> {
         val adresseBeskyttelseBolk = pdlClient.hentAdressebeskyttelseBolk(personIdenter, fagsystem)
+        logger.info("personIdenter fra pdl ${personIdenter.size}")
         return adresseBeskyttelseBolk.filter { (_, person) ->
             person.adressebeskyttelse.any { adressebeskyttelse ->
                 adressebeskyttelse.gradering == ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG ||

--- a/src/main/resources/pdl/hent-adressebeskyttelse-bolk.graphql
+++ b/src/main/resources/pdl/hent-adressebeskyttelse-bolk.graphql
@@ -1,0 +1,9 @@
+query($identer: [ID!]!) {personBolk: hentPersonBolk(identer: $identer) {
+       ident,
+       person {
+           adressebeskyttelse {
+               gradering
+           }
+       },
+       code
+}}

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/ValiderBrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/ValiderBrevmottakerServiceTest.kt
@@ -1,17 +1,15 @@
 package no.nav.familie.tilbake.behandling
 
-import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import no.nav.familie.kontrakter.felles.tilbakekreving.MottakerType
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerService
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.domene.ManuellBrevmottaker
 import no.nav.familie.tilbake.person.PersonService
+import org.assertj.core.api.Assertions.assertThatNoException
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import java.util.*
 
@@ -36,11 +34,6 @@ class ValiderBrevmottakerServiceTest {
         landkode = "NO"
     )
 
-    @AfterEach
-    internal fun tearDown() {
-        clearAllMocks()
-    }
-
     @Test
     fun `Skal ikke kaste en Feil exception når en behandling ikke inneholder noen manuelle brevmottakere`() {
         every { manuellBrevmottakerService.hentBrevmottakere(any()) } returns emptyList()
@@ -48,14 +41,7 @@ class ValiderBrevmottakerServiceTest {
             behandlingId,
             fagsak.id
         )
-        verify(exactly = 1) { manuellBrevmottakerService.hentBrevmottakere(behandlingId) }
-        verify(exactly = 0) { fagsakService.hentFagsak(any()) }
-        verify(exactly = 0) {
-            personService.hentIdenterMedStrengtFortroligAdressebeskyttelse(
-                any(),
-                any()
-            )
-        }
+        assertThatNoException()
     }
 
     @Test
@@ -83,12 +69,7 @@ class ValiderBrevmottakerServiceTest {
             behandlingId,
             fagsak.id
         )
-        verify(exactly = 1) {
-            personService.hentIdenterMedStrengtFortroligAdressebeskyttelse(
-                any(),
-                any()
-            )
-        }
+        assertThatNoException()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/ValiderBrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/ValiderBrevmottakerServiceTest.kt
@@ -1,0 +1,106 @@
+package no.nav.familie.tilbake.behandling
+
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.kontrakter.felles.tilbakekreving.MottakerType
+import no.nav.familie.tilbake.common.exceptionhandler.Feil
+import no.nav.familie.tilbake.data.Testdata
+import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerService
+import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.domene.ManuellBrevmottaker
+import no.nav.familie.tilbake.person.PersonService
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class ValiderBrevmottakerServiceTest {
+    private val manuellBrevmottakerService = mockk<ManuellBrevmottakerService>()
+    private val fagsakService = mockk<FagsakService>()
+    private val personService = mockk<PersonService>()
+    val validerBrevmottakerService = ValiderBrevmottakerService(
+        manuellBrevmottakerService,
+        fagsakService,
+        personService
+    )
+    private val behandlingId = UUID.randomUUID()
+    private val fagsak = Testdata.fagsak
+    private val manuellBrevmottaker = ManuellBrevmottaker(
+        type = MottakerType.BRUKER_MED_UTENLANDSK_ADRESSE,
+        behandlingId = behandlingId,
+        navn = "Donald Duck",
+        adresselinje1 = "adresselinje1",
+        postnummer = "postnummer",
+        poststed = "poststed",
+        landkode = "NO"
+    )
+
+    @AfterEach
+    internal fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `Skal ikke kaste en Feil exception når en behandling ikke inneholder noen manuelle brevmottakere`() {
+        every { manuellBrevmottakerService.hentBrevmottakere(any()) } returns emptyList()
+        validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligPersonMedManuelleBrevmottakere(
+            behandlingId,
+            fagsak.id
+        )
+        verify(exactly = 1) { manuellBrevmottakerService.hentBrevmottakere(behandlingId) }
+        verify(exactly = 0) { fagsakService.hentFagsak(any()) }
+        verify(exactly = 0) {
+            personService.hentIdenterMedStrengtFortroligAdressebeskyttelse(
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `Skal kaste en Feil exception når en behandling inneholder en strengt fortrolig person og minst en manuell brevmottaker`() {
+        every { manuellBrevmottakerService.hentBrevmottakere(behandlingId) } returns listOf(manuellBrevmottaker)
+        every { fagsakService.hentFagsak(any()) } returns fagsak
+        every { personService.hentIdenterMedStrengtFortroligAdressebeskyttelse(any(), any()) } returns listOf(
+            fagsak.bruker.ident
+        )
+        assertThatThrownBy {
+            validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligPersonMedManuelleBrevmottakere(
+                behandlingId,
+                fagsak.id
+            )
+        }.isInstanceOf(Feil::class.java)
+            .hasMessageContaining("strengt fortrolig adressebeskyttelse og kan ikke kombineres med manuelle brevmottakere")
+    }
+
+    @Test
+    fun `Skal ikke kaste Feil exception når behandling ikke inneholder strengt fortrolig person og inneholder en manuell brevmottaker`() {
+        every { manuellBrevmottakerService.hentBrevmottakere(behandlingId) } returns listOf(manuellBrevmottaker)
+        every { fagsakService.hentFagsak(any()) } returns fagsak
+        every { personService.hentIdenterMedStrengtFortroligAdressebeskyttelse(any(), any()) } returns emptyList()
+        validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligPersonMedManuelleBrevmottakere(
+            behandlingId,
+            fagsak.id
+        )
+        verify(exactly = 1) {
+            personService.hentIdenterMedStrengtFortroligAdressebeskyttelse(
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `Skal ikke kaste Feil exception når en behandling inneholder strengt fortrolig person og ingen manuelle brevmottakere`() {
+        every { manuellBrevmottakerService.hentBrevmottakere(behandlingId) } returns emptyList()
+        every { fagsakService.hentFagsak(any()) } returns fagsak
+        every { personService.hentIdenterMedStrengtFortroligAdressebeskyttelse(any(), any()) } returns listOf(
+            fagsak.bruker.ident
+        )
+        validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligPersonMedManuelleBrevmottakere(
+            behandlingId,
+            fagsak.id
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/familie/tilbake/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/config/PdlClientConfig.kt
@@ -48,6 +48,9 @@ class PdlClientConfig {
                 errors = listOf()
             )
         }
+        every { pdlClient.hentAdressebeskyttelseBolk(any(), any()) } answers {
+            emptyMap()
+        }
         return pdlClient
     }
 }


### PR DESCRIPTION
* Nytt PDL kall i PDLClient for å sjekke STRENGT_FORTROLIG / STRENGT_FORTROLIG_UTLAND adressebeskyttelse
* Lagt til validering i siste steg (FORESLÅ_VEDTAK) for at behandling med "strengt fortrolig person" (adressebeskyttelse: STRENGT_FORTROLIG eller STRENGT_FORTROLIG_UTLAND) ikke tillates å ha manuelle brevmottakere.
* ktlint