### PR TITLE
Flytter try-catch blokka lagt til i HåndterGammelKravgrunnlagTask inn i håndter-funksjonen

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/common/exceptionhandler/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/common/exceptionhandler/Feil.kt
@@ -24,3 +24,5 @@ class UkjentravgrunnlagFeil(val melding: String) : RuntimeException(melding)
 class UgyldigStatusmeldingFeil(val melding: String) : RuntimeException(melding)
 
 class SperretKravgrunnlagFeil(val melding: String) : IntegrasjonException(melding)
+
+class KravgrunnlagIkkeFunnetFeil(val melding: String) : IntegrasjonException(melding)

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/økonomi/OppdragClient.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/økonomi/OppdragClient.kt
@@ -8,6 +8,7 @@ import no.nav.familie.kontrakter.felles.simulering.FeilutbetalingerFraSimulering
 import no.nav.familie.kontrakter.felles.simulering.FeilutbetaltPeriode
 import no.nav.familie.kontrakter.felles.simulering.HentFeilutbetalingerFraSimuleringRequest
 import no.nav.familie.tilbake.common.exceptionhandler.IntegrasjonException
+import no.nav.familie.tilbake.common.exceptionhandler.KravgrunnlagIkkeFunnetFeil
 import no.nav.familie.tilbake.common.exceptionhandler.SperretKravgrunnlagFeil
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagMapper
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
@@ -135,6 +136,9 @@ class DefaultOppdragClient(
                 "Kravgrunnlag kan ikke hentes fra økonomi for eksternKravgrunnlagId=$kravgrunnlagId. " +
                     "Feiler med ${exception.message}"
             )
+            if (exception.message?.contains("Kravgrunnlag ikke funnet") == true) {
+                throw KravgrunnlagIkkeFunnetFeil(exception.message!!)
+            }
             throw IntegrasjonException(
                 msg = "Noe gikk galt ved henting av kravgrunnlag for kravgrunnlagId=$kravgrunnlagId",
                 throwable = exception

--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HåndterGammelKravgrunnlagTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HåndterGammelKravgrunnlagTask.kt
@@ -4,7 +4,6 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.tilbake.behandling.HentFagsystemsbehandlingService
-import no.nav.familie.tilbake.common.exceptionhandler.IntegrasjonException
 import no.nav.familie.tilbake.common.exceptionhandler.UkjentravgrunnlagFeil
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -57,26 +56,7 @@ class HåndterGammelKravgrunnlagTask(
                     "Feiler med $feilMelding"
             )
         }
-        try {
-            håndterGamleKravgrunnlagService.håndter(hentFagsystemsbehandlingRespons.hentFagsystemsbehandling!!, mottattXml)
-        } catch (e: IntegrasjonException) {
-            if (e.cause?.message?.contains("Kravgrunnlag ikke funnet") == true &&
-                håndterGamleKravgrunnlagService.sjekkArkivForDuplikatKravgrunnlagMedKravstatusAvsluttet(
-                        kravgrunnlagIkkeFunnet = mottattXml
-                    )
-            ) {
-                task.metadata["merknad"] =
-                    "Arkivert da kravgrunnlag ikke ble funnet hos økonomi, " +
-                            "og duplikat kravgrunnlag med kravstatus AVSLUTTET funnet i arkivet"
-                logger.warn(
-                    "Arkiverer kravgrunnlag(id=$mottattXmlId, eksternFagsakId=$eksternFagsakId) som ikke ble funnet hos økonomi, " +
-                        "da identisk kravgrunnlag med påfølgende melding om at kravet er avsluttet ble funnet i arkivet"
-                )
-                håndterGamleKravgrunnlagService.arkiverKravgrunnlag(mottattXmlId)
-            } else {
-                throw e
-            }
-        }
+        håndterGamleKravgrunnlagService.håndter(hentFagsystemsbehandlingRespons.hentFagsystemsbehandling!!, mottattXml, task)
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/HåndterGammelKravgrunnlagTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/HåndterGammelKravgrunnlagTaskTest.kt
@@ -31,6 +31,7 @@ import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstilstand
 import no.nav.familie.tilbake.common.exceptionhandler.IntegrasjonException
+import no.nav.familie.tilbake.common.exceptionhandler.KravgrunnlagIkkeFunnetFeil
 import no.nav.familie.tilbake.common.exceptionhandler.SperretKravgrunnlagFeil
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.dokumentbestilling.felles.BrevsporingRepository
@@ -264,7 +265,7 @@ internal class HåndterGammelKravgrunnlagTaskTest : OppslagSpringRunnerTest() {
         )
 
         every { mockHentKravgrunnlagService.hentKravgrunnlagFraØkonomi(any(), any()) } throws
-            IntegrasjonException(msg = "Noe gikk galt", throwable = IntegrasjonException("Kravgrunnlag ikke funnet"))
+            KravgrunnlagIkkeFunnetFeil(melding = "Noe gikk galt")
 
         val task = lagTask()
         håndterGammelKravgrunnlagTask.doTask(task)


### PR DESCRIPTION
… som workaround for UnexpectedRollbackException etter det ble lagt til logikk for automatisk håndtering av gamle kravgrunnlag ikke funnet hos økonomi. Hører nok mer naturlig hjemme der uansett..