### PR TITLE
Hent og sett client id og secret automatisk

### DIFF
--- a/src/test/kotlin/no/nav/familie/tilbake/LauncherLocal.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/LauncherLocal.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.tilbake
 
 import no.nav.familie.tilbake.config.ApplicationConfig
+import no.nav.familie.tilbake.config.TestLauncherConfig
 import no.nav.familie.tilbake.database.DbContainerInitializer
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
@@ -15,6 +16,8 @@ fun main(args: Array<String>) {
         "spring.profiles.active",
         "local, mock-pdl, mock-oauth, mock-oppgave, mock-integrasjoner, mock-økonomi",
     )
+
+    TestLauncherConfig().settClientIdOgSecretForLokalKjøring()
 
     SpringApplicationBuilder(ApplicationConfig::class.java)
         .initializers(DbContainerInitializer())

--- a/src/test/kotlin/no/nav/familie/tilbake/LauncherLocalPostgres.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/LauncherLocalPostgres.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.tilbake
 
+import no.nav.familie.tilbake.config.TestLauncherConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
@@ -20,6 +21,8 @@ fun main(args: Array<String>) {
         "spring.profiles.active",
         "local, mock-pdl, mock-oauth, mock-oppgave, mock-integrasjoner, mock-økonomi",
     )
+
+    TestLauncherConfig().settClientIdOgSecretForLokalKjøring()
 
     SpringApplicationBuilder(LauncherLocalPostgres::class.java)
         .profiles("local", "mock-pdl", "mock-oauth", "mock-oppgave", "mock-integrasjoner", "mock-økonomi")

--- a/src/test/kotlin/no/nav/familie/tilbake/config/TestLauncherConfig.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/config/TestLauncherConfig.kt
@@ -1,0 +1,34 @@
+package no.nav.familie.tilbake.config
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+class TestLauncherConfig {
+    fun settClientIdOgSecretForLokalKjøring() {
+        val cmd = "src/test/resources/hentMiljøvariabler-lokal.sh"
+
+        hentOgSettMiljøVariabler(cmd)
+    }
+
+    fun settClientIdOgSecretForLokalKjøringMotPreprod() {
+        val cmd = "src/test/resources/hentMiljøvariabler-preprod.sh"
+
+        hentOgSettMiljøVariabler(cmd)
+    }
+
+    private fun hentOgSettMiljøVariabler(cmd: String) {
+        val process = ProcessBuilder(cmd).start()
+
+        if (process.waitFor() == 1) {
+            error("Klarte ikke hente variabler fra Nais. Er du logget på Naisdevice og gcloud?")
+        }
+
+        val inputStream = BufferedReader(InputStreamReader(process.inputStream))
+        inputStream.readLine() // "Switched to context dev-gcp"
+        val split = inputStream.readLine().split(";")
+        split
+            .map { it.split("=") }
+            .map { System.setProperty(it[0], it[1]) }
+        inputStream.close()
+    }
+}

--- a/src/test/resources/hentMiljøvariabler-lokal.sh
+++ b/src/test/resources/hentMiljøvariabler-lokal.sh
@@ -1,0 +1,12 @@
+kubectl config use-context dev-gcp
+TILBAKE_LOKAL_SECRETS=$(kubectl -n teamfamilie get secret azuread-familie-tilbake-lokal -o json | jq '.data | map_values(@base64d)');
+
+AZURE_APP_CLIENT_ID=$(echo "$TILBAKE_LOKAL_SECRETS" | jq -r '.AZURE_APP_CLIENT_ID')
+AZURE_APP_CLIENT_SECRET=$(echo "$TILBAKE_LOKAL_SECRETS" | jq -r '.AZURE_APP_CLIENT_SECRET')
+
+if [ -z "$AZURE_APP_CLIENT_ID" ]
+then
+      return 1
+else
+      printf "%s;%s" "AZURE_APP_CLIENT_ID=$AZURE_APP_CLIENT_ID" "AZURE_APP_CLIENT_SECRET=$AZURE_APP_CLIENT_SECRET"
+fi

--- a/src/test/resources/hentMiljøvariabler-preprod.sh
+++ b/src/test/resources/hentMiljøvariabler-preprod.sh
@@ -1,0 +1,18 @@
+kubectl config use-context dev-gcp
+PODNAVN=$(kubectl -n teamfamilie get pods --field-selector=status.phase==Running -o name | grep familie-tilbake | grep -v "frontend" |  sed "s/^.\{4\}//" | head -n 1);
+
+PODVARIABLER="$(kubectl -n teamfamilie exec -c familie-tilbake -it "$PODNAVN" -- env)"
+UNLEASH_VARIABLER="$(kubectl -n teamfamilie get secret familie-tilbake-unleash-api-token -o json | jq '.data | map_values(@base64d)')"
+
+AZURE_APP_CLIENT_ID="$(echo "$PODVARIABLER" | grep "AZURE_APP_CLIENT_ID" | tr -d '\r' )"
+AZURE_APP_CLIENT_SECRET="$(echo "$PODVARIABLER" | grep "AZURE_APP_CLIENT_SECRET" | tr -d '\r' )";
+
+UNLEASH_SERVER_API_URL="$(echo "$UNLEASH_VARIABLER" | grep "UNLEASH_SERVER_API_URL" | sed 's/:/=/1' | tr -d ' "')"
+UNLEASH_SERVER_API_TOKEN="$(echo "$UNLEASH_VARIABLER" | grep "UNLEASH_SERVER_API_TOKEN" | sed 's/:/=/1' | tr -d ' ,"')"
+
+if [ -z "$AZURE_APP_CLIENT_ID" ]
+then
+      return 1
+else
+      printf "%s;%s;%s;%s" "$AZURE_APP_CLIENT_ID" "$AZURE_APP_CLIENT_SECRET" "$UNLEASH_SERVER_API_URL" "$UNLEASH_SERVER_API_TOKEN"
+fi


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16843

På samme måte som i BA-sak så ønsker vi å automatisk hente og sette clientId/clientSecret når vi kjører tjenesten lokalt.
Merk at kommandoene for lokal-secrets er litt annerledes, fordi der henter vi secrets fra en kubernetes secrets og ikke fra pod variabel som når vi går mot preprod.