### PR TITLE
Finn oppgave selv om saksbehandler har byttet behandlingstype

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
@@ -203,7 +203,6 @@ class OppgaveService(
         fagsak: Fagsak,
     ): Pair<FinnOppgaveRequest, FinnOppgaveResponseDto> {
         val finnOppgaveRequest = FinnOppgaveRequest(
-            behandlingstype = Behandlingstype.Tilbakekreving,
             saksreferanse = behandling.eksternBrukId.toString(),
             oppgavetype = oppgavetype,
             tema = fagsak.ytelsestype.tilTema(),


### PR DESCRIPTION
Samme som: https://github.com/navikt/familie-tilbake/pull/1246

Oppgaver blir ikke ferdigstilt hvis saksbehandler har byttet behandlingstype i gosys, fordi den ikke finner oppgaver på Tilbakekreving når den er flyttet til EØS.