### PR TITLE
Fyll ut foreldelsessteg

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreldelsessteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreldelsessteg.kt
@@ -75,21 +75,21 @@ class Foreldelsessteg(
     @Transactional
     override fun utførStegAutomatisk(behandlingId: UUID) {
         logger.info("Behandling $behandlingId er på ${Behandlingssteg.FORELDELSE} steg og behandler automatisk..")
-        if (!harGrunnlagForeldetPeriode(behandlingId)) {
-            utførSteg(behandlingId)
-            return
-        }
-        foreldelseService.lagreFastForeldelseForAutomatiskSaksbehandling(behandlingId)
-        lagHistorikkinnslag(behandlingId, Aktør.VEDTAKSLØSNING)
+        if (harGrunnlagForeldetPeriode(behandlingId)) {
+            foreldelseService.lagreFastForeldelseForAutomatiskSaksbehandling(behandlingId)
+            lagHistorikkinnslag(behandlingId, Aktør.VEDTAKSLØSNING)
 
-        behandlingskontrollService.oppdaterBehandlingsstegStatus(
-            behandlingId,
-            Behandlingsstegsinfo(
-                Behandlingssteg.FORELDELSE,
-                Behandlingsstegstatus.UTFØRT,
-            ),
-        )
-        behandlingskontrollService.fortsettBehandling(behandlingId)
+            behandlingskontrollService.oppdaterBehandlingsstegStatus(
+                behandlingId,
+                Behandlingsstegsinfo(
+                    Behandlingssteg.FORELDELSE,
+                    Behandlingsstegstatus.UTFØRT,
+                ),
+            )
+            behandlingskontrollService.fortsettBehandling(behandlingId)
+        } else {
+            utførSteg(behandlingId)
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/tilbake/config/Constants.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/Constants.kt
@@ -52,12 +52,20 @@ object Constants {
         )
 
     const val AUTOMATISK_SAKSBEHANDLING_BEGRUNNELSE = "Automatisk satt verdi"
-    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR = "Automatisk behandling av tilbakekreving under 4 ganger rettsgebyr. Ingen tilbakekreving."
+    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FAKTA_BEGRUNNELSE = "Automatisk behandling av tilbakekreving under 4 ganger rettsgebyr. Ingen tilbakekreving."
+    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FORELDELSE_BEGRUNNELSE = "Automatisk behandlet under 4 ganger rettsgebyr på foreldet periode. Ikke relevant."
 
     fun hentAutomatiskSaksbehandlingBegrunnelse(saksbehandlingstype: Saksbehandlingstype): String =
         when (saksbehandlingstype) {
             Saksbehandlingstype.ORDINÆR -> throw Feil("Kan ikke utlede automatisk saksbehandlingsbegrunnelse for ordinære saker")
-            Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR -> AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR
+            Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR -> AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FAKTA_BEGRUNNELSE
+            Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_LAVT_BELØP -> AUTOMATISK_SAKSBEHANDLING_BEGRUNNELSE
+        }
+
+    fun hentAutomatiskForeldelsesbegrunnelse(saksbehandlingstype: Saksbehandlingstype): String =
+        when (saksbehandlingstype) {
+            Saksbehandlingstype.ORDINÆR -> throw Feil("Kan ikke utlede automatisk saksbehandlingsbegrunnelse for ordinære saker")
+            Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR -> AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FORELDELSE_BEGRUNNELSE
             Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_LAVT_BELØP -> AUTOMATISK_SAKSBEHANDLING_BEGRUNNELSE
         }
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/foreldelse/ForeldelseService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/foreldelse/ForeldelseService.kt
@@ -4,7 +4,9 @@ import no.nav.familie.kontrakter.felles.Månedsperiode
 import no.nav.familie.tilbake.api.dto.BehandlingsstegForeldelseDto
 import no.nav.familie.tilbake.api.dto.ForeldelsesperiodeDto
 import no.nav.familie.tilbake.api.dto.VurdertForeldelseDto
+import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.beregning.KravgrunnlagsberegningService
+import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.config.Constants
 import no.nav.familie.tilbake.faktaomfeilutbetaling.LogiskPeriodeUtil
 import no.nav.familie.tilbake.foreldelse.domain.Foreldelsesvurderingstype
@@ -21,6 +23,7 @@ class ForeldelseService(
     private val foreldelseRepository: VurdertForeldelseRepository,
     private val kravgrunnlagRepository: KravgrunnlagRepository,
     private val vilkårsvurderingRepository: VilkårsvurderingRepository,
+    private val behandlingRepository: BehandlingRepository,
 ) {
     fun hentVurdertForeldelse(behandlingId: UUID): VurdertForeldelseDto {
         val vurdertForeldelse: VurdertForeldelse? = foreldelseRepository.findByBehandlingIdAndAktivIsTrue(behandlingId)
@@ -62,11 +65,12 @@ class ForeldelseService(
 
     @Transactional
     fun lagreFastForeldelseForAutomatiskSaksbehandling(behandlingId: UUID) {
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         val foreldetPerioder =
             hentVurdertForeldelse(behandlingId).foreldetPerioder.map {
                 ForeldelsesperiodeDto(
                     periode = it.periode,
-                    begrunnelse = Constants.AUTOMATISK_SAKSBEHANDLING_BEGRUNNELSE,
+                    begrunnelse = Constants.hentAutomatiskForeldelsesbegrunnelse(behandling.saksbehandlingstype),
                     foreldelsesvurderingstype = Foreldelsesvurderingstype.IKKE_FORELDET,
                 )
             }

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/AutomatiskBehandlingAvKravgrunnlagUnder4Rettsgebyr.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/AutomatiskBehandlingAvKravgrunnlagUnder4Rettsgebyr.kt
@@ -22,6 +22,7 @@ import no.nav.familie.tilbake.behandlingskontroll.domain.Venteårsak
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.config.Constants
 import no.nav.familie.tilbake.config.FeatureToggleConfig
+import no.nav.familie.tilbake.config.FeatureToggleMockConfig
 import no.nav.familie.tilbake.config.FeatureToggleService
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.faktaomfeilutbetaling.FaktaFeilutbetalingRepository
@@ -58,7 +59,8 @@ class AutomatiskBehandlingAvKravgrunnlagUnder4Rettsgebyr : OppslagSpringRunnerTe
     @Autowired
     private lateinit var faktaFeilutbetalingRepository: FaktaFeilutbetalingRepository
 
-    val mockFeatureToggleService: FeatureToggleService = mockk()
+    @Autowired
+    private lateinit var featureToggleService : FeatureToggleService
 
     private lateinit var behandlingId: UUID
 
@@ -72,7 +74,7 @@ class AutomatiskBehandlingAvKravgrunnlagUnder4Rettsgebyr : OppslagSpringRunnerTe
         fagsakRepository.insert(fagsakOvergangsstønad)
         behandlingId = behandlingRepository.insert(automatiskBehandling).id
 
-        every { mockFeatureToggleService.isEnabled(FeatureToggleConfig.AUTOMATISK_BEHANDLE_TILBAKEKREVING_UNDER_4X_RETTSGEBYR) } returns true
+        every { featureToggleService.isEnabled(FeatureToggleConfig.AUTOMATISK_BEHANDLE_TILBAKEKREVING_UNDER_4X_RETTSGEBYR) } returns true
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/AutomatiskBehandlingAvKravgrunnlagUnder4Rettsgebyr.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/AutomatiskBehandlingAvKravgrunnlagUnder4Rettsgebyr.kt
@@ -5,7 +5,6 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
-import io.mockk.mockk
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import no.nav.familie.prosessering.domene.Task
@@ -22,10 +21,10 @@ import no.nav.familie.tilbake.behandlingskontroll.domain.Venteårsak
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.config.Constants
 import no.nav.familie.tilbake.config.FeatureToggleConfig
-import no.nav.familie.tilbake.config.FeatureToggleMockConfig
 import no.nav.familie.tilbake.config.FeatureToggleService
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.faktaomfeilutbetaling.FaktaFeilutbetalingRepository
+import no.nav.familie.tilbake.foreldelse.ForeldelseService
 import no.nav.familie.tilbake.kravgrunnlag.domain.Kravstatuskode
 import no.nav.familie.tilbake.kravgrunnlag.task.BehandleKravgrunnlagTask
 import org.junit.jupiter.api.BeforeEach
@@ -60,7 +59,10 @@ class AutomatiskBehandlingAvKravgrunnlagUnder4Rettsgebyr : OppslagSpringRunnerTe
     private lateinit var faktaFeilutbetalingRepository: FaktaFeilutbetalingRepository
 
     @Autowired
-    private lateinit var featureToggleService : FeatureToggleService
+    private lateinit var foreldelseService: ForeldelseService
+
+    @Autowired
+    private lateinit var featureToggleService: FeatureToggleService
 
     private lateinit var behandlingId: UUID
 
@@ -98,7 +100,9 @@ class AutomatiskBehandlingAvKravgrunnlagUnder4Rettsgebyr : OppslagSpringRunnerTe
         val behandlingsstegstilstand = behandlingsstegstilstandRepository.findByBehandlingId(behandlingId)
         behandlingsstegstilstand.any { it.behandlingssteg == Behandlingssteg.IVERKSETT_VEDTAK } shouldBe true
         val fakta = faktaFeilutbetalingRepository.findFaktaFeilutbetalingByBehandlingIdAndAktivIsTrue(behandlingId)
-        fakta.begrunnelse shouldBe Constants.AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR
+        fakta.begrunnelse shouldBe Constants.AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FAKTA_BEGRUNNELSE
+        val vurdertForeldelse = foreldelseService.hentAktivVurdertForeldelse(behandlingId)
+        vurdertForeldelse?.foreldelsesperioder shouldBe null
     }
 
     @Test
@@ -120,6 +124,33 @@ class AutomatiskBehandlingAvKravgrunnlagUnder4Rettsgebyr : OppslagSpringRunnerTe
 
         val exception = shouldThrow<Feil> { automatiskSaksbehandlingTask.doTask(automatiskSaksbehandlingTasks.first()) }
         exception.message shouldContain "Skal ikke behandle beløp over 4x rettsgebyr automatisk"
+    }
+
+    @Test
+    fun `Skal behandle automatisk selv om det finnes foreldet periode i kravgrunnlag`() {
+        lagGrunnlagssteg()
+
+        val kravgrunnlagXml = readXml("/kravgrunnlagxml/kravgrunnlag_EF_under_4x_rettsgebyr_foreldet.xml")
+
+        val task = opprettTask(kravgrunnlagXml)
+        behandleKravgrunnlagTask.doTask(task)
+
+        val kravgrunnlag = kravgrunnlagRepository.findByBehandlingIdAndAktivIsTrue(behandlingId)
+        kravgrunnlag.shouldNotBeNull()
+        kravgrunnlag.kravstatuskode shouldBe Kravstatuskode.NYTT
+        KravgrunnlagUtil.tilYtelsestype(kravgrunnlag.fagområdekode.name) shouldBe Ytelsestype.OVERGANGSSTØNAD
+
+        val automatiskSaksbehandlingTasks = taskService.finnAlleTaskerMedPayloadOgType(behandlingId.toString(), AutomatiskSaksbehandlingTask.TYPE)
+        automatiskSaksbehandlingTasks.size shouldBe 1
+
+        automatiskSaksbehandlingTask.doTask(automatiskSaksbehandlingTasks.first())
+        val behandlingsstegstilstand = behandlingsstegstilstandRepository.findByBehandlingId(behandlingId)
+        behandlingsstegstilstand.any { it.behandlingssteg == Behandlingssteg.IVERKSETT_VEDTAK } shouldBe true
+        val fakta = faktaFeilutbetalingRepository.findFaktaFeilutbetalingByBehandlingIdAndAktivIsTrue(behandlingId)
+        fakta.begrunnelse shouldBe Constants.AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FAKTA_BEGRUNNELSE
+        val vurdertForeldelse = foreldelseService.hentAktivVurdertForeldelse(behandlingId)
+        vurdertForeldelse?.foreldelsesperioder?.size shouldBe 1
+        vurdertForeldelse?.foreldelsesperioder?.first()?.begrunnelse shouldBe Constants.AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FORELDELSE_BEGRUNNELSE
     }
 
     private fun lagGrunnlagssteg() {

--- a/src/test/resources/kravgrunnlagxml/kravgrunnlag_EF_under_4x_rettsgebyr.xml
+++ b/src/test/resources/kravgrunnlagxml/kravgrunnlag_EF_under_4x_rettsgebyr.xml
@@ -14,13 +14,13 @@
         <urn:enhetAnsvarlig>8020</urn:enhetAnsvarlig>
         <urn:enhetBosted>8020</urn:enhetBosted>
         <urn:enhetBehandl>8020</urn:enhetBehandl>
-        <urn:kontrollfelt>2021-11-01-18.40.23.787834</urn:kontrollfelt>
+        <urn:kontrollfelt>2024-11-01-18.40.23.787834</urn:kontrollfelt>
         <urn:saksbehId>K231B433</urn:saksbehId>
         <urn:referanse>1</urn:referanse>
         <urn:tilbakekrevingsPeriode>
             <urn:periode>
-                <mmel:fom>2021-03-01</mmel:fom>
-                <mmel:tom>2021-03-31</mmel:tom>
+                <mmel:fom>2024-03-01</mmel:fom>
+                <mmel:tom>2024-03-31</mmel:tom>
             </urn:periode>
             <urn:belopSkattMnd>243.00</urn:belopSkattMnd>
             <urn:tilbakekrevingsBelop>

--- a/src/test/resources/kravgrunnlagxml/kravgrunnlag_EF_under_4x_rettsgebyr_foreldet.xml
+++ b/src/test/resources/kravgrunnlagxml/kravgrunnlag_EF_under_4x_rettsgebyr_foreldet.xml
@@ -14,21 +14,21 @@
         <urn:enhetAnsvarlig>8020</urn:enhetAnsvarlig>
         <urn:enhetBosted>8020</urn:enhetBosted>
         <urn:enhetBehandl>8020</urn:enhetBehandl>
-        <urn:kontrollfelt>2024-11-01-18.40.23.787834</urn:kontrollfelt>
+        <urn:kontrollfelt>2017-11-01-18.40.23.787834</urn:kontrollfelt>
         <urn:saksbehId>K231B433</urn:saksbehId>
         <urn:referanse>1</urn:referanse>
         <urn:tilbakekrevingsPeriode>
             <urn:periode>
-                <mmel:fom>2024-03-01</mmel:fom>
-                <mmel:tom>2024-03-31</mmel:tom>
+                <mmel:fom>2017-03-01</mmel:fom>
+                <mmel:tom>2017-03-31</mmel:tom>
             </urn:periode>
-            <urn:belopSkattMnd>24300.00</urn:belopSkattMnd>
+            <urn:belopSkattMnd>243.00</urn:belopSkattMnd>
             <urn:tilbakekrevingsBelop>
                 <urn:kodeKlasse>EFOG</urn:kodeKlasse>
                 <urn:typeKlasse>YTEL</urn:typeKlasse>
-                <urn:belopOpprUtbet>203000.00</urn:belopOpprUtbet>
-                <urn:belopNy>154400.00</urn:belopNy>
-                <urn:belopTilbakekreves>48600.00</urn:belopTilbakekreves>
+                <urn:belopOpprUtbet>2030.00</urn:belopOpprUtbet>
+                <urn:belopNy>1544.00</urn:belopNy>
+                <urn:belopTilbakekreves>486.00</urn:belopTilbakekreves>
                 <urn:belopUinnkrevd>0.00</urn:belopUinnkrevd>
                 <urn:skattProsent>50.0000</urn:skattProsent>
             </urn:tilbakekrevingsBelop>
@@ -36,7 +36,7 @@
                 <urn:kodeKlasse>KL_KODE_FEIL_EFOG</urn:kodeKlasse>
                 <urn:typeKlasse>FEIL</urn:typeKlasse>
                 <urn:belopOpprUtbet>0.00</urn:belopOpprUtbet>
-                <urn:belopNy>48600.00</urn:belopNy>
+                <urn:belopNy>486.00</urn:belopNy>
                 <urn:belopTilbakekreves>0.00</urn:belopTilbakekreves>
                 <urn:belopUinnkrevd>0.00</urn:belopUinnkrevd>
                 <urn:skattProsent>50.0000</urn:skattProsent>


### PR DESCRIPTION
Fyller ut foreldelsessteg for behandlinger med feilutbetaling under 4x rettsgebyr. 
Dersom det ikke finnes perioder er foreldet, vil det ikke bli satt noen verdier.
Dersom det finnes perioder som er foreldet, vil de bli vurdert til ikke_foreldet og satt begrunnelse til at den ikke er relevant dersom feilutbetaling er over 1/2 rettsgebyr og under 4x rettsgebyr.