### PR TITLE
Mindre streng "harKravstatusAvsluttet"-sjekk i HåndterGamleKravgrunnlagService  

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HåndterGamleKravgrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HåndterGamleKravgrunnlagService.kt
@@ -264,7 +264,6 @@ private fun ØkonomiXmlMottattArkiv.harKravstatusAvsluttet(statusmeldingerMottat
     return statusmeldingerMottatt.any {
         KravgrunnlagUtil.unmarshalStatusmelding(it.melding).let { statusmelding ->
             statusmelding.vedtakId == kravgrunnlagDto.vedtakId &&
-                statusmelding.referanse == kravgrunnlagDto.referanse &&
                 statusmelding.kodeStatusKrav == Kravstatuskode.AVSLUTTET.kode
         }
     }


### PR DESCRIPTION
Trenger ikke kreve at statusmelding og kravgrunnlag skal ha lik referanse i 'harKravstatusAvsluttet', siden det er strengere enn da kravgrunnlaget ble arkivert på bakgrunn av den samme statusmeldingen til å begynne med.