### PR TITLE
sjekk om mottatt kravgrunnlag allerede er blitt arkivert dersom det ikke ligger i db

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/ØkonomiXmlMottattService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/ØkonomiXmlMottattService.kt
@@ -71,11 +71,14 @@ class ØkonomiXmlMottattService(
                 .findByEksternFagsakIdAndYtelsestypeAndVedtakId(eksternFagsakId, ytelsestype, vedtakId)
         val kravgrunnlagXmlListe = mottattXmlListe.filter { it.melding.contains(Constants.KRAVGRUNNLAG_XML_ROOT_ELEMENT) }
         if (kravgrunnlagXmlListe.isEmpty()) {
-            throw Feil(
-                message =
-                    "Det finnes intet kravgrunnlag for fagsystemId=$eksternFagsakId og " +
-                        "ytelsestype=$ytelsestype",
-            )
+            val arkivertMottattXmlListe = mottattXmlArkivRepository.findByEksternFagsakIdAndYtelsestype(eksternFagsakId, ytelsestype)
+            if (arkivertMottattXmlListe.isNotEmpty()) {
+                return emptyList()
+            } else {
+                throw Feil(
+                    message = "Det finnes ikke noe kravgrunnlag for fagsystemId=$eksternFagsakId og ytelsestype=$ytelsestype"
+                )
+            }
         }
         return kravgrunnlagXmlListe
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/BehandleStatusmeldingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/BehandleStatusmeldingTaskTest.kt
@@ -86,7 +86,7 @@ internal class BehandleStatusmeldingTaskTest : OppslagSpringRunnerTest() {
         val task = opprettTask(statusmeldingXml, BehandleStatusmeldingTask.TYPE)
 
         val exception = shouldThrow<Feil> { behandleStatusmeldingTask.doTask(task) }
-        exception.message shouldBe "Det finnes intet kravgrunnlag for fagsystemId=${fagsak.eksternFagsakId} " +
+        exception.message shouldBe "Det finnes ikke noe kravgrunnlag for fagsystemId=${fagsak.eksternFagsakId} " +
             "og ytelsestype=${fagsak.ytelsestype}"
     }
 


### PR DESCRIPTION
Får inn mange feilmelding på behandleStatusmelding fordi vi ikke finner mottat Kravgrunnlag i okonomi_xml_mottatt. Dette skjer fordi vi typisk har plukket to kravgrunnlag i en task og arkivert begge siden den første har kravstatusskode = avsluttet. 

I disse tilfellene går vi utifra at det er riktig at kravgrunnlagene skal være arkivert og at vi derfor ikke vil kaste en feil. Går derfor videre med emptyList()