### PR TITLE
Legg til tilbakekrevingsbegrunnelse på behandling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <main-class>no.nav.familie.tilbake.LauncherKt</main-class>
         <kotlin.version>1.9.23</kotlin.version>
         <common-java-modules.version>2.2021.09.17_07.09-67428a6422cc</common-java-modules.version>
-        <kontrakter.version>3.0_20240411113533_8de49a4</kontrakter.version>
+        <kontrakter.version>3.0_20240429104705_2be7a67</kontrakter.version>
         <felles.version>2.20240123084817_35f03aa</felles.version>
         <!-- kotest.properties kan antakelig fjernes i versjon 6, for autoscan blir default false -->
         <kotest.version>5.8.1</kotest.version>

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapper.kt
@@ -67,6 +67,7 @@ object BehandlingMapper {
             varsler = varsler,
             verger = verger,
             regelverk = opprettTilbakekrevingRequest.regelverk,
+            begrunnelseForTilbakekreving = opprettTilbakekrevingRequest.begrunnelseForTilbakekreving
         )
     }
 
@@ -270,6 +271,7 @@ object BehandlingMapper {
             fagsystemsbehandling = setOf(kopiFagsystemsbehandling(originalBehandling)),
             verger = verger,
             regelverk = originalBehandling.regelverk,
+            begrunnelseForTilbakekreving = originalBehandling.begrunnelseForTilbakekreving,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/domain/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/domain/Behandling.kt
@@ -45,6 +45,8 @@ data class Behandling(
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar(),
     val regelverk: Regelverk? = null,
+    @Column("begrunnelse_for_tilbakekreving")
+    val begrunnelseForTilbakekreving: String? = null,
 ) {
     val erAvsluttet get() = Behandlingsstatus.AVSLUTTET == status
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/domain/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/domain/Behandling.kt
@@ -46,7 +46,7 @@ data class Behandling(
     val sporbar: Sporbar = Sporbar(),
     val regelverk: Regelverk? = null,
     @Column("begrunnelse_for_tilbakekreving")
-    val begrunnelseForTilbakekreving: String? = null,
+    val begrunnelseForTilbakekreving: String?,
 ) {
     val erAvsluttet get() = Behandlingsstatus.AVSLUTTET == status
 

--- a/src/main/resources/db/migration/V35__behandling_legg_til_begrunnelse.sql
+++ b/src/main/resources/db/migration/V35__behandling_legg_til_begrunnelse.sql
@@ -1,0 +1,3 @@
+ALTER TABLE behandling
+    ADD COLUMN begrunnelse_for_tilbakekreving TEXT;
+


### PR DESCRIPTION
Når saksbehandleren for tilbakekreving skal begrunne hvorfor tilbakekrevingen er opprettet, er det allerede mye av jobben gjort i saksbehandlingsapplikasjonen. Endrer så vi lagrer begrunnelsen som er gitt i saksbehandlingsapplikasjonen slik at tilbakekrevingsbehandleren kan gjenbruke teksten skrevet av saksbehandleren. 