### PR TITLE
Fikser sporadisk feilende test

### DIFF
--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevServiceTest.kt
@@ -553,6 +553,9 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
             )
         lokalBehandling = behandlingRepository.insert(lokalBehandling)
 
+        // Er nødt til å opprette kravgrunnlag for revurderingen
+        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431.copy(id = UUID.randomUUID(), behandlingId = lokalBehandling.id, perioder = emptySet()))
+
         lagFakta(lokalBehandling.id)
         lagVilkårsvurdering(lokalBehandling.id)
 

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevServiceTest.kt
@@ -147,7 +147,7 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
             )
 
         fagsak = fagsakRepository.insert(Testdata.fagsak)
-        behandling = behandlingRepository.insert(Testdata.behandling)
+        behandling = behandlingRepository.insert(Testdata.behandling.copy(avsluttetDato = LocalDate.now()))
         val kravgrunnlagsperiode432 = Testdata.kravgrunnlag431.perioder.first().copy(periode = Månedsperiode(YearMonth.of(2023, 3), YearMonth.of(2023, 4)))
         kravgrunnlagRepository.insert(Testdata.kravgrunnlag431.copy(perioder = setOf(kravgrunnlagsperiode432)))
         vilkårsvurderingRepository.insert(
@@ -543,6 +543,7 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
             Testdata.revurdering.copy(
                 id = UUID.randomUUID(),
                 eksternBrukId = UUID.randomUUID(),
+                avsluttetDato = null,
                 årsaker =
                     setOf(
                         Behandlingsårsak(


### PR DESCRIPTION
Favro: [NAV-18186](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18186)

Sørger for at testen (`lagreUtkastAvFriteksterFraSaksbehandler skal lagre selv når påkrevet fritekst mangler for oppsummering`) ikke feiler sporadisk.

Testen feiler da det ikke er satt opp noe kravgrunnlag tilknyttet revurderingsbehandlingen og `avsluttetDato` ikke er satt på førstegangsbehandlingen. 

Feilen oppstod sporadisk pga hvordan vi henter ut "aktiv" behandling fra `behandlinger` lista på entiteten `Vedtaksbrevgrunnlag`. Den var basert på behandlingenes `avsluttetDato`, hvor behandlingen med høyeste `avsluttetDato` eller behandlingen med `avsluttetDato` satt til null ble valgt. Her var `avsluttetDato` satt til null for både førstegangsbehandling og revurderingsbehandling, og det ble rekkefølgen på behandlingen i `behandlinger`-lista som ble avgjørende for hvilken behandling som skulle brukes. Fordi det kun var den ene av behandlingene som hadde et tilknyttet kravgrunnlag, feilet testen i de tilfellene behandlingen uten kravgrunnlag ble valgt.

Feilen er rettet ved at vi nå lagrer et nytt kravgrunnlag tilknyttet revurderingsbehandlingen samt at vi setter `avsluttetDato` på førstegangsbehandlingen.