### PR TITLE
Opprett behandling for feilutbetaling under 4x rettsgebyr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <main-class>no.nav.familie.tilbake.LauncherKt</main-class>
         <kotlin.version>1.9.23</kotlin.version>
         <common-java-modules.version>2.2021.09.17_07.09-67428a6422cc</common-java-modules.version>
-        <kontrakter.version>3.0_20240228112956_0728048</kontrakter.version>
+        <kontrakter.version>3.0_20240411113533_8de49a4</kontrakter.version>
         <felles.version>2.20240123084817_35f03aa</felles.version>
         <!-- kotest.properties kan antakelig fjernes i versjon 6, for autoscan blir default false -->
         <kotest.version>5.8.1</kotest.version>

--- a/src/main/kotlin/no/nav/familie/tilbake/api/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/BehandlingController.kt
@@ -54,7 +54,7 @@ class BehandlingController(
 
     @Operation(summary = "Opprett tilbakekrevingsbehandling automatisk som ikke skal kreve inn beløp under 4x rettsgebyr")
     @PostMapping(
-        path = ["/v1"],
+        path = ["/v1/automatisk"],
         consumes = [MediaType.APPLICATION_JSON_VALUE],
         produces = [MediaType.APPLICATION_JSON_VALUE],
     )

--- a/src/main/kotlin/no/nav/familie/tilbake/api/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/BehandlingController.kt
@@ -52,6 +52,21 @@ class BehandlingController(
         return Ressurs.success(behandling.eksternBrukId.toString(), melding = "Behandling er opprettet.")
     }
 
+    @Operation(summary = "Opprett tilbakekrevingsbehandling automatisk som ikke skal kreve inn beløp under 4x rettsgebyr")
+    @PostMapping(
+        path = ["/v1"],
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+    )
+    @Rolletilgangssjekk(Behandlerrolle.SAKSBEHANDLER, "Oppretter tilbakekreving som automatisk behandles", AuditLoggerEvent.CREATE)
+    fun oppretBehandlingForFeilutbetalingUnder4GangerRettsgebyr(
+        @Valid @RequestBody
+        opprettTilbakekrevingRequest: OpprettTilbakekrevingRequest,
+    ): Ressurs<String> {
+        val behandling = behandlingService.opprettBehandlingUnder4xRettsgebyr(opprettTilbakekrevingRequest)
+        return Ressurs.success(behandling.eksternBrukId.toString(), melding = "Behandling er opprettet.")
+    }
+
     @Operation(summary = "Opprett tilbakekrevingsbehandling manuelt")
     @PostMapping(
         path = ["/manuelt/task/v1"],

--- a/src/main/kotlin/no/nav/familie/tilbake/api/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/BehandlingController.kt
@@ -52,21 +52,6 @@ class BehandlingController(
         return Ressurs.success(behandling.eksternBrukId.toString(), melding = "Behandling er opprettet.")
     }
 
-    @Operation(summary = "Opprett tilbakekrevingsbehandling automatisk som ikke skal kreve inn beløp under 4x rettsgebyr")
-    @PostMapping(
-        path = ["/v1/automatisk"],
-        consumes = [MediaType.APPLICATION_JSON_VALUE],
-        produces = [MediaType.APPLICATION_JSON_VALUE],
-    )
-    @Rolletilgangssjekk(Behandlerrolle.SAKSBEHANDLER, "Oppretter tilbakekreving som automatisk behandles", AuditLoggerEvent.CREATE)
-    fun oppretBehandlingForFeilutbetalingUnder4GangerRettsgebyr(
-        @Valid @RequestBody
-        opprettTilbakekrevingRequest: OpprettTilbakekrevingRequest,
-    ): Ressurs<String> {
-        val behandling = behandlingService.opprettBehandlingUnder4xRettsgebyr(opprettTilbakekrevingRequest)
-        return Ressurs.success(behandling.eksternBrukId.toString(), melding = "Behandling er opprettet.")
-    }
-
     @Operation(summary = "Opprett tilbakekrevingsbehandling manuelt")
     @PostMapping(
         path = ["/manuelt/task/v1"],

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -121,9 +121,9 @@ class BehandlingService(
                 type = SendVarselbrevTask.TYPE,
                 payload = behandling.id.toString(),
                 properties =
-                Properties().apply {
-                    setProperty(PropertyName.FAGSYSTEM, opprettTilbakekrevingRequest.fagsystem.name)
-                },
+                    Properties().apply {
+                        setProperty(PropertyName.FAGSYSTEM, opprettTilbakekrevingRequest.fagsystem.name)
+                    },
             )
         taskService.save(sendVarselbrev)
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -112,23 +112,6 @@ class BehandlingService(
         return behandling
     }
 
-    fun opprettBehandlingUnder4xRettsgebyr(opprettTilbakekrevingRequest: OpprettTilbakekrevingRequest): Behandling {
-        val behandling: Behandling = opprettFørstegangsbehandling(opprettTilbakekrevingRequest)
-
-        val sendVarselbrev =
-            Task(
-                type = SendVarselbrevTask.TYPE,
-                payload = behandling.id.toString(),
-                properties =
-                    Properties().apply {
-                        setProperty(PropertyName.FAGSYSTEM, opprettTilbakekrevingRequest.fagsystem.name)
-                    },
-            )
-        taskService.save(sendVarselbrev)
-
-        return behandling
-    }
-
     @Transactional
     fun opprettBehandlingManuellTask(opprettManueltTilbakekrevingRequest: OpprettManueltTilbakekrevingRequest) {
         val kanBehandlingOpprettesManuelt =

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -113,6 +113,23 @@ class BehandlingService(
         return behandling
     }
 
+    fun opprettBehandlingUnder4xRettsgebyr(opprettTilbakekrevingRequest: OpprettTilbakekrevingRequest): Behandling {
+        val behandling: Behandling = opprettFørstegangsbehandling(opprettTilbakekrevingRequest)
+
+        val sendVarselbrev =
+            Task(
+                type = SendVarselbrevTask.TYPE,
+                payload = behandling.id.toString(),
+                properties =
+                Properties().apply {
+                    setProperty(PropertyName.FAGSYSTEM, opprettTilbakekrevingRequest.fagsystem.name)
+                },
+            )
+        taskService.save(sendVarselbrev)
+
+        return behandling
+    }
+
     @Transactional
     fun opprettBehandlingManuellTask(opprettManueltTilbakekrevingRequest: OpprettManueltTilbakekrevingRequest) {
         val kanBehandlingOpprettesManuelt =
@@ -470,11 +487,11 @@ class BehandlingService(
             integrasjonerClient.hentSaksbehandler(opprettTilbakekrevingRequest.saksbehandlerIdent)
 
         logger.info(
-            "Oppretter Tilbakekrevingsbehandling for ytelsestype=$ytelsestype,eksternFagsakId=$eksternFagsakId " +
+            "Oppretter Tilbakekrevingsbehandling for feilutbetaling under 4x rettsgebyr for ytelsestype=$ytelsestype,eksternFagsakId=$eksternFagsakId " +
                 "og eksternId=$eksternId",
         )
         secureLogger.info(
-            "Oppretter Tilbakekrevingsbehandling for ytelsestype=$ytelsestype,eksternFagsakId=$eksternFagsakId " +
+            "Oppretter Tilbakekrevingsbehandling for feilutbetaling under 4x rettsgebyr for ytelsestype=$ytelsestype,eksternFagsakId=$eksternFagsakId " +
                 " og personIdent=${opprettTilbakekrevingRequest.personIdent}",
         )
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -96,8 +96,7 @@ class BehandlingService(
                 opprettFørstegangsbehandling(opprettTilbakekrevingRequest)
             }
 
-        if ((opprettTilbakekrevingRequest.faktainfo.tilbakekrevingsvalg === Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL) && !behandling.manueltOpprettet
-        ) {
+        if (opprettTilbakekrevingRequest.faktainfo.tilbakekrevingsvalg === Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL && !behandling.manueltOpprettet) {
             val sendVarselbrev =
                 Task(
                     type = SendVarselbrevTask.TYPE,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -487,6 +487,15 @@ class BehandlingService(
         val ansvarligsaksbehandler =
             integrasjonerClient.hentSaksbehandler(opprettTilbakekrevingRequest.saksbehandlerIdent)
 
+        logger.info(
+            "Oppretter Tilbakekrevingsbehandling for feilutbetaling under 4x rettsgebyr for ytelsestype=$ytelsestype,eksternFagsakId=${opprettTilbakekrevingRequest.eksternFagsakId} " +
+                "og eksternId=${opprettTilbakekrevingRequest.eksternId}",
+        )
+        secureLogger.info(
+            "Oppretter Tilbakekrevingsbehandling for feilutbetaling under 4x rettsgebyr for ytelsestype=$ytelsestype,eksternFagsakId=${opprettTilbakekrevingRequest.eksternFagsakId} " +
+                " og personIdent=${opprettTilbakekrevingRequest.personIdent}",
+        )
+
         val behandling =
             BehandlingMapper.tilDomeneBehandling(
                 opprettTilbakekrevingRequest,
@@ -512,11 +521,11 @@ class BehandlingService(
             integrasjonerClient.hentSaksbehandler(opprettTilbakekrevingRequest.saksbehandlerIdent)
 
         logger.info(
-            "Oppretter Tilbakekrevingsbehandling for feilutbetaling under 4x rettsgebyr for ytelsestype=$ytelsestype,eksternFagsakId=$eksternFagsakId " +
+            "Oppretter Tilbakekrevingsbehandling for ytelsestype=$ytelsestype,eksternFagsakId=$eksternFagsakId " +
                 "og eksternId=$eksternId",
         )
         secureLogger.info(
-            "Oppretter Tilbakekrevingsbehandling for feilutbetaling under 4x rettsgebyr for ytelsestype=$ytelsestype,eksternFagsakId=$eksternFagsakId " +
+            "Oppretter Tilbakekrevingsbehandling for ytelsestype=$ytelsestype,eksternFagsakId=$eksternFagsakId " +
                 " og personIdent=${opprettTilbakekrevingRequest.personIdent}",
         )
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -96,10 +96,7 @@ class BehandlingService(
                 opprettFørstegangsbehandling(opprettTilbakekrevingRequest)
             }
 
-        if ((
-                opprettTilbakekrevingRequest.faktainfo.tilbakekrevingsvalg === Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL ||
-                    opprettTilbakekrevingRequest.faktainfo.tilbakekrevingsvalg === Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_AUTOMATISK
-            ) && !behandling.manueltOpprettet
+        if ((opprettTilbakekrevingRequest.faktainfo.tilbakekrevingsvalg === Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL) && !behandling.manueltOpprettet
         ) {
             val sendVarselbrev =
                 Task(


### PR DESCRIPTION
Egen service-metode for å opprette behandlinger med feilutbetaling under 4x rettsgebyr. Det skal blant annet ikke opprettes en egen behandle-sak oppgave, da det skal gjøres automatisk (dersom kravgrunnlaget stemmer overens).
Dette blir trigget som ved iverksetting og dersom tilbakekrevingsvalg er "opprett automatisk".