### PR TITLE
Fjern gruppering av dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,12 +24,6 @@ updates:
   registries:
     - familie-kontrakter
     - familie-felles
-  groups:
-    all-dependencies:
-      patterns:
-        - "*"
-      exclude-patterns:
-        - "*pdf*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Ser at vi har en del sårbarheter med høyt nivå i [nais-console](https://console.nav.cloud.nais.io/team/teamfamilie/vulnerabilities?col=SEVERITY_HIGH&dir=DESC). Dette er vanskelig å ta tak i fordi dependabot grupperer alle oppdateringer sammen, og siden én av endringene brekker noe brekker hele [PRen](https://github.com/navikt/familie-tilbake/pull/1331). 

<img width="1457" alt="image" src="https://github.com/navikt/familie-tilbake/assets/17828446/588e0aa1-a730-4604-8e35-86e78659e8f4">

Endrer så dependabot ikke bundler sammen alt