### PR TITLE
Automatisk håndtering av gamle kravgrunnlag som ikke finnes hos økonomi

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HentFagsystemsbehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HentFagsystemsbehandlingTask.kt
@@ -30,6 +30,7 @@ class HentFagsystemsbehandlingTask(
         logger.info("HentFagsystemsbehandlingTask prosesserer med id=${task.id} og metadata ${task.metadata}")
         val mottattXmlId = UUID.fromString(task.payload)
         val mottattXml = håndterGamleKravgrunnlagService.hentFrakobletKravgrunnlag(mottattXmlId)
+        task.metadata["eksternFagsakId"] = mottattXml.eksternFagsakId
 
         håndterGamleKravgrunnlagService.sjekkOmDetFinnesEnAktivBehandling(mottattXml)
         hentFagsystemsbehandlingService.sendHentFagsystemsbehandlingRequest(

--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/ØkonomiXmlMottattService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/ØkonomiXmlMottattService.kt
@@ -117,4 +117,11 @@ class ØkonomiXmlMottattService(
             )
         )
     }
+
+    fun hentArkiverteKravgrunnlag(
+        eksternFagsakId: String,
+        ytelsestype: Ytelsestype
+    ): List<ØkonomiXmlMottattArkiv> {
+        return mottattXmlArkivRepository.findByEksternFagsakIdAndYtelsestype(eksternFagsakId, ytelsestype)
+    }
 }


### PR DESCRIPTION
… pga. duplikat utsending som følge av feil.

Utvider HåndterGammelKravgrunnlagTask med logikk som sjekker om det er mottatt nytt, duplikat kravgrunnlag i etterkant, slik tilfellet er for minst to (og sannsynligvis de fleste) av taskene som har feilet pga. "Kravgrunnlag ikke funnet": https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-14260