### PR TITLE
Nedgraderer kotest da versjon 5.7.2 gjør oppstart av tester treg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <common-java-modules.version>2.2021.09.17_07.09-67428a6422cc</common-java-modules.version>
         <kontrakter.version>3.0_20231006095938_4f85a1d</kontrakter.version>
         <felles.version>2.20230928165350_3e5b5e9</felles.version>
-        <kotest.version>5.7.2</kotest.version>
+        <kotest.version>5.6.2</kotest.version>
         <token-validation-spring.version>3.1.5</token-validation-spring.version>
         <okhttp3.version>4.9.1</okhttp3.version><!-- Inntil videre nødvendig for token-validation-spring-test-->
         <com.openhtmltopdf.version>1.0.10</com.openhtmltopdf.version>

--- a/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
@@ -2,16 +2,11 @@ package no.nav.familie.tilbake.config
 
 import io.getunleash.strategy.Strategy
 import no.nav.familie.unleash.UnleashService
-import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
-import java.awt.PageAttributes
 
 @Configuration
 class FeatureToggleConfig(@Value("\${NAIS_CLUSTER_NAME}") private val clusterName: String) {

--- a/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
@@ -269,18 +269,18 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
         assertBehandlingssteg(
             behandlingsstegstilstand,
             Behandlingssteg.VILKÅRSVURDERING,
-            Behandlingsstegstatus.TILBAKEFØRT
+            Behandlingsstegstatus.TILBAKEFØRT,
         )
         assertBehandlingssteg(
             behandlingsstegstilstand,
             Behandlingssteg.FORESLÅ_VEDTAK,
-            Behandlingsstegstatus.TILBAKEFØRT
+            Behandlingsstegstatus.TILBAKEFØRT,
         )
         assertBehandlingssteg(behandlingsstegstilstand, Behandlingssteg.FATTE_VEDTAK, Behandlingsstegstatus.TILBAKEFØRT)
         assertBehandlingssteg(
             behandlingsstegstilstand,
             Behandlingssteg.IVERKSETT_VEDTAK,
-            Behandlingsstegstatus.TILBAKEFØRT
+            Behandlingsstegstatus.TILBAKEFØRT,
         )
 
         faktaFeilutbetalingRepository.findByBehandlingIdAndAktivIsTrue(behandling.id).shouldBeNull()


### PR DESCRIPTION
Forbedrer byggetid drastisk.

Det er tydelig at dette har skjedd med flere: https://github.com/kotest/kotest/issues/3126

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15978)