### PR TITLE
Justerer ned log level til warn ved gjenoppretting av oppgave i OppdaterOppgaveTask

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterOppgaveTask.kt
@@ -44,7 +44,7 @@ class OppdaterOppgaveTask(
             try {
                 oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandlingId)
             } catch (e: ManglerOppgaveFeil) {
-                log.error("Fant ingen oppgave å oppdatere på behandling $behandlingId. Vil forsøke å opprette en ny isteden")
+                log.warn("Fant ingen oppgave å oppdatere på behandling $behandlingId. Vil forsøke å opprette en ny isteden")
                 null
             }
 


### PR DESCRIPTION
Kan sikkert justere ned log level til warn, sånn at det ikke skal komme alarm hver gang oppgave gjenopprettes, nå som forventet oppførsel er verifisert i prod