### PR TITLE
Fjerner CPU-limit

### DIFF
--- a/.deploy/nais/app-dev-gcp.yaml
+++ b/.deploy/nais/app-dev-gcp.yaml
@@ -97,11 +97,9 @@ spec:
   replicas:
     min: 2
     max: 4
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 1024Mi
-      cpu: "1"
     requests:
       memory: 512Mi
       cpu: 500m

--- a/.deploy/nais/app-prod-gcp.yaml
+++ b/.deploy/nais/app-prod-gcp.yaml
@@ -95,11 +95,9 @@ spec:
   replicas:
     min: 2
     max: 4
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 1024Mi
-      cpu: "1"
     requests:
       memory: 512Mi
       cpu: 500m


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)