### PR TITLE
Begrunnelse av vilkårsvurdering og aktsomhet settes for automatisk behandling av feilutbetalinger under 4x rettsgebyr

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/config/Constants.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/Constants.kt
@@ -54,6 +54,8 @@ object Constants {
     const val AUTOMATISK_SAKSBEHANDLING_BEGRUNNELSE = "Automatisk satt verdi"
     const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FAKTA_BEGRUNNELSE = "Automatisk behandling av tilbakekreving under 4 ganger rettsgebyr. Ingen tilbakekreving."
     const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FORELDELSE_BEGRUNNELSE = "Automatisk behandlet under 4 ganger rettsgebyr på foreldet periode. Ikke relevant."
+    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_BEGRUNNELSE = "Automatisk behandlet under 4 ganger rettsgebyr. Vilkår oppfylt."
+    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_AKTSOMHET_BEGRUNNELSE = "Automatisk behandlet feilutbetaling under 4 ganger rettsgebyr. Simpel uaktsomhet legges til grunn."
 
     fun hentAutomatiskSaksbehandlingBegrunnelse(saksbehandlingstype: Saksbehandlingstype): String =
         when (saksbehandlingstype) {
@@ -64,8 +66,22 @@ object Constants {
 
     fun hentAutomatiskForeldelsesbegrunnelse(saksbehandlingstype: Saksbehandlingstype): String =
         when (saksbehandlingstype) {
-            Saksbehandlingstype.ORDINÆR -> throw Feil("Kan ikke utlede automatisk saksbehandlingsbegrunnelse for ordinære saker")
+            Saksbehandlingstype.ORDINÆR -> throw Feil("Kan ikke utlede automatisk foreldelsesbegrunnelse for ordinære saker")
             Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR -> AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FORELDELSE_BEGRUNNELSE
+            Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_LAVT_BELØP -> AUTOMATISK_SAKSBEHANDLING_BEGRUNNELSE
+        }
+
+    fun hentAutomatiskVilkårsvurderingBegrunnelse(saksbehandlingstype: Saksbehandlingstype): String =
+        when (saksbehandlingstype) {
+            Saksbehandlingstype.ORDINÆR -> throw Feil("Kan ikke utlede automatisk vilkårsvurderingsbegrunnelse for ordinære saker")
+            Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR -> AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_BEGRUNNELSE
+            Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_LAVT_BELØP -> AUTOMATISK_SAKSBEHANDLING_BEGRUNNELSE
+        }
+
+    fun hentAutomatiskVilkårsvurderingAktsomhetBegrunnelse(saksbehandlingstype: Saksbehandlingstype): String =
+        when (saksbehandlingstype) {
+            Saksbehandlingstype.ORDINÆR -> throw Feil("Kan ikke utlede automatisk aktsomhetsbegrunnelse for ordinære saker")
+            Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR -> AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_AKTSOMHET_BEGRUNNELSE
             Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_LAVT_BELØP -> AUTOMATISK_SAKSBEHANDLING_BEGRUNNELSE
         }
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/config/Constants.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/Constants.kt
@@ -54,8 +54,8 @@ object Constants {
     const val AUTOMATISK_SAKSBEHANDLING_BEGRUNNELSE = "Automatisk satt verdi"
     const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FAKTA_BEGRUNNELSE = "Automatisk behandling av tilbakekreving under 4 ganger rettsgebyr. Ingen tilbakekreving."
     const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FORELDELSE_BEGRUNNELSE = "Automatisk behandlet under 4 ganger rettsgebyr på foreldet periode. Ikke relevant."
-    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_BEGRUNNELSE = "Automatisk behandlet feilutbetaling under 4 ganger rettsgebyr. Beløpet skal ikke tilbakebetales."
-    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_AKTSOMHET_BEGRUNNELSE = "Automatisk behandlet feilutbetaling under 4 ganger rettsgebyr. Bruker har ikke handlet forsettlig eller grovt uaktsomt."
+    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_BEGRUNNELSE = "Automatisk behandlet. Feilutbetaling under 4 ganger rettsgebyr. Beløpet skal ikke tilbakebetales."
+    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_AKTSOMHET_BEGRUNNELSE = "Automatisk behandlet. Feilutbetaling under 4 ganger rettsgebyr. Bruker har ikke handlet forsettlig eller grovt uaktsomt."
 
     fun hentAutomatiskSaksbehandlingBegrunnelse(saksbehandlingstype: Saksbehandlingstype): String =
         when (saksbehandlingstype) {

--- a/src/main/kotlin/no/nav/familie/tilbake/config/Constants.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/Constants.kt
@@ -54,8 +54,8 @@ object Constants {
     const val AUTOMATISK_SAKSBEHANDLING_BEGRUNNELSE = "Automatisk satt verdi"
     const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FAKTA_BEGRUNNELSE = "Automatisk behandling av tilbakekreving under 4 ganger rettsgebyr. Ingen tilbakekreving."
     const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_FORELDELSE_BEGRUNNELSE = "Automatisk behandlet under 4 ganger rettsgebyr på foreldet periode. Ikke relevant."
-    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_BEGRUNNELSE = "Automatisk behandlet under 4 ganger rettsgebyr. Vilkår oppfylt."
-    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_AKTSOMHET_BEGRUNNELSE = "Automatisk behandlet feilutbetaling under 4 ganger rettsgebyr. Simpel uaktsomhet legges til grunn."
+    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_BEGRUNNELSE = "Automatisk behandlet feilutbetaling under 4 ganger rettsgebyr. Beløpet skal ikke tilbakebetales."
+    const val AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_AKTSOMHET_BEGRUNNELSE = "Automatisk behandlet feilutbetaling under 4 ganger rettsgebyr. Bruker har ikke handlet forsettlig eller grovt uaktsomt."
 
     fun hentAutomatiskSaksbehandlingBegrunnelse(saksbehandlingstype: Saksbehandlingstype): String =
         when (saksbehandlingstype) {

--- a/src/main/kotlin/no/nav/familie/tilbake/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/vilkårsvurdering/VilkårsvurderingService.kt
@@ -9,7 +9,8 @@ import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
-import no.nav.familie.tilbake.config.Constants
+import no.nav.familie.tilbake.config.Constants.hentAutomatiskVilkårsvurderingAktsomhetBegrunnelse
+import no.nav.familie.tilbake.config.Constants.hentAutomatiskVilkårsvurderingBegrunnelse
 import no.nav.familie.tilbake.faktaomfeilutbetaling.FaktaFeilutbetalingService
 import no.nav.familie.tilbake.foreldelse.ForeldelseService
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
@@ -103,12 +104,12 @@ class VilkårsvurderingService(
                 VilkårsvurderingsperiodeDto(
                     periode = it.periode,
                     vilkårsvurderingsresultat = Vilkårsvurderingsresultat.FORSTO_BURDE_FORSTÅTT,
-                    begrunnelse = Constants.AUTOMATISK_SAKSBEHANDLING_BEGRUNNELSE,
+                    begrunnelse = hentAutomatiskVilkårsvurderingBegrunnelse(behandling.saksbehandlingstype),
                     aktsomhetDto =
                         AktsomhetDto(
                             aktsomhet = Aktsomhet.SIMPEL_UAKTSOMHET,
                             tilbakekrevSmåbeløp = false,
-                            begrunnelse = Constants.AUTOMATISK_SAKSBEHANDLING_BEGRUNNELSE,
+                            begrunnelse = hentAutomatiskVilkårsvurderingAktsomhetBegrunnelse(behandling.saksbehandlingstype),
                         ),
                 )
             }


### PR DESCRIPTION
Setter samme verdier som for eksisterende automatisk behandling under halvt rettsgebyr, med unntak av begrunnelser som endres i denne PR'n.