### PR TITLE
Spike finn gamle benandlinger uten oppgave

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingRepository.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.tilbake.behandling
 
+import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.common.repository.InsertUpdateRepository
@@ -8,6 +9,7 @@ import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
@@ -60,6 +62,17 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         eksternFagsakId: String,
         eksternBrukId: UUID,
     ): Behandling?
+
+    @Query(
+        """
+            SELECT b.id
+            FROM behandling b JOIN fagsak f ON b.fagsak_id = f.id
+            WHERE b.status != 'AVSLUTTET'
+            AND b.endret_tid < :ikkeEndretEtterDato
+            AND f.fagsystem = :fagsystem
+        """,
+    )
+    fun finnÅpneBehandlingerIkkeEndretEtter(fagsystem: Fagsystem, ikkeEndretEtterDato: LocalDateTime = LocalDateTime.now().minusMonths(4)): List<UUID>?
 
     fun findByEksternBrukId(eksternBrukId: UUID): Behandling
 

--- a/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
@@ -2,16 +2,11 @@ package no.nav.familie.tilbake.config
 
 import io.getunleash.strategy.Strategy
 import no.nav.familie.unleash.UnleashService
-import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
-import java.awt.PageAttributes
 
 @Configuration
 class FeatureToggleConfig(@Value("\${NAIS_CLUSTER_NAME}") private val clusterName: String) {

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveManglerLoggerService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveManglerLoggerService.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.tilbake.oppgave
+
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.leader.LeaderClient
+import no.nav.familie.tilbake.behandling.BehandlingRepository
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class OppgaveManglerLoggerService(
+    private val oppgaveService: OppgaveService,
+    private val behandlingRepository: BehandlingRepository,
+) {
+
+    @Scheduled(initialDelay = MINUTT, fixedDelay = DØGN)
+    fun loggGamleÅpneBehandlingerUtenOppgave() {
+        if (LeaderClient.erLeder()) {
+            val gamleBehandlinger: List<UUID> =
+                behandlingRepository.finnÅpneBehandlingerIkkeEndretEtter(fagsystem = Fagsystem.EF) ?: emptyList()
+            gamleBehandlinger.forEach {
+                try {
+                    oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(it)
+                } catch (e: Exception) {
+                    // lag oppgave ;D
+                }
+            }
+        }
+    }
+    fun LeaderClient.erLeder() = isLeader() ?: false
+
+    companion object {
+        const val DØGN = 24 * 60 * 60 * 1000L
+        const val MINUTT = 60 * 1000L
+    }
+}

--- a/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
@@ -269,18 +269,18 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
         assertBehandlingssteg(
             behandlingsstegstilstand,
             Behandlingssteg.VILKÅRSVURDERING,
-            Behandlingsstegstatus.TILBAKEFØRT
+            Behandlingsstegstatus.TILBAKEFØRT,
         )
         assertBehandlingssteg(
             behandlingsstegstilstand,
             Behandlingssteg.FORESLÅ_VEDTAK,
-            Behandlingsstegstatus.TILBAKEFØRT
+            Behandlingsstegstatus.TILBAKEFØRT,
         )
         assertBehandlingssteg(behandlingsstegstilstand, Behandlingssteg.FATTE_VEDTAK, Behandlingsstegstatus.TILBAKEFØRT)
         assertBehandlingssteg(
             behandlingsstegstilstand,
             Behandlingssteg.IVERKSETT_VEDTAK,
-            Behandlingsstegstatus.TILBAKEFØRT
+            Behandlingsstegstatus.TILBAKEFØRT,
         )
 
         faktaFeilutbetalingRepository.findByBehandlingIdAndAktivIsTrue(behandling.id).shouldBeNull()


### PR DESCRIPTION
Vil gjøre en liten spike på EF for å se om det er mange gamle, åpne behandlinger som mangler oppgaver. Denne vil kun sjekke EF da det er relativt få gamle behandlinger. Dette er ikke ment å være kode som skal leve, kun brukes for å sjekke en gang, eller to. 

Denne koden skal slettes, eller forbedres i løpet av uka. 