### PR TITLE
Vi endrer på teksten som dukker opp i vedtaksbrevet ved forsett + mangellfull opplysning og forsett + feil opplysning

### DIFF
--- a/src/main/resources/templates/nb/vedtak/periode_vilkår.hbs
+++ b/src/main/resources/templates/nb/vedtak/periode_vilkår.hbs
@@ -1,5 +1,20 @@
 {{~#* inline "pronomen"~}}{{#if gjelderDødsfall}}dere{{else}}du{{/if}}{{~/inline~}}
 {{~#* inline "Pronomen"~}}{{#if gjelderDødsfall}}Dere{{else}}Du{{/if}}{{~/inline~}}
+{{~#* inline "forsettTekst"~}}
+    {{#switch vurderinger.vilkårsvurderingsresultat}}
+        {{#case "FORSTO_BURDE_FORSTÅTT"}}
+Selv hvis du har meldt fra til oss, kan vi kreve tilbake det du har fått for mye hvis du forsto at beløpet var feil. At du må betale tilbake, betyr ikke at du selv har skyld i feilutbetalingen.
+
+Ut fra informasjonen du har fått, legger vi til grunn at du forsto at du fikk utbetalt for mye. Derfor kan vi kreve tilbake.
+        {{/case}}
+        {{#case "FEIL_OPPLYSNINGER_FRA_BRUKER"}}
+Etter vår vurdering forsto du at opplysningene du ga oss var uriktige. Derfor kan vi kreve pengene tilbake.
+        {{/case}}
+        {{#case "MANGELFULLE_OPPLYSNINGER_FRA_BRUKER"}}
+Etter vår vurdering forsto du at du ikke ga oss alle opplysningene vi trengte tidsnok for å sikre at du fikk riktig utbetaling. Derfor kan vi kreve pengene tilbake.
+        {{/case}}
+    {{/switch}}
+{{~/inline~}}
 {{#* inline "fritekst"}}
 {{#if vurderinger.fritekst}}
 
@@ -90,19 +105,7 @@ Vi har ikke gitt deg den informasjonen du trengte for å forstå at beløpet du 
 {{> fritekst}}
     {{/if}}
     {{#if (eq vurderinger.aktsomhetsresultat "FORSETT")}}
-Du har fått vite om du har rett til {{{ytelsesnavnUbestemt}}} og hvor mye du har rett til. Selv hvis du har meldt fra til oss, kan vi kreve tilbake det du har fått for mye hvis du forsto at beløpet var feil. At du må betale tilbake, betyr ikke at du selv har skyld i feilutbetalingen.
+Du har fått vite om du har rett til {{{ytelsesnavnUbestemt}}} og hvor mye du har rett til. {{> forsettTekst ~}}
 {{>fritekst}}
-
-        {{#switch vurderinger.vilkårsvurderingsresultat}}
-        {{#case "FORSTO_BURDE_FORSTÅTT"}}
-Ut fra informasjonen du har fått, legger vi til grunn at du forsto at du fikk utbetalt for mye. Derfor kan vi kreve tilbake.
-        {{/case}}
-        {{#case "FEIL_OPPLYSNINGER_FRA_BRUKER"}}
-Etter vår vurdering forsto du at du ga oss uriktige opplysninger. Derfor må du betale tilbake det du har fått for mye.
-        {{/case}}
-        {{#case "MANGELFULLE_OPPLYSNINGER_FRA_BRUKER"}}
-Vi vurderer at du forsto at du ikke ga oss alle nødvendige opplysninger i saken din. Du må derfor betale tilbake det du har fått for mye.
-        {{/case}}
-        {{/switch}}
     {{/if}}
 {{/if}}

--- a/src/test/resources/vedtaksbrev/OS_fritekst_overalt.txt
+++ b/src/test/resources/vedtaksbrev/OS_fritekst_overalt.txt
@@ -38,11 +38,9 @@ Her burde du passet mer på!
 _Perioden fra og med 1. april 2019 til og med 30. april 2019
 Du har fått overgangsstønad for barn som ikke bor fast hos deg. Du har derfor fått 1 krone for mye utbetalt i denne perioden.
 __Hvordan har vi kommet fram til at du må betale tilbake?
-Du har fått vite om du har rett til overgangsstønad og hvor mye du har rett til. Selv hvis du har meldt fra til oss, kan vi kreve tilbake det du har fått for mye hvis du forsto at beløpet var feil. At du må betale tilbake, betyr ikke at du selv har skyld i feilutbetalingen.
+Du har fått vite om du har rett til overgangsstønad og hvor mye du har rett til. Etter vår vurdering forsto du at du ikke ga oss alle opplysningene vi trengte tidsnok for å sikre at du fikk riktig utbetaling. Derfor kan vi kreve pengene tilbake.
 
 Dette gjorde du med vilje!
-
-Vi vurderer at du forsto at du ikke ga oss alle nødvendige opplysninger i saken din. Du må derfor betale tilbake det du har fått for mye.
 _Lovhjemmelen vi har brukt
 Vedtaket er gjort etter Folketrygdloven § 22-15.
 _Skatt og skatteoppgjør


### PR DESCRIPTION
Favro:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15850

Vi ønsker å justere litt av teksten som dukker opp i vedtaksbrevet når kombinasjonen er forsett + mangelfullopplsning og forsett + feil opplysning.

Forsett + mangelopplysning
![mangel](https://github.com/navikt/familie-tilbake/assets/110383605/1677e1e5-d89d-487a-97db-4b5ee001033b)

Forsett + feilopplysning
![feil opplys](https://github.com/navikt/familie-tilbake/assets/110383605/6bd2fdc0-9e9a-4b7f-914f-e5f3af5751d7)
