### PR TITLE
Rettelse i Unleash config

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
@@ -2,11 +2,16 @@ package no.nav.familie.tilbake.config
 
 import io.getunleash.strategy.Strategy
 import no.nav.familie.unleash.UnleashService
+import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.awt.PageAttributes
 
 @Configuration
 class FeatureToggleConfig(@Value("\${NAIS_CLUSTER_NAME}") private val clusterName: String) {
@@ -40,6 +45,27 @@ class FeatureToggleService(val unleashService: UnleashService) {
 
     fun isEnabled(toggleId: String, defaultValue: Boolean): Boolean {
         return unleashService.isEnabled(toggleId, defaultValue)
+    }
+}
+
+/**
+ * TODO : Fjern etter testing er utført.
+ */
+@RestController
+@RequestMapping(path = ["/api/featuretoggle"])
+@Unprotected
+class FeatureToggleController(private val featureToggleService: FeatureToggleService) {
+
+    private val funksjonsbrytere: Set<String> = setOf(
+        FeatureToggleConfig.BRUK_6_DESIMALER_I_SKATTEBEREGNING,
+        FeatureToggleConfig.KAN_OPPRETTE_BEH_MED_EKSTERNID_SOM_HAR_AVSLUTTET_TBK,
+        FeatureToggleConfig.OVERSTYR_DELVILS_TILBAKEKREVING_TIL_FULL_TILBAKEKREVING,
+        FeatureToggleConfig.IKKE_VALIDER_SÆRLIG_GRUNNET_ANNET_FRITEKST,
+    )
+
+    @GetMapping
+    fun sjekkAlle(): Map<String, Boolean> {
+        return funksjonsbrytere.associate { it to featureToggleService.isEnabled(it) }
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
@@ -48,27 +48,6 @@ class FeatureToggleService(val unleashService: UnleashService) {
     }
 }
 
-/**
- * TODO : Fjern etter testing er utført.
- */
-@RestController
-@RequestMapping(path = ["/api/featuretoggle"])
-@Unprotected
-class FeatureToggleController(private val featureToggleService: FeatureToggleService) {
-
-    private val funksjonsbrytere: Set<String> = setOf(
-        FeatureToggleConfig.BRUK_6_DESIMALER_I_SKATTEBEREGNING,
-        FeatureToggleConfig.KAN_OPPRETTE_BEH_MED_EKSTERNID_SOM_HAR_AVSLUTTET_TBK,
-        FeatureToggleConfig.OVERSTYR_DELVILS_TILBAKEKREVING_TIL_FULL_TILBAKEKREVING,
-        FeatureToggleConfig.IKKE_VALIDER_SÆRLIG_GRUNNET_ANNET_FRITEKST,
-    )
-
-    @GetMapping
-    fun sjekkAlle(): Map<String, Boolean> {
-        return funksjonsbrytere.associate { it to featureToggleService.isEnabled(it) }
-    }
-}
-
 class ByClusterStrategy(private val clusterName: String) : Strategy {
 
     override fun isEnabled(parameters: MutableMap<String, String>): Boolean {

--- a/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.tilbake.config
 
 import io.getunleash.strategy.Strategy
-import no.nav.familie.unleash.DefaultUnleashService
+import no.nav.familie.unleash.UnleashService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -9,22 +9,11 @@ import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 
 @Configuration
-class FeatureToggleConfig(
-    @Value("\${UNLEASH_SERVER_API_URL}") private val apiUrl: String,
-    @Value("\${UNLEASH_SERVER_API_TOKEN}") private val apiToken: String,
-    @Value("\${NAIS_APP_NAME}") private val appName: String,
-    @Value("\${NAIS_CLUSTER_NAME}") private val clusterName: String,
-
-) {
+class FeatureToggleConfig(@Value("\${NAIS_CLUSTER_NAME}") private val clusterName: String) {
 
     @Bean
     fun strategies(): List<Strategy> {
         return listOf(ByClusterStrategy(clusterName))
-    }
-
-    @Bean
-    fun defaultUnleashService(strategies: List<Strategy>): DefaultUnleashService {
-        return DefaultUnleashService(apiUrl, apiToken, appName, strategies)
     }
 
     companion object {
@@ -43,14 +32,14 @@ class FeatureToggleConfig(
 
 @Service
 @Profile("!integrasjonstest")
-class FeatureToggleService(val defaultUnleashService: DefaultUnleashService) {
+class FeatureToggleService(val unleashService: UnleashService) {
 
     fun isEnabled(toggleId: String): Boolean {
-        return defaultUnleashService.isEnabled(toggleId, false)
+        return unleashService.isEnabled(toggleId, false)
     }
 
     fun isEnabled(toggleId: String, defaultValue: Boolean): Boolean {
-        return defaultUnleashService.isEnabled(toggleId, defaultValue)
+        return unleashService.isEnabled(toggleId, defaultValue)
     }
 }
 


### PR DESCRIPTION
Hvorfor ?

DefaultUnleashService skal ikke bønnes opp i FeatureToggleConfig, siden dette gjøres nå i felles. Denne må derfor fjernes.

Testet ok i dev.