### PR TITLE
Swagger spring 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <!--suppress UnresolvedMavenProperty Ligger som secret i github-->
         <sonar.login>${SONAR_LOGIN}</sonar.login>
         <spring.cloud-contract>4.0.3</spring.cloud-contract>
+        <springdoc.version>2.2.0</springdoc.version>
         <testcontainers.version>1.18.3</testcontainers.version>
         <tjenestespesifikasjoner.version>2612.db4dc68</tjenestespesifikasjoner.version>
         <familie-tjenestespesifikasjoner.version>1.0_20230718100517_1e1beb0</familie-tjenestespesifikasjoner.version>
@@ -295,8 +296,13 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.7.0</version>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-common</artifactId>
+            <version>${springdoc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.getunleash</groupId>


### PR DESCRIPTION
Swagger virker ikke etter oppgradering til Spring 3. Det må brukes andre avhengigheter av springdoc for å være kompatibel med Spring 3.

Testet i preprod og ser ut til å virke: https://familie-tilbake.intern.dev.nav.no/swagger-ui/index.html
