### PR TITLE
Featuretoggle for automatisk behandling av tilbakekrevinger under 4x rettsgebyr

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
@@ -27,6 +27,8 @@ class FeatureToggleConfig(
 
         const val IKKE_VALIDER_SÆRLIG_GRUNNET_ANNET_FRITEKST =
             "familie-tilbake.ikke-valider-saerlig-grunnet-annet-fritekst"
+
+        const val AUTOMATISK_BEHANDLE_TILBAKEKREVING_UNDER_4X_RETTSGEBYR = "familie-tilbake.automatisk-behandle-under-4x-rettsgebyr"
     }
 }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingServiceTest.kt
@@ -69,6 +69,7 @@ import no.nav.familie.tilbake.common.exceptionhandler.ManglerOppgaveFeil
 import no.nav.familie.tilbake.common.repository.Sporbar
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.config.Constants
+import no.nav.familie.tilbake.config.FeatureToggleService
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.datavarehus.saksstatistikk.BehandlingTilstandService
 import no.nav.familie.tilbake.dokumentbestilling.felles.BrevsporingRepository
@@ -370,6 +371,7 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
         val tilgangService = mockk<TilgangService>(relaxed = true)
         val integrasjonerClient = mockk<IntegrasjonerClient>(relaxed = true)
         val validerBehandlingService = mockk<ValiderBehandlingService>()
+        val featureToggleService = mockk<FeatureToggleService>()
 
         val behandlingServiceMock =
             BehandlingService(
@@ -389,8 +391,10 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
                 6,
                 integrasjonerClient,
                 validerBehandlingService,
+                featureToggleService,
             )
         justRun { validerBehandlingService.validerOpprettBehandling(any()) }
+        every { featureToggleService.isEnabled(any()) } returns false
         every { behandlingRepository.finnÅpenTilbakekrevingsbehandling(any(), any()) } returns null
         every { behandlingRepository.finnAvsluttetTilbakekrevingsbehandlinger(any()) } returns listOf(Testdata.behandling)
         every { behandlingRepository.insert(any()) } returns Testdata.behandling
@@ -426,6 +430,7 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
         val tilgangService = mockk<TilgangService>(relaxed = true)
         val integrasjonerClient = mockk<IntegrasjonerClient>(relaxed = true)
         val validerBehandlingService = mockk<ValiderBehandlingService>()
+        val featureToggleService = mockk<FeatureToggleService>()
 
         val behandlingServiceMock =
             BehandlingService(
@@ -445,8 +450,10 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
                 6,
                 integrasjonerClient,
                 validerBehandlingService,
+                featureToggleService,
             )
-        justRun { validerBehandlingService.validerOpprettBehandling(any()) } // default toggelen er av
+        justRun { validerBehandlingService.validerOpprettBehandling(any()) }
+        every { featureToggleService.isEnabled(any()) } returns false
         every { behandlingRepository.finnÅpenTilbakekrevingsbehandling(any(), any()) } returns null
         every { behandlingRepository.finnAvsluttetTilbakekrevingsbehandlinger(any()) } returns listOf(Testdata.behandling.copy(resultater = setOf(Testdata.behandlingsresultat.copy(type = Behandlingsresultatstype.HENLAGT_KRAVGRUNNLAG_NULLSTILT))))
         every { behandlingRepository.insert(any()) } returns Testdata.behandling.copy(resultater = setOf(Testdata.behandlingsresultat.copy(type = Behandlingsresultatstype.HENLAGT_KRAVGRUNNLAG_NULLSTILT)))


### PR DESCRIPTION
Har allerede en featuretoggle i ef-sak-frontend, men lager en egen for familie-tilbake som også kan brukes senere i løypa.