### PR TITLE
Endrer oppsett av integrasjonstester slik at det genereres nye ids for behandling/fagsak før det lagres til db

### DIFF
--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingRepositoryTest.kt
@@ -18,10 +18,11 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
-    private val behandling = Testdata.behandling
+    private lateinit var behandling: Behandling
 
     @BeforeEach
     fun init() {
+        behandling = Testdata.behandling
         fagsakRepository.insert(Testdata.fagsak)
     }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/VarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/VarselServiceTest.kt
@@ -5,9 +5,11 @@ import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import no.nav.familie.tilbake.OppslagSpringRunnerTest
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
+import no.nav.familie.tilbake.kravgrunnlag.domain.Kravgrunnlag431
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -25,11 +27,13 @@ internal class VarselServiceTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var varselService: VarselService
 
-    private val behandling = Testdata.behandling
-    private val kravgrunnlag = Testdata.kravgrunnlag431
+    private lateinit var behandling: Behandling
+    private lateinit var kravgrunnlag: Kravgrunnlag431
 
     @BeforeEach
     fun setup() {
+        behandling = Testdata.behandling
+        kravgrunnlag = Testdata.kravgrunnlag431
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/steg/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/steg/StegServiceTest.kt
@@ -37,8 +37,10 @@ import no.nav.familie.tilbake.api.dto.VurdertTotrinnDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
 import no.nav.familie.tilbake.behandling.VergeService
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Behandlingsresultatstype
 import no.nav.familie.tilbake.behandling.domain.Behandlingsstatus
+import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.behandling.domain.Iverksettingsstatus
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingsstegstilstandRepository
@@ -110,15 +112,18 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var stegService: StegService
 
-    private val fagsak = Testdata.fagsak
-    private val behandling = Testdata.behandling
-    private val behandlingId = behandling.id
+    private lateinit var fagsak: Fagsak
+    private lateinit var behandling: Behandling
+    private lateinit var behandlingId: UUID
 
     private val fom = YearMonth.now().minusMonths(1).atDay(1)
     private val tom = YearMonth.now().atEndOfMonth()
 
     @BeforeEach
     fun init() {
+        fagsak = Testdata.fagsak
+        behandling = Testdata.behandling
+        behandlingId = behandling.id
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
 

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/task/OppdaterFaktainfoTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/task/OppdaterFaktainfoTaskTest.kt
@@ -16,6 +16,8 @@ import no.nav.familie.tilbake.behandling.BehandlingService
 import no.nav.familie.tilbake.behandling.FagsakRepository
 import no.nav.familie.tilbake.behandling.HentFagsystemsbehandlingRequestSendtRepository
 import no.nav.familie.tilbake.behandling.HentFagsystemsbehandlingService
+import no.nav.familie.tilbake.behandling.domain.Behandling
+import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.behandling.domain.HentFagsystemsbehandlingRequestSendt
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.data.Testdata
@@ -44,14 +46,15 @@ internal class OppdaterFaktainfoTaskTest : OppslagSpringRunnerTest() {
     private lateinit var hentFagsystemsbehandlingService: HentFagsystemsbehandlingService
     private lateinit var oppdaterFaktainfoTask: OppdaterFaktainfoTask
 
-    private val fagsak = Testdata.fagsak
-    private val behandling = Testdata.behandling
+    private lateinit var fagsak: Fagsak
+    private lateinit var behandling: Behandling
 
     @BeforeEach
     fun init() {
         hentFagsystemsbehandlingService = HentFagsystemsbehandlingService(requestSendtRepository, mockKafkaProducer)
         oppdaterFaktainfoTask = OppdaterFaktainfoTask(hentFagsystemsbehandlingService, behandlingService)
-
+        fagsak = Testdata.fagsak
+        behandling = Testdata.behandling
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollServiceTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Behandlingsstatus
 import no.nav.familie.tilbake.behandling.domain.Fagsystemsbehandling
 import no.nav.familie.tilbake.behandling.domain.Varsel
@@ -51,10 +52,11 @@ internal class BehandlingskontrollServiceTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var behandlingskontrollService: BehandlingskontrollService
 
-    private val behandling = Testdata.behandling
+    private lateinit var behandling: Behandling
 
     @BeforeEach
     fun init() {
+        behandling = Testdata.behandling
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/task/DistribuerDokumentVedDødsfallTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/task/DistribuerDokumentVedDødsfallTaskTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.config.Constants
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.dokumentbestilling.felles.Brevmottager
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDateTime
 import java.util.Properties
+import java.util.UUID
 
 internal class DistribuerDokumentVedDødsfallTaskTest : OppslagSpringRunnerTest() {
     @Autowired
@@ -36,11 +38,13 @@ internal class DistribuerDokumentVedDødsfallTaskTest : OppslagSpringRunnerTest(
     @Autowired
     private lateinit var distribuerDokumentVedDødsfallTask: DistribuerDokumentVedDødsfallTask
 
-    private val behandling = Testdata.behandling
-    private val behandlingId = behandling.id
+    private lateinit var behandling: Behandling
+    private lateinit var behandlingId: UUID
 
     @BeforeEach
     fun init() {
+        behandling = Testdata.behandling
+        behandlingId = behandling.id
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/task/LagreBrevsporingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/task/LagreBrevsporingTaskTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.config.Constants
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.dokumentbestilling.felles.Brevmottager
@@ -42,14 +43,16 @@ internal class LagreBrevsporingTaskTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var lagreBrevsporingTask: LagreBrevsporingTask
 
-    private val behandling = Testdata.behandling
-    private val behandlingId = behandling.id
+    private lateinit var behandling: Behandling
+    private lateinit var behandlingId: UUID
 
     private val dokumentId: String = "testverdi"
     private val journalpostId: String = "testverdi"
 
     @BeforeEach
     fun init() {
+        behandling = Testdata.behandling
+        behandlingId = behandling.id
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/faktaomfeilutbetaling/FaktaFeilutbetalingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/faktaomfeilutbetaling/FaktaFeilutbetalingRepositoryTest.kt
@@ -5,6 +5,8 @@ import io.kotest.matchers.shouldBe
 import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
+import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.faktaomfeilutbetaling.domain.FaktaFeilutbetaling
@@ -22,12 +24,15 @@ internal class FaktaFeilutbetalingRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var behandlingRepository: BehandlingRepository
 
-    private val fagsak = Testdata.fagsak
-    private val behandling = Testdata.behandling
-    private val faktaFeilutbetaling = Testdata.faktaFeilutbetaling
+    private lateinit var fagsak: Fagsak
+    private lateinit var behandling: Behandling
+    private lateinit var faktaFeilutbetaling: FaktaFeilutbetaling
 
     @BeforeEach
     fun init() {
+        fagsak = Testdata.fagsak
+        behandling = Testdata.behandling
+        faktaFeilutbetaling = Testdata.faktaFeilutbetaling
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/faktaomfeilutbetaling/FaktaFeilutbetalingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/faktaomfeilutbetaling/FaktaFeilutbetalingServiceTest.kt
@@ -40,7 +40,7 @@ internal class FaktaFeilutbetalingServiceTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var faktaFeilutbetalingService: FaktaFeilutbetalingService
 
-    private val behandling = Testdata.behandling
+    private lateinit var behandling: Behandling
     private val periode =
         Månedsperiode(
             fom = YearMonth.now().minusMonths(2),
@@ -49,6 +49,7 @@ internal class FaktaFeilutbetalingServiceTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun init() {
+        behandling = Testdata.behandling
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
         val kravgrunnlag =

--- a/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
@@ -15,6 +15,7 @@ import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
 import no.nav.familie.tilbake.behandling.HentFagsystemsbehandlingRequestSendtRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Behandlingsresultatstype
 import no.nav.familie.tilbake.behandling.domain.Behandlingsstatus
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingsstegstilstandRepository
@@ -85,10 +86,11 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var forvaltningService: ForvaltningService
 
-    private val behandling = Testdata.behandling
+    private lateinit var behandling: Behandling
 
     @BeforeEach
     fun init() {
+        behandling = Testdata.behandling
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
         behandlingsstegstilstandRepository

--- a/src/test/kotlin/no/nav/familie/tilbake/historikkinnslag/HistorikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/historikkinnslag/HistorikkServiceTest.kt
@@ -14,9 +14,11 @@ import no.nav.familie.kontrakter.felles.historikkinnslag.OpprettHistorikkinnslag
 import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Behandlingsresultat
 import no.nav.familie.tilbake.behandling.domain.Behandlingsresultatstype
 import no.nav.familie.tilbake.behandling.domain.Behandlingsvedtak
+import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.behandling.domain.Iverksettingsstatus
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
@@ -57,9 +59,9 @@ internal class HistorikkServiceTest : OppslagSpringRunnerTest() {
     private lateinit var spyKafkaProducer: KafkaProducer
     private lateinit var historikkService: HistorikkService
 
-    private val fagsak = Testdata.fagsak
-    private val behandling = Testdata.behandling
-    private val behandlingId = behandling.id
+    private lateinit var fagsak: Fagsak
+    private lateinit var behandling: Behandling
+    private lateinit var behandlingId: UUID
     private val opprettetTidspunkt = LocalDateTime.now()
 
     private val behandlingIdSlot = slot<UUID>()
@@ -68,6 +70,9 @@ internal class HistorikkServiceTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun init() {
+        behandling = Testdata.behandling
+        behandlingId = behandling.id
+        fagsak = Testdata.fagsak
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
 

--- a/src/test/kotlin/no/nav/familie/tilbake/integration/økonomi/OppdragClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/integration/økonomi/OppdragClientTest.kt
@@ -20,6 +20,8 @@ import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
+import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.common.exceptionhandler.IntegrasjonException
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.iverksettvedtak.TilbakekrevingsvedtakMarshaller
@@ -57,8 +59,8 @@ internal class OppdragClientTest : OppslagSpringRunnerTest() {
     private val restOperations: RestOperations = RestTemplateBuilder().build()
     private val wireMockServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
 
-    private val fagsak = Testdata.fagsak
-    private val behandling = Testdata.behandling
+    private lateinit var fagsak: Fagsak
+    private lateinit var behandling: Behandling
     private lateinit var tilbakekrevingsvedtakRequest: TilbakekrevingsvedtakRequest
     private lateinit var hentKravgrunnlagRequest: KravgrunnlagHentDetaljRequest
     private val kravgrunnlagId: BigInteger = BigInteger.ZERO
@@ -66,7 +68,8 @@ internal class OppdragClientTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun init() {
         wireMockServer.start()
-
+        fagsak = Testdata.fagsak
+        behandling = Testdata.behandling
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
         oppdragClient = DefaultOppdragClient(restOperations, URI.create(wireMockServer.baseUrl()))

--- a/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/AvsluttBehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/AvsluttBehandlingTaskTest.kt
@@ -8,7 +8,9 @@ import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Behandlingsstatus
+import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingsstegstilstandRepository
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
@@ -21,6 +23,7 @@ import no.nav.familie.tilbake.iverksettvedtak.task.AvsluttBehandlingTask
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
 
 internal class AvsluttBehandlingTaskTest : OppslagSpringRunnerTest() {
     @Autowired
@@ -38,12 +41,15 @@ internal class AvsluttBehandlingTaskTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var avsluttBehandlingTask: AvsluttBehandlingTask
 
-    private val fagsak = Testdata.fagsak
-    private val behandling = Testdata.behandling
-    private val behandlingId = behandling.id
+    private lateinit var fagsak: Fagsak
+    private lateinit var behandling: Behandling
+    private lateinit var behandlingId: UUID
 
     @BeforeEach
     fun init() {
+        fagsak = Testdata.fagsak
+        behandling = Testdata.behandling
+        behandlingId = behandling.id
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/IverksettelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/IverksettelseServiceTest.kt
@@ -22,7 +22,9 @@ import no.nav.familie.tilbake.api.dto.VilkårsvurderingsperiodeDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.BehandlingsvedtakService
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Behandlingsresultatstype
+import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.beregning.TilbakekrevingsberegningService
 import no.nav.familie.tilbake.common.exceptionhandler.IntegrasjonException
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
@@ -93,9 +95,9 @@ internal class IverksettelseServiceTest : OppslagSpringRunnerTest() {
     private val wireMockServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
 
     private val mockFeatureToggleService: FeatureToggleService = mockk()
-    private val fagsak = Testdata.fagsak
-    private val behandling = Testdata.behandling
-    private val behandlingId = behandling.id
+    private lateinit var fagsak: Fagsak
+    private lateinit var behandling: Behandling
+    private lateinit var behandlingId: UUID
     private val perioder =
         listOf(
             Månedsperiode(YearMonth.of(2021, 1), YearMonth.of(2021, 1)),
@@ -105,6 +107,9 @@ internal class IverksettelseServiceTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun init() {
+        fagsak = Testdata.fagsak
+        behandling = Testdata.behandling
+        behandlingId = behandling.id
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
 

--- a/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/TilbakekrevingsvedtakBeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/TilbakekrevingsvedtakBeregningServiceTest.kt
@@ -16,6 +16,8 @@ import no.nav.familie.tilbake.api.dto.SærligGrunnDto
 import no.nav.familie.tilbake.api.dto.VilkårsvurderingsperiodeDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
+import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.foreldelse.ForeldelseService
@@ -69,8 +71,8 @@ internal class TilbakekrevingsvedtakBeregningServiceTest : OppslagSpringRunnerTe
     @Autowired
     private lateinit var iverksettelseService: IverksettelseService
 
-    private val fagsak = Testdata.fagsak
-    private val behandling = Testdata.behandling
+    private lateinit var fagsak: Fagsak
+    private lateinit var behandling: Behandling
 
     private val perioder =
         listOf(
@@ -82,6 +84,8 @@ internal class TilbakekrevingsvedtakBeregningServiceTest : OppslagSpringRunnerTe
 
     @BeforeEach
     fun init() {
+        behandling = Testdata.behandling
+        fagsak = Testdata.fagsak
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
 

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/BehandleKravgrunnlagTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/BehandleKravgrunnlagTaskTest.kt
@@ -26,7 +26,9 @@ import no.nav.familie.tilbake.api.dto.GodTroDto
 import no.nav.familie.tilbake.api.dto.VilkårsvurderingsperiodeDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Behandlingsstatus
+import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.behandling.domain.Fagsystemsbehandling
 import no.nav.familie.tilbake.behandling.steg.StegService
 import no.nav.familie.tilbake.behandling.task.OppdaterFaktainfoTask
@@ -108,11 +110,13 @@ internal class BehandleKravgrunnlagTaskTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var behandleKravgrunnlagTask: BehandleKravgrunnlagTask
 
-    private val fagsak = Testdata.fagsak
-    private val behandling = Testdata.behandling
+    private lateinit var fagsak: Fagsak
+    private lateinit var behandling: Behandling
 
     @BeforeEach
     fun init() {
+        fagsak = Testdata.fagsak
+        behandling = Testdata.behandling
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/BehandleStatusmeldingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/BehandleStatusmeldingTaskTest.kt
@@ -15,7 +15,9 @@ import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Behandlingsstatus
+import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingsstegstilstandRepository
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg.FAKTA
@@ -72,11 +74,13 @@ internal class BehandleStatusmeldingTaskTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var behandleKravgrunnlagTask: BehandleKravgrunnlagTask
 
-    private val fagsak = Testdata.fagsak
-    private val behandling = Testdata.behandling
+    private lateinit var fagsak: Fagsak
+    private lateinit var behandling: Behandling
 
     @BeforeEach
     fun init() {
+        fagsak = Testdata.fagsak
+        behandling = Testdata.behandling
         fagsakRepository.insert(fagsak)
     }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagRepositoryTest.kt
@@ -5,6 +5,8 @@ import io.kotest.matchers.shouldBe
 import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
+import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.kravgrunnlag.domain.Kravgrunnlag431
@@ -22,12 +24,15 @@ internal class KravgrunnlagRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var behandlingRepository: BehandlingRepository
 
-    private val fagsak = Testdata.fagsak
-    private val kravgrunnlag431 = Testdata.kravgrunnlag431
-    private val behandling = Testdata.behandling
+    private lateinit var fagsak: Fagsak
+    private lateinit var kravgrunnlag431: Kravgrunnlag431
+    private lateinit var behandling: Behandling
 
     @BeforeEach
     fun init() {
+        fagsak = Testdata.fagsak
+        kravgrunnlag431 = Testdata.kravgrunnlag431
+        behandling = Testdata.behandling
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceTest.kt
@@ -8,6 +8,8 @@ import no.nav.familie.tilbake.api.dto.Totrinnsstegsinfo
 import no.nav.familie.tilbake.api.dto.VurdertTotrinnDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
+import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingsstegstilstandRepository
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
@@ -16,6 +18,7 @@ import no.nav.familie.tilbake.data.Testdata
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
 
 internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
     @Autowired
@@ -30,12 +33,15 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var totrinnService: TotrinnService
 
-    private val fagsak = Testdata.fagsak
-    private val behandling = Testdata.behandling
-    private val behandlingId = behandling.id
+    private lateinit var fagsak: Fagsak
+    private lateinit var behandling: Behandling
+    private lateinit var behandlingId: UUID
 
     @BeforeEach
     fun init() {
+        fagsak = Testdata.fagsak
+        behandling = Testdata.behandling
+        behandlingId = behandling.id
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -19,6 +19,7 @@ import no.nav.familie.tilbake.api.dto.SærligGrunnDto
 import no.nav.familie.tilbake.api.dto.VilkårsvurderingsperiodeDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingsstegstilstandRepository
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
@@ -74,10 +75,11 @@ internal class VilkårsvurderingServiceTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var vilkårsvurderingService: VilkårsvurderingService
 
-    private val behandling = Testdata.behandling
+    private lateinit var behandling: Behandling
 
     @BeforeEach
     fun init() {
+        behandling = Testdata.behandling
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
         val førstePeriode =


### PR DESCRIPTION
I forsøk på å fikse enhetstester som feiler tilfeldig i GHA