### PR TITLE
NAV-13885 - Lagt til utvidet validering for at det ikke er tillatt med manuelle brevmottakere når behandlingen inneholder fortrolig person

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/ValiderBrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/ValiderBrevmottakerService.kt
@@ -1,19 +1,19 @@
 package no.nav.familie.tilbake.behandling
 
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
-import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerService
+import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerRepository
 import no.nav.familie.tilbake.person.PersonService
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
 class ValiderBrevmottakerService(
-    private val manuellBrevmottakerService: ManuellBrevmottakerService,
+    private val manuellBrevmottakerRepository: ManuellBrevmottakerRepository,
     private val fagsakService: FagsakService,
     private val personService: PersonService
 ) {
     fun validerAtBehandlingIkkeInneholderStrengtFortroligPersonMedManuelleBrevmottakere(behandlingId: UUID, fagsakId: UUID) {
-        val manuelleBrevmottakere = manuellBrevmottakerService.hentBrevmottakere(behandlingId).takeIf { it.isNotEmpty() } ?: return
+        val manuelleBrevmottakere = manuellBrevmottakerRepository.findByBehandlingId(behandlingId).takeIf { it.isNotEmpty() } ?: return
         val fagsak = fagsakService.hentFagsak(fagsakId)
         val bruker = fagsak.bruker
         val fagsystem = fagsak.fagsystem
@@ -23,6 +23,22 @@ class ValiderBrevmottakerService(
         if (strengtFortroligePersonIdenter.isNotEmpty()) {
             val melding =
                 "Behandlingen (id: $behandlingId) inneholder person med strengt fortrolig adressebeskyttelse og kan ikke kombineres med manuelle brevmottakere (${manuelleBrevmottakere.size} stk)."
+            val frontendFeilmelding =
+                "Behandlingen inneholder person med strengt fortrolig adressebeskyttelse og kan ikke kombineres med manuelle brevmottakere."
+            throw Feil(melding, frontendFeilmelding)
+        }
+    }
+
+    fun validerAtBehandlingenIkkeInneholderStrengtFortroligPerson(behandlingId: UUID, fagsakId: UUID) {
+        val fagsak = fagsakService.hentFagsak(fagsakId)
+        val bruker = fagsak.bruker
+        val fagsystem = fagsak.fagsystem
+        val personIdenter = listOfNotNull(bruker.ident)
+        if (personIdenter.isEmpty()) return
+        val strengtFortroligePersonIdenter = personService.hentIdenterMedStrengtFortroligAdressebeskyttelse(personIdenter, fagsystem)
+        if (strengtFortroligePersonIdenter.isNotEmpty()) {
+            val melding =
+                "Behandlingen (id: $behandlingId) inneholder person med strengt fortrolig adressebeskyttelse og kan ikke kombineres med manuelle brevmottakere."
             val frontendFeilmelding =
                 "Behandlingen inneholder person med strengt fortrolig adressebeskyttelse og kan ikke kombineres med manuelle brevmottakere."
             throw Feil(melding, frontendFeilmelding)

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
@@ -22,6 +22,7 @@ import no.nav.familie.tilbake.api.dto.ManuellBrevmottakerRequestDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
 import no.nav.familie.tilbake.behandling.FagsakService
+import no.nav.familie.tilbake.behandling.ValiderBrevmottakerService
 import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Behandlingsstatus
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
@@ -71,6 +72,9 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var fagsakService: FagsakService
 
+    @Autowired
+    private lateinit var validerBrevmottakerService: ValiderBrevmottakerService
+
     private lateinit var behandling: Behandling
     private lateinit var manuellBrevmottakerService: ManuellBrevmottakerService
     private val opprettetTidspunktSlot = mutableListOf<LocalDateTime>()
@@ -103,7 +107,9 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
             behandlingskontrollService = behandlingskontrollService,
             fagsakService = fagsakService,
             pdlClient = mockPdlClient,
-            integrasjonerClient = mockIntegrasjonerClient
+            integrasjonerClient = mockIntegrasjonerClient,
+            validerBrevmottakerService = validerBrevmottakerService
+
         )
 
         every {


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13885

Lagt til validering for at det ikke er tillatt med manuelle brevmottakere når behandlingen inneholder fortrolig person (person med adressebeskyttelse STRENGT_FORTROLIG / STRENGT_FORTROLIG_UTLAND) i “leggTilBrevmottaker” og i “opprettBrevmottakerSteg”.
Visning av validerings-feilmelding i frontend er allerede merget i familie-tilbake-frontend i egne PR: 
https://github.com/navikt/familie-tilbake-frontend/pull/1460 og
https://github.com/navikt/familie-tilbake-frontend/pull/1464