### PR TITLE
Fikser at FinnÅpneBehandlingerUtenOppgave kjøres med token som har lov til å lese oppgave.

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/FinnGammelBehandlingUtenOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/FinnGammelBehandlingUtenOppgaveTask.kt
@@ -1,0 +1,68 @@
+package no.nav.familie.tilbake.oppgave
+
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.tilbake.behandling.BehandlingRepository
+import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.common.repository.findByIdOrThrow
+import no.nav.familie.tilbake.integration.familie.IntegrasjonerClient
+import no.nav.familie.tilbake.integration.pdl.internal.secureLogger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = FinnGammelBehandlingUtenOppgaveTask.TYPE,
+    maxAntallFeil = 2,
+    beskrivelse = "Finn gammel behandling som mangler oppgave",
+    triggerTidVedFeilISekunder = 300L,
+)
+class FinnGammelBehandlingUtenOppgaveTask(
+    private val integrasjonerClient: IntegrasjonerClient,
+    private val behandlingRepository: BehandlingRepository,
+    private val fagsakRepository: FagsakRepository,
+) : AsyncTaskStep {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun doTask(task: Task) {
+        val dto =
+            objectMapper.readValue(task.payload, FinnGammelBehandlingUtenOppgaveDto::class.java)
+
+        val gamleBehandlinger: List<UUID> =
+            behandlingRepository.finnÅpneBehandlingerOpprettetFør(
+                fagsystem = dto.fagsystem,
+                opprettetFørDato = LocalDateTime.now().minusMonths(2),
+            ) ?: emptyList()
+
+        secureLogger.info("Fant ${gamleBehandlinger.size} gamle åpne behandlinger. Prøver å finne ut om noen mangler oppgave.")
+
+        gamleBehandlinger.forEach {
+            val behandling = behandlingRepository.findByIdOrThrow(it)
+            val fagsak = fagsakRepository.findByIdOrThrow(behandling.fagsakId)
+
+            val finnOppgaveRequest =
+                FinnOppgaveRequest(
+                    saksreferanse = behandling.eksternBrukId.toString(),
+                    tema = fagsak.ytelsestype.tilTema(),
+                )
+            val finnOppgaveResponse = integrasjonerClient.finnOppgaver(finnOppgaveRequest)
+            if (finnOppgaveResponse.antallTreffTotalt == 0L) {
+                secureLogger.info("Ingen oppgave for behandlingId: ${behandling.id} fagsakId: ${fagsak.id}. Oppretter ny oppgave.")
+            }
+        }
+    }
+
+    data class FinnGammelBehandlingUtenOppgaveDto(
+        val fagsystem: Fagsystem,
+    )
+
+    companion object {
+        const val TYPE = "finnGammelBehandlingUtenOppgave"
+    }
+}

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveTaskService.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.tilbake.oppgave
 
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
@@ -183,6 +185,18 @@ class OppgaveTaskService(
                 type = OppdaterPrioritetTask.TYPE,
                 payload = behandlingId.toString(),
                 properties = properties,
+            ),
+        )
+    }
+
+    @Transactional
+    fun opprettFinnGammelBehandlingUtenOppgaveTask(
+        fagsystem: Fagsystem,
+    ) {
+        taskService.save(
+            Task(
+                type = FinnGammelBehandlingUtenOppgaveTask.TYPE,
+                payload = objectMapper.writeValueAsString(FinnGammelBehandlingUtenOppgaveTask.FinnGammelBehandlingUtenOppgaveDto(fagsystem)),
             ),
         )
     }


### PR DESCRIPTION
Flytter kode i forvaltning for å finne behandlinger uten oppgave til en task, slik at man kjører med token som har lov til å lese oppgave. Siden at token man får når man logger inn i swagger ikke har tilgang til oppgaven og lager støy eksternt hos #team-intern-samhand. Ved å flytte det til en task, så vil tasken kjørt med client_credentials.