### PR TITLE
Reduser hvor mye CPU vi ber om

### DIFF
--- a/.deploy/nais/app-dev-gcp.yaml
+++ b/.deploy/nais/app-dev-gcp.yaml
@@ -111,7 +111,7 @@ spec:
       memory: 1024Mi
     requests:
       memory: 512Mi
-      cpu: 500m
+      cpu: 25m
   ingresses:
     - https://familie-tilbake.intern.dev.nav.no
   secureLogs:

--- a/.deploy/nais/app-dev-gcp.yaml
+++ b/.deploy/nais/app-dev-gcp.yaml
@@ -110,7 +110,7 @@ spec:
     limits:
       memory: 1024Mi
     requests:
-      memory: 512Mi
+      memory: 1024Mi
       cpu: 25m
   ingresses:
     - https://familie-tilbake.intern.dev.nav.no

--- a/.deploy/nais/app-prod-gcp.yaml
+++ b/.deploy/nais/app-prod-gcp.yaml
@@ -105,7 +105,7 @@ spec:
       memory: 1024Mi
     requests:
       memory: 512Mi
-      cpu: 500m
+      cpu: 50m
   secureLogs:
     enabled: true
   ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.

--- a/.deploy/nais/app-prod-gcp.yaml
+++ b/.deploy/nais/app-prod-gcp.yaml
@@ -104,7 +104,7 @@ spec:
     limits:
       memory: 1024Mi
     requests:
-      memory: 512Mi
+      memory: 1024Mi
       cpu: 50m
   secureLogs:
     enabled: true


### PR DESCRIPTION
Vi bruker ca 3% av cpu vi spør om. Reduserer request med 90% i prod og 95% i preprod. 

Ser også at vi bruker mer minne en vi spør om. Det kan være litt uheldig da dette kan føre til at prosessene blir drept. Det er kjipere om vi går tom for minne enn om vi "går tom for" cpu, da man alltid kan throttle en app. Øker derfor hvor mye minne vi ber om

Prod: 
![image](https://github.com/navikt/familie-tilbake/assets/17828446/b74389fb-23e1-4ad6-b81d-eea7ce148f53)

Dev: 
![image](https://github.com/navikt/familie-tilbake/assets/17828446/9cddcd16-7b6e-4aa6-b964-d2626ee82ef5)

