### PR TITLE
kotest 5.7.x har autoscan av classpath, som skaper trøbbel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <common-java-modules.version>2.2021.09.17_07.09-67428a6422cc</common-java-modules.version>
         <kontrakter.version>3.0_20231006095938_4f85a1d</kontrakter.version>
         <felles.version>2.20230928165350_3e5b5e9</felles.version>
+        <!-- kotest.properties kan antakelig fjernes i versjon 6, for autoscan blir default false -->
         <kotest.version>5.7.2</kotest.version>
         <token-validation-spring.version>3.1.5</token-validation-spring.version>
         <okhttp3.version>4.9.1</okhttp3.version><!-- Inntil videre nødvendig for token-validation-spring-test-->

--- a/src/test/resources/kotest.properties
+++ b/src/test/resources/kotest.properties
@@ -1,4 +1,4 @@
-# Noe skjedde i 5.7.0, kommer bli disabled by defailt i 6.0
+# Noe skjedde i 5.7.0, kommer bli disabled by default i 6.0
 # https://github.com/kotest/kotest/issues/3126#issuecomment-1517219616
 kotest.framework.classpath.scanning.autoscan.disable=true
 kotest.framework.classpath.scanning.config.disable=true

--- a/src/test/resources/kotest.properties
+++ b/src/test/resources/kotest.properties
@@ -1,0 +1,4 @@
+# Noe skjedde i 5.7.0, kommer bli disabled by defailt i 6.0
+# https://github.com/kotest/kotest/issues/3126#issuecomment-1517219616
+kotest.framework.classpath.scanning.autoscan.disable=true
+kotest.framework.classpath.scanning.config.disable=true


### PR DESCRIPTION
Byggene etter https://github.com/navikt/familie-tilbake/commit/fc95e191512aa6302d888b6c9f95793c95961102 tar veldig lang tid
https://kotlinlang.slack.com/archives/CT0G9SD7Z/p1694159552294569?thread_ts=1694104017.743329&cid=CT0G9SD7Z
```
See this link: https://kotest.io/docs/intellij/intellij-properties.html
Try adding a separate runtime properties file at /resources/kotest.properties. The resources dir should be a sibling of your kotlin dir.
Content:
kotest.framework.classpath.scanning.autoscan.disable=true
kotest.framework.classpath.scanning.config.disable=true
kotest.framework.config.fqn=com.example.ProjectConfig
```

https://kotest.io/docs/intellij/intellij-properties.html#common-use-case