### PR TITLE
Skriver om Testdata til å ikke bruke samme behandling for alle testene

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagService.kt
@@ -146,7 +146,7 @@ class KravgrunnlagService(
 
     private fun identifiserAktivtKravgrunnlagOgLagre(
         mottattKravgrunnlag: Kravgrunnlag431,
-        ytelsestype: Ytelsestype
+        ytelsestype: Ytelsestype,
     ) {
         val eksisterendeKravgrunnlag = kravgrunnlagRepository.findByBehandlingIdAndAktivIsTrue(mottattKravgrunnlag.behandlingId)
 

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingRepositoryTest.kt
@@ -22,7 +22,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun init() {
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         fagsakRepository.insert(Testdata.fagsak)
     }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingServiceTest.kt
@@ -71,6 +71,7 @@ import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.config.Constants
 import no.nav.familie.tilbake.config.FeatureToggleService
 import no.nav.familie.tilbake.data.Testdata
+import no.nav.familie.tilbake.data.Testdata.behandlingsresultat
 import no.nav.familie.tilbake.datavarehus.saksstatistikk.BehandlingTilstandService
 import no.nav.familie.tilbake.dokumentbestilling.felles.BrevsporingRepository
 import no.nav.familie.tilbake.dokumentbestilling.felles.BrevsporingService
@@ -396,12 +397,13 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
         justRun { validerBehandlingService.validerOpprettBehandling(any()) }
         every { featureToggleService.isEnabled(any()) } returns false
         every { behandlingRepository.finnÅpenTilbakekrevingsbehandling(any(), any()) } returns null
-        every { behandlingRepository.finnAvsluttetTilbakekrevingsbehandlinger(any()) } returns listOf(Testdata.behandling)
-        every { behandlingRepository.insert(any()) } returns Testdata.behandling
+        val behandling = Testdata.lagBehandling()
+        every { behandlingRepository.finnAvsluttetTilbakekrevingsbehandlinger(any()) } returns listOf(behandling)
+        every { behandlingRepository.insert(any()) } returns behandling
         every { fagsakService.finnFagsak(any(), any()) } returns null
         every { fagsakService.opprettFagsak(any(), any(), any()) } returns Testdata.fagsak
 
-        val behandling = shouldNotThrowAny { behandlingServiceMock.opprettBehandling(opprettTilbakekrevingRequest) }
+        shouldNotThrowAny { behandlingServiceMock.opprettBehandling(opprettTilbakekrevingRequest) }
         behandling.shouldNotBeNull()
     }
 
@@ -455,13 +457,15 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
         justRun { validerBehandlingService.validerOpprettBehandling(any()) }
         every { featureToggleService.isEnabled(any()) } returns false
         every { behandlingRepository.finnÅpenTilbakekrevingsbehandling(any(), any()) } returns null
-        every { behandlingRepository.finnAvsluttetTilbakekrevingsbehandlinger(any()) } returns listOf(Testdata.behandling.copy(resultater = setOf(Testdata.behandlingsresultat.copy(type = Behandlingsresultatstype.HENLAGT_KRAVGRUNNLAG_NULLSTILT))))
-        every { behandlingRepository.insert(any()) } returns Testdata.behandling.copy(resultater = setOf(Testdata.behandlingsresultat.copy(type = Behandlingsresultatstype.HENLAGT_KRAVGRUNNLAG_NULLSTILT)))
+        val behandling = Testdata.lagBehandling()
+        every { behandlingRepository.finnAvsluttetTilbakekrevingsbehandlinger(any()) } returns listOf(behandling.copy(resultater = setOf(behandlingsresultat.copy(type = Behandlingsresultatstype.HENLAGT_KRAVGRUNNLAG_NULLSTILT))))
+        every { behandlingRepository.insert(any()) } returns behandling.copy(resultater = setOf(behandlingsresultat.copy(type = Behandlingsresultatstype.HENLAGT_KRAVGRUNNLAG_NULLSTILT)))
         every { fagsakService.finnFagsak(any(), any()) } returns null
         every { fagsakService.opprettFagsak(any(), any(), any()) } returns Testdata.fagsak
 
-        val behandling = shouldNotThrowAny { behandlingServiceMock.opprettBehandling(opprettTilbakekrevingRequest) }
-        behandling.shouldNotBeNull()
+        shouldNotThrowAny { behandlingServiceMock.opprettBehandling(opprettTilbakekrevingRequest) }.apply {
+            this.shouldNotBeNull()
+        }
     }
 
     @Test
@@ -613,8 +617,8 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `opprettRevurdering skal opprette revurdering for gitt avsluttet tilbakekrevingsbehandling`() {
         fagsakRepository.insert(Testdata.fagsak)
-        var behandling = behandlingRepository.insert(Testdata.behandling)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        var behandling = behandlingRepository.insert(Testdata.lagBehandling())
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         behandling = behandlingRepository.findByIdOrThrow(behandling.id)
         behandlingRepository.update(behandling.copy(status = Behandlingsstatus.AVSLUTTET))
 
@@ -653,7 +657,7 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `opprettRevurdering skal ikke opprette revurdering for tilbakekreving som er avsluttet uten kravgrunnlag`() {
         fagsakRepository.insert(Testdata.fagsak)
-        var behandling = behandlingRepository.insert(Testdata.behandling)
+        var behandling = behandlingRepository.insert(Testdata.lagBehandling())
         behandling = behandlingRepository.findByIdOrThrow(behandling.id)
         behandlingRepository.update(behandling.copy(status = Behandlingsstatus.AVSLUTTET))
 
@@ -909,7 +913,7 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `hentBehandling kan ikke opprette revurdering når tilbakekreving ikke har kravgrunnlag`() {
         fagsakRepository.insert(Testdata.fagsak)
-        var behandling = behandlingRepository.insert(Testdata.behandling)
+        var behandling = behandlingRepository.insert(Testdata.lagBehandling())
         behandling = behandlingRepository.findByIdOrThrow(behandling.id)
         behandlingRepository.update(behandling.copy(status = Behandlingsstatus.AVSLUTTET))
 
@@ -920,9 +924,9 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `hentBehandling kan opprette revurdering når tilbakekreving er avsluttet med kravgrunnlag`() {
         fagsakRepository.insert(Testdata.fagsak)
-        var behandling = behandlingRepository.insert(Testdata.behandling)
+        var behandling = behandlingRepository.insert(Testdata.lagBehandling())
         behandling = behandlingRepository.findByIdOrThrow(behandling.id)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         behandling = behandlingRepository.findByIdOrThrow(behandling.id)
         behandlingRepository.update(behandling.copy(status = Behandlingsstatus.AVSLUTTET))
 
@@ -933,13 +937,13 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `hentBehandling kan ikke opprette revurdering når tilbakekreving har en åpen revurdering`() {
         fagsakRepository.insert(Testdata.fagsak)
-        var behandling = behandlingRepository.insert(Testdata.behandling)
+        var behandling = behandlingRepository.insert(Testdata.lagBehandling())
         behandling = behandlingRepository.findByIdOrThrow(behandling.id)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         behandling = behandlingRepository.findByIdOrThrow(behandling.id)
         behandlingRepository.update(behandling.copy(status = Behandlingsstatus.AVSLUTTET))
 
-        behandlingRepository.insert(Testdata.revurdering)
+        behandlingRepository.insert(Testdata.lagRevurdering(behandling.id))
 
         val behandlingDto = behandlingService.hentBehandling(behandling.id)
         behandlingDto.kanRevurderingOpprettes.shouldBeFalse()
@@ -948,13 +952,13 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `hentBehandling kan opprette revurdering når tilbakekreving har en avsluttet revurdering`() {
         fagsakRepository.insert(Testdata.fagsak)
-        var behandling = behandlingRepository.insert(Testdata.behandling)
+        var behandling = behandlingRepository.insert(Testdata.lagBehandling())
         behandling = behandlingRepository.findByIdOrThrow(behandling.id)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         behandling = behandlingRepository.findByIdOrThrow(behandling.id)
         behandlingRepository.update(behandling.copy(status = Behandlingsstatus.AVSLUTTET))
 
-        var revurdering = behandlingRepository.insert(Testdata.revurdering)
+        var revurdering = behandlingRepository.insert(Testdata.lagRevurdering(behandling.id))
         revurdering = behandlingRepository.findByIdOrThrow(revurdering.id)
         behandlingRepository.update(revurdering.copy(status = Behandlingsstatus.AVSLUTTET))
 
@@ -1048,7 +1052,7 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `taBehandlingAvvent skal ikke gjenoppta når behandling er avsluttet`() {
         fagsakRepository.insert(Testdata.fagsak)
-        val behandling = behandlingRepository.insert(Testdata.behandling)
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling())
         val lagretBehandling = behandlingRepository.findByIdOrThrow(behandling.id)
         behandlingRepository.update(lagretBehandling.copy(status = Behandlingsstatus.AVSLUTTET))
 
@@ -1059,7 +1063,7 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `taBehandlingAvvent skal ikke gjenoppta når behandling er ikke på vent`() {
         fagsakRepository.insert(Testdata.fagsak)
-        val behandling = behandlingRepository.insert(Testdata.behandling)
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling())
 
         val exception = shouldThrow<RuntimeException> { behandlingService.taBehandlingAvvent(behandling.id) }
         exception.message shouldBe "Behandling ${behandling.id} er ikke på vent, kan ike gjenoppta"
@@ -1075,7 +1079,7 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
                 tilbakekrevingsvalg = Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_UTEN_VARSEL,
             )
         val behandling = behandlingService.opprettBehandling(opprettTilbakekrevingRequest)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431.copy(behandlingId = behandling.id))
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id).copy(behandlingId = behandling.id))
 
         behandlingService.settBehandlingPåVent(
             behandlingId = behandling.id,
@@ -1119,7 +1123,7 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
                 it.venteårsak == Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING
         }
 
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431.copy(behandlingId = behandling.id))
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id).copy(behandlingId = behandling.id))
 
         behandlingService.taBehandlingAvvent(behandling.id)
 
@@ -1345,7 +1349,7 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
                 tilbakekrevingsvalg = Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_UTEN_VARSEL,
             )
         val behandling = behandlingService.opprettBehandling(opprettTilbakekrevingRequest)
-        val kravgrunnlag = Testdata.kravgrunnlag431
+        val kravgrunnlag = Testdata.lagKravgrunnlag(behandling.id)
         kravgrunnlagRepository.insert(kravgrunnlag.copy(behandlingId = behandling.id))
 
         val exception =

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/VarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/VarselServiceTest.kt
@@ -32,8 +32,8 @@ internal class VarselServiceTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun setup() {
-        behandling = Testdata.behandling
-        kravgrunnlag = Testdata.kravgrunnlag431
+        behandling = Testdata.lagBehandling()
+        kravgrunnlag = Testdata.lagKravgrunnlag(behandling.id)
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/VergeServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/VergeServiceTest.kt
@@ -25,6 +25,7 @@ import no.nav.familie.tilbake.behandlingskontroll.domain.Venteårsak
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.data.Testdata
+import no.nav.familie.tilbake.data.Testdata.lagKravgrunnlag
 import no.nav.familie.tilbake.historikkinnslag.HistorikkTaskService
 import no.nav.familie.tilbake.historikkinnslag.TilbakekrevingHistorikkinnslagstype
 import no.nav.familie.tilbake.integration.familie.IntegrasjonerClient
@@ -74,7 +75,7 @@ internal class VergeServiceTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun setUp() {
         fagsakRepository.insert(Testdata.fagsak)
-        behandlingRepository.insert(Testdata.behandling)
+
         vergeService =
             VergeService(
                 behandlingRepository,
@@ -89,9 +90,14 @@ internal class VergeServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `lagreVerge skal lagre verge i basen`() {
-        vergeService.lagreVerge(Testdata.behandling.id, vergeDto)
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
 
-        val behandling = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
+        vergeService.lagreVerge(behandlingId, vergeDto)
+
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         val verge = behandling.aktivVerge!!
         verge.aktiv shouldBe true
         verge.orgNr shouldBe "987654321"
@@ -103,21 +109,29 @@ internal class VergeServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `lagreVerge skal deaktivere eksisterende verger i basen`() {
-        val behandlingFørOppdatering = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
+        val behandlingFørOppdatering = behandlingRepository.findByIdOrThrow(behandlingId)
         val gammelVerge = behandlingFørOppdatering.aktivVerge!!
 
-        vergeService.lagreVerge(Testdata.behandling.id, vergeDto)
+        vergeService.lagreVerge(behandlingId, vergeDto)
 
-        val behandling = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         val deaktivertVerge = behandling.verger.first { !it.aktiv }
         deaktivertVerge.id shouldBe gammelVerge.id
     }
 
     @Test
     fun `lagreVerge skal kalle historikkTaskService for å opprette historikkTask`() {
-        vergeService.lagreVerge(Testdata.behandling.id, vergeDto)
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
+        vergeService.lagreVerge(behandlingId, vergeDto)
 
-        val behandling = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
 
         verify {
             historikkTaskService.lagHistorikkTask(
@@ -130,8 +144,12 @@ internal class VergeServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `lagreVerge skal ikke lagre verge når organisasjonen er tom`() {
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
         val vergeDto = vergeDto.copy(orgNr = null, ident = "123")
-        val exception = shouldThrow<RuntimeException> { vergeService.lagreVerge(Testdata.behandling.id, vergeDto) }
+        val exception = shouldThrow<RuntimeException> { vergeService.lagreVerge(behandlingId, vergeDto) }
         exception.message shouldBe "orgNr kan ikke være null for ${Vergetype.ADVOKAT}"
     }
 
@@ -150,14 +168,22 @@ internal class VergeServiceTest : OppslagSpringRunnerTest() {
 
         every { mockIntegrasjonerClient.validerOrganisasjon(any()) } returns false
 
-        val exception = shouldThrow<RuntimeException> { vergeService.lagreVerge(Testdata.behandling.id, vergeDto) }
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
+        val exception = shouldThrow<RuntimeException> { vergeService.lagreVerge(behandlingId, vergeDto) }
         exception.message shouldBe "Organisasjon ${vergeDto.orgNr} er ikke gyldig"
     }
 
     @Test
     fun `lagreVerge skal ikke lagre verge når ident er tom`() {
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
         val vergeDto = vergeDto.copy(type = Vergetype.VERGE_FOR_BARN)
-        val exception = shouldThrow<RuntimeException> { vergeService.lagreVerge(Testdata.behandling.id, vergeDto) }
+        val exception = shouldThrow<RuntimeException> { vergeService.lagreVerge(behandlingId, vergeDto) }
         exception.message shouldBe "ident kan ikke være null for ${vergeDto.type}"
     }
 
@@ -179,25 +205,33 @@ internal class VergeServiceTest : OppslagSpringRunnerTest() {
         every { mockPdlClient.hentPersoninfo(any(), any()) } throws Feil(message = "Feil ved oppslag på person")
 
         val vergeDto = VergeDto(ident = "123", type = Vergetype.VERGE_FOR_BARN, navn = "testverdi", begrunnelse = "testverdi")
-        val exception = shouldThrow<RuntimeException> { vergeService.lagreVerge(Testdata.behandling.id, vergeDto) }
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
+        val exception = shouldThrow<RuntimeException> { vergeService.lagreVerge(behandlingId, vergeDto) }
         exception.message shouldBe "Feil ved oppslag på person"
     }
 
     @Test
     fun `fjernVerge skal deaktivere verge i basen hvis det finnes aktiv verge`() {
-        val behandlingFørOppdatering = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
+        val behandlingFørOppdatering = behandlingRepository.findByIdOrThrow(behandlingId)
         val gammelVerge = behandlingFørOppdatering.aktivVerge!!
 
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandlingId))
 
         lagBehandlingsstegstilstand(behandlingFørOppdatering.id, Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(behandlingFørOppdatering.id, Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(behandlingFørOppdatering.id, Behandlingssteg.VERGE, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(behandlingFørOppdatering.id, Behandlingssteg.FAKTA, Behandlingsstegstatus.KLAR)
 
-        vergeService.fjernVerge(Testdata.behandling.id)
+        vergeService.fjernVerge(behandlingId)
 
-        val behandling = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         val deaktivertVerge = behandling.verger.first()
         deaktivertVerge.id shouldBe gammelVerge.id
         deaktivertVerge.aktiv shouldBe false
@@ -211,18 +245,22 @@ internal class VergeServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `fjernVerge skal tilbakeføre verge steg når behandling er på vilkårsvurdering steg og verge fjernet`() {
-        val behandlingFørOppdatering = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
+        val behandlingFørOppdatering = behandlingRepository.findByIdOrThrow(behandlingId)
         val gammelVerge = behandlingFørOppdatering.aktivVerge
         gammelVerge.shouldNotBeNull()
 
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(lagKravgrunnlag(behandlingId))
 
         lagBehandlingsstegstilstand(behandlingFørOppdatering.id, Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(behandlingFørOppdatering.id, Behandlingssteg.VERGE, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(behandlingFørOppdatering.id, Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(behandlingFørOppdatering.id, Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.KLAR)
 
-        vergeService.fjernVerge(Testdata.behandling.id)
+        vergeService.fjernVerge(behandlingId)
 
         behandlingRepository.findByIdOrThrow(behandlingFørOppdatering.id).harVerge.shouldBeFalse()
         verify {
@@ -241,10 +279,14 @@ internal class VergeServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `fjernVerge skal tilbakeføre verge steg og fortsette til fakta når behandling er på verge steg og verge fjernet`() {
-        val behandlingFørOppdatering = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
+        val behandlingFørOppdatering = behandlingRepository.findByIdOrThrow(behandlingId)
         val behandlingUtenVerge = behandlingRepository.update(behandlingFørOppdatering.copy(verger = emptySet()))
 
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(lagKravgrunnlag(behandlingId))
 
         lagBehandlingsstegstilstand(behandlingUtenVerge.id, Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(behandlingUtenVerge.id, Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
@@ -264,8 +306,12 @@ internal class VergeServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `opprettVergeSteg skal opprette verge steg når behandling er på vilkårsvurdering steg`() {
-        val behandling = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
+        kravgrunnlagRepository.insert(lagKravgrunnlag(behandlingId))
 
         lagBehandlingsstegstilstand(behandling.id, Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(behandling.id, Behandlingssteg.FORELDELSE, Behandlingsstegstatus.AUTOUTFØRT)
@@ -281,7 +327,11 @@ internal class VergeServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `opprettVergeSteg skal ikke opprette verge steg når behandling er avsluttet`() {
-        val behandling = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         behandlingRepository.update(behandling.copy(status = Behandlingsstatus.AVSLUTTET))
 
         val exception = shouldThrow<RuntimeException> { vergeService.opprettVergeSteg(behandling.id) }
@@ -290,7 +340,11 @@ internal class VergeServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `opprettVergeSteg skal ikke opprette verge steg når behandling er på vent`() {
-        val behandling = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
+        val behandlingId =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }.id
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         lagBehandlingsstegstilstand(behandling.id, Behandlingssteg.FAKTA, Behandlingsstegstatus.KLAR)
         behandlingskontrollService.settBehandlingPåVent(
             behandling.id,
@@ -304,10 +358,14 @@ internal class VergeServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentVerge skal returnere lagret verge data`() {
-        val aktivVerge = Testdata.behandling.aktivVerge
+        val behandling =
+            Testdata.lagBehandling().apply {
+                behandlingRepository.insert(this)
+            }
+        val aktivVerge = behandling.aktivVerge
         aktivVerge.shouldNotBeNull()
 
-        val respons = vergeService.hentVerge(Testdata.behandling.id)
+        val respons = vergeService.hentVerge(behandling.id)
 
         respons.shouldNotBeNull()
         respons.begrunnelse shouldBe aktivVerge.begrunnelse

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskGjenopptaBehandlingBatchTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskGjenopptaBehandlingBatchTest.kt
@@ -35,9 +35,9 @@ internal class AutomatiskGjenopptaBehandlingBatchTest : OppslagSpringRunnerTest(
     @Test
     fun `skal lage task på behandling som venter på varsel og tidsfristen har utgått`() {
         fagsakRepository.insert(Testdata.fagsak)
-        val behandling = behandlingRepository.insert(Testdata.behandling.copy(status = Behandlingsstatus.UTREDES))
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling().copy(status = Behandlingsstatus.UTREDES))
         behandlingsstegstilstandRepository.insert(
-            Testdata.behandlingsstegstilstand.copy(
+            Testdata.lagBehandlingsstegstilstand(behandling.id).copy(
                 behandlingssteg = Behandlingssteg.VARSEL,
                 behandlingsstegsstatus = Behandlingsstegstatus.VENTER,
                 venteårsak = Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING,
@@ -55,10 +55,10 @@ internal class AutomatiskGjenopptaBehandlingBatchTest : OppslagSpringRunnerTest(
     @Test
     fun `skal lage task på behandling som venter på avvent dokumentasjon`() {
         fagsakRepository.insert(Testdata.fagsak)
-        val behandling = behandlingRepository.insert(Testdata.behandling.copy(status = Behandlingsstatus.UTREDES))
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling().copy(status = Behandlingsstatus.UTREDES))
         val tidsfrist = LocalDate.now().minusWeeks(1)
         behandlingsstegstilstandRepository.insert(
-            Testdata.behandlingsstegstilstand.copy(
+            Testdata.lagBehandlingsstegstilstand(behandling.id).copy(
                 behandlingssteg = Behandlingssteg.VILKÅRSVURDERING,
                 behandlingsstegsstatus = Behandlingsstegstatus.VENTER,
                 venteårsak = Venteårsak.AVVENTER_DOKUMENTASJON,

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskGjenopptaBehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskGjenopptaBehandlingTaskTest.kt
@@ -48,17 +48,17 @@ internal class AutomatiskGjenopptaBehandlingTaskTest : OppslagSpringRunnerTest()
     @Test
     fun `skal gjenoppta behandling som venter på varsel og har allerede fått kravgrunnlag til FAKTA steg`() {
         fagsakRepository.insert(Testdata.fagsak)
-        val behandling = behandlingRepository.insert(Testdata.behandling.copy(status = Behandlingsstatus.UTREDES))
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling().copy(status = Behandlingsstatus.UTREDES))
         val tidsfrist = LocalDate.now().minusWeeks(4)
         behandlingsstegstilstandRepository.insert(
-            Testdata.behandlingsstegstilstand.copy(
+            Testdata.lagBehandlingsstegstilstand(behandling.id).copy(
                 behandlingssteg = Behandlingssteg.VARSEL,
                 behandlingsstegsstatus = Behandlingsstegstatus.VENTER,
                 venteårsak = Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING,
                 tidsfrist = tidsfrist,
             ),
         )
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
 
         shouldNotThrow<RuntimeException> { automatiskGjenopptaBehandlingTask.doTask(lagTask(behandling.id)) }
         val behandlingsstegstilstand = behandlingsstegstilstandRepository.findByBehandlingId(behandling.id)
@@ -90,10 +90,10 @@ internal class AutomatiskGjenopptaBehandlingTaskTest : OppslagSpringRunnerTest()
     @Test
     fun `skal gjenoppta behandling som venter på varsel og har ikke fått kravgrunnlag til GRUNNLAG steg`() {
         fagsakRepository.insert(Testdata.fagsak)
-        val behandling = behandlingRepository.insert(Testdata.behandling.copy(status = Behandlingsstatus.UTREDES))
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling().copy(status = Behandlingsstatus.UTREDES))
         val tidsfrist = LocalDate.now().minusWeeks(4)
         behandlingsstegstilstandRepository.insert(
-            Testdata.behandlingsstegstilstand.copy(
+            Testdata.lagBehandlingsstegstilstand(behandling.id).copy(
                 behandlingssteg = Behandlingssteg.VARSEL,
                 behandlingsstegsstatus = Behandlingsstegstatus.VENTER,
                 venteårsak = Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING,
@@ -147,17 +147,17 @@ internal class AutomatiskGjenopptaBehandlingTaskTest : OppslagSpringRunnerTest()
     @Test
     fun `skal gjenoppta behandling som venter på avvent dokumentasjon`() {
         fagsakRepository.insert(Testdata.fagsak)
-        val behandling = behandlingRepository.insert(Testdata.behandling.copy(status = Behandlingsstatus.UTREDES))
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling().copy(status = Behandlingsstatus.UTREDES))
         val tidsfrist = LocalDate.now().minusWeeks(1)
         behandlingsstegstilstandRepository.insert(
-            Testdata.behandlingsstegstilstand.copy(
+            Testdata.lagBehandlingsstegstilstand(behandling.id).copy(
                 behandlingssteg = Behandlingssteg.VILKÅRSVURDERING,
                 behandlingsstegsstatus = Behandlingsstegstatus.VENTER,
                 venteårsak = Venteårsak.AVVENTER_DOKUMENTASJON,
                 tidsfrist = tidsfrist,
             ),
         )
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         shouldNotThrow<RuntimeException> { automatiskGjenopptaBehandlingTask.doTask(lagTask(behandling.id)) }
 
         val behandlingsstegstilstand = behandlingsstegstilstandRepository.findByBehandlingId(behandling.id)

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingBatchTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingBatchTest.kt
@@ -57,7 +57,7 @@ internal class AutomatiskSaksbehandlingBatchTest : OppslagSpringRunnerTest() {
     private lateinit var automatiskSaksbehandlingBatch: AutomatiskSaksbehandlingBatch
 
     private val fagsak: Fagsak = Testdata.fagsak
-    private val behandling: Behandling = Testdata.behandling
+    private val behandling: Behandling = Testdata.lagBehandling()
 
     @BeforeEach
     fun init() {
@@ -82,7 +82,7 @@ internal class AutomatiskSaksbehandlingBatchTest : OppslagSpringRunnerTest() {
             )
 
         val kravgrunnlag =
-            Testdata.kravgrunnlag431
+            Testdata.lagKravgrunnlag(behandling.id)
                 .copy(
                     kontrollfelt = "2019-11-22-19.09.31.458065",
                     perioder =
@@ -144,7 +144,7 @@ internal class AutomatiskSaksbehandlingBatchTest : OppslagSpringRunnerTest() {
                         .OPPRETT_TILBAKEKREVING_MED_VARSEL,
             )
         behandlingRepository.update(behandling.copy(fagsystemsbehandling = setOf(fagsystemsbehandling)))
-        brevsporingRepository.insert(Testdata.brevsporing)
+        brevsporingRepository.insert(Testdata.lagBrevsporing(behandling.id))
 
         automatiskSaksbehandlingBatch.behandleAutomatisk()
         taskService.findAll().any {

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingTaskTest.kt
@@ -90,10 +90,11 @@ internal class AutomatiskSaksbehandlingTaskTest : OppslagSpringRunnerTest() {
     private lateinit var automatiskSaksbehandlingTask: AutomatiskSaksbehandlingTask
 
     private val fagsak: Fagsak = Testdata.fagsak
-    private val behandling: Behandling = Testdata.behandling
+    private lateinit var behandling: Behandling
 
     @BeforeEach
     fun init() {
+        behandling = Testdata.lagBehandling()
         fagsakRepository.insert(fagsak)
         val fagsystemsbehandling =
             behandling.aktivFagsystemsbehandling.copy(
@@ -115,7 +116,7 @@ internal class AutomatiskSaksbehandlingTaskTest : OppslagSpringRunnerTest() {
             )
 
         val kravgrunnlag =
-            Testdata.kravgrunnlag431
+            Testdata.lagKravgrunnlag(behandling.id)
                 .copy(
                     kontrollfelt = "2019-11-22-19.09.31.458065",
                     perioder =

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/steg/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/steg/StegServiceTest.kt
@@ -122,7 +122,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun init() {
         fagsak = Testdata.fagsak
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         behandlingId = behandling.id
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
@@ -146,7 +146,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
             Behandlingsstegstatus.VENTER,
             Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG,
         )
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
 
         stegService.håndterSteg(behandlingId)
         val behandlingsstegstilstand = behandlingsstegstilstandRepository.findByBehandlingId(behandlingId)
@@ -161,7 +161,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
             Behandlingsstegstatus.VENTER,
             Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG,
         )
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
 
         stegService.håndterSteg(behandlingId)
         val behandlingsstegstilstand = behandlingsstegstilstandRepository.findByBehandlingId(behandlingId)
@@ -213,7 +213,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `håndterSteg skal utføre faktafeilutbetalingssteg for behandling`() {
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.KLAR)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
 
         val behandlingsstegFaktaDto = lagBehandlingsstegFaktaDto()
         stegService.håndterSteg(behandlingId, behandlingsstegFaktaDto)
@@ -240,7 +240,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
         lagBehandlingsstegstilstand(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.AUTOUTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FORESLÅ_VEDTAK, Behandlingsstegstatus.KLAR)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
 
         val behandlingsstegFaktaDto = lagBehandlingsstegFaktaDto()
 
@@ -274,7 +274,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
         lagBehandlingsstegstilstand(Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FORESLÅ_VEDTAK, Behandlingsstegstatus.KLAR)
 
-        var kravgrunnlag431 = Testdata.kravgrunnlag431
+        var kravgrunnlag431 = Testdata.lagKravgrunnlag(behandling.id)
         for (grunnlagsperiode in kravgrunnlag431.perioder) {
             kravgrunnlag431 =
                 kravgrunnlag431.copy(
@@ -337,7 +337,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.KLAR)
 
-        var kravgrunnlag431 = Testdata.kravgrunnlag431
+        var kravgrunnlag431 = Testdata.lagKravgrunnlag(behandling.id)
         for (grunnlagsperiode in kravgrunnlag431.perioder) {
             kravgrunnlag431 =
                 kravgrunnlag431.copy(
@@ -426,7 +426,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
                         ),
                 )
 
-        val kravgrunnlag431 = Testdata.kravgrunnlag431.copy(perioder = setOf(førstePeriode, andrePeriode))
+        val kravgrunnlag431 = Testdata.lagKravgrunnlag(behandling.id).copy(perioder = setOf(førstePeriode, andrePeriode))
         kravgrunnlagRepository.insert(kravgrunnlag431)
         val behandlingsstegForeldelseDto =
             BehandlingsstegForeldelseDto(
@@ -463,7 +463,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.KLAR)
 
-        var kravgrunnlag431 = Testdata.kravgrunnlag431
+        var kravgrunnlag431 = Testdata.lagKravgrunnlag(behandling.id)
         for (grunnlagsperiode in kravgrunnlag431.perioder) {
             kravgrunnlag431 =
                 kravgrunnlag431.copy(
@@ -553,7 +553,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
     fun `håndterSteg skal utføre foreslå vedtak og forsette til fatte vedtak`() {
         // behandle fakta steg
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.KLAR)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         val behandlingsstegFaktaDto = lagBehandlingsstegFaktaDto()
         stegService.håndterSteg(behandlingId, lagBehandlingsstegFaktaDto())
 
@@ -595,7 +595,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
     fun `håndterSteg skal utføre foreslå vedtak på nytt når beslutter underkjente steg og forsette til fatte vedtak`() {
         // behandle fakta steg
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.KLAR)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         stegService.håndterSteg(behandlingId, lagBehandlingsstegFaktaDto())
 
         // behandle vilkårsvurderingssteg
@@ -642,7 +642,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `håndterSteg skal utføre fatte vedtak og forsette til iverksette vedtak når beslutter godkjenner alt`() {
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
 
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.AUTOUTFØRT)
@@ -682,7 +682,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `håndterSteg skal tilbakeføre fatte vedtak og flytte til foreslå vedtak når beslutter underkjente steg`() {
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.AUTOUTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.UTFØRT)
@@ -757,7 +757,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `håndterSteg skal opprette og utføre verge steg når behandling er på foreslå vedtak`() {
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.AUTOUTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.UTFØRT)
@@ -838,7 +838,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
             Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING,
         )
 
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
 
         stegService.gjenopptaSteg(behandlingId)
 
@@ -880,7 +880,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
             Behandlingsstegstatus.VENTER,
             Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG,
         )
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
 
         stegService.gjenopptaSteg(behandlingId)
 
@@ -896,7 +896,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `gjenopptaSteg skal gjenoppta behandling når behandling er i vilkårsvurderingssteg`() {
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         lagBehandlingsstegstilstand(
             Behandlingssteg.VILKÅRSVURDERING,
             Behandlingsstegstatus.VENTER,

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/task/OppdaterFaktainfoTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/task/OppdaterFaktainfoTaskTest.kt
@@ -54,7 +54,7 @@ internal class OppdaterFaktainfoTaskTest : OppslagSpringRunnerTest() {
         hentFagsystemsbehandlingService = HentFagsystemsbehandlingService(requestSendtRepository, mockKafkaProducer)
         oppdaterFaktainfoTask = OppdaterFaktainfoTask(hentFagsystemsbehandlingService, behandlingService)
         fagsak = Testdata.fagsak
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingsstegstilstandRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingsstegstilstandRepositoryTest.kt
@@ -23,12 +23,13 @@ internal class BehandlingsstegstilstandRepositoryTest : OppslagSpringRunnerTest(
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
-    private val behandlingsstegstilstand = Testdata.behandlingsstegstilstand
+    private lateinit var behandlingsstegstilstand: Behandlingsstegstilstand
 
     @BeforeEach
     fun init() {
         fagsakRepository.insert(Testdata.fagsak)
-        behandlingRepository.insert(Testdata.behandling)
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling())
+        behandlingsstegstilstand = Testdata.lagBehandlingsstegstilstand(behandling.id)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/tilbake/data/Testdata.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/data/Testdata.kt
@@ -107,25 +107,6 @@ object Testdata {
 
     val behandlingsresultat = Behandlingsresultat(behandlingsvedtak = behandlingsvedtak)
 
-    val behandling =
-        Behandling(
-            fagsakId = fagsak.id,
-            type = Behandlingstype.TILBAKEKREVING,
-            opprettetDato = LocalDate.now(),
-            avsluttetDato = null,
-            ansvarligSaksbehandler = "saksbehandler",
-            ansvarligBeslutter = "beslutter",
-            behandlendeEnhet = "testverdi",
-            behandlendeEnhetsNavn = "testverdi",
-            manueltOpprettet = false,
-            fagsystemsbehandling = setOf(fagsystemsbehandling),
-            resultater = setOf(behandlingsresultat),
-            varsler = setOf(varsel),
-            verger = setOf(verge),
-            eksternBrukId = UUID.randomUUID(),
-            begrunnelseForTilbakekreving = null,
-        )
-
     fun lagBehandling() =
         Behandling(
             fagsakId = fagsak.id,
@@ -145,13 +126,13 @@ object Testdata {
             begrunnelseForTilbakekreving = null,
         )
 
-    val revurdering =
+    fun lagRevurdering(originalBehandlingId: UUID) =
         Behandling(
             fagsakId = fagsak.id,
             årsaker =
                 setOf(
                     Behandlingsårsak(
-                        originalBehandlingId = behandling.id,
+                        originalBehandlingId = originalBehandlingId,
                         type = Behandlingsårsakstype.REVURDERING_KLAGE_KA,
                     ),
                 ),
@@ -169,22 +150,16 @@ object Testdata {
             begrunnelseForTilbakekreving = null,
         )
 
-    val behandlingsårsak =
-        Behandlingsårsak(
-            type = Behandlingsårsakstype.REVURDERING_KLAGE_KA,
-            originalBehandlingId = behandling.id,
-        )
-
-    val behandlingsstegstilstand =
+    fun lagBehandlingsstegstilstand(behandlingId: UUID) =
         Behandlingsstegstilstand(
-            behandlingId = behandling.id,
+            behandlingId = behandlingId,
             behandlingssteg = Behandlingssteg.FAKTA,
             behandlingsstegsstatus = Behandlingsstegstatus.KLAR,
         )
 
-    val totrinnsvurdering =
+    fun lagTotrinnsvurdering(behandlingId: UUID) =
         Totrinnsvurdering(
-            behandlingId = behandling.id,
+            behandlingId = behandlingId,
             behandlingssteg = Behandlingssteg.FAKTA,
             godkjent = true,
             begrunnelse = "testverdi",
@@ -199,9 +174,9 @@ object Testdata {
             oppdagelsesdato = LocalDate.now(),
         )
 
-    val vurdertForeldelse =
+    fun lagVurdertForeldelse(behandlingId: UUID) =
         VurdertForeldelse(
-            behandlingId = behandling.id,
+            behandlingId = behandlingId,
             foreldelsesperioder = setOf(foreldelsesperiode),
         )
 
@@ -246,33 +221,6 @@ object Testdata {
                     ytelKravgrunnlagsbeløp433,
                 ),
             månedligSkattebeløp = BigDecimal("123.11"),
-        )
-
-    val kravgrunnlag431 =
-        Kravgrunnlag431(
-            behandlingId = behandling.id,
-            vedtakId = BigInteger.ZERO,
-            kravstatuskode = Kravstatuskode.NYTT,
-            fagområdekode = Fagområdekode.EFOG,
-            fagsystemId = "testverdi",
-            fagsystemVedtaksdato = LocalDate.now(),
-            omgjortVedtakId = BigInteger.ZERO,
-            gjelderVedtakId = "testverdi",
-            gjelderType = GjelderType.PERSON,
-            utbetalesTilId = "testverdi",
-            utbetIdType = GjelderType.PERSON,
-            hjemmelkode = "testverdi",
-            beregnesRenter = true,
-            ansvarligEnhet = "testverdi",
-            bostedsenhet = "testverdi",
-            behandlingsenhet = "testverdi",
-            kontrollfelt = "testverdi",
-            saksbehandlerId = "testverdi",
-            referanse = "testverdi",
-            eksternKravgrunnlagId = BigInteger.ZERO,
-            perioder = setOf(kravgrunnlagsperiode432),
-            aktiv = true,
-            sperret = false,
         )
 
     fun lagKravgrunnlag(behandlingId: UUID) =
@@ -336,9 +284,9 @@ object Testdata {
             godTro = vilkårsvurderingGodTro,
         )
 
-    val vilkårsvurdering =
+    fun lagVilkårsvurdering(behandlingId: UUID) =
         Vilkårsvurdering(
-            behandlingId = behandling.id,
+            behandlingId = behandlingId,
             perioder = setOf(vilkårsperiode),
         )
 
@@ -349,11 +297,11 @@ object Testdata {
             hendelsesundertype = Hendelsesundertype.ANNET_FRITEKST,
         )
 
-    val faktaFeilutbetaling =
+    fun lagFaktaFeilutbetaling(behandlingId: UUID) =
         FaktaFeilutbetaling(
             begrunnelse = "testverdi",
             aktiv = true,
-            behandlingId = behandling.id,
+            behandlingId = behandlingId,
             perioder =
                 setOf(
                     FaktaFeilutbetalingsperiode(
@@ -385,38 +333,38 @@ object Testdata {
             ytelsestype = Ytelsestype.BARNETRYGD,
         )
 
-    val vedtaksbrevsoppsummering =
+    fun lagVedtaksbrevsoppsummering(behandlingId: UUID) =
         Vedtaksbrevsoppsummering(
-            behandlingId = behandling.id,
+            behandlingId = behandlingId,
             oppsummeringFritekst = "testverdi",
         )
 
-    val vedtaksbrevsperiode =
+    fun lagVedtaksbrevsperiode(behandlingId: UUID) =
         Vedtaksbrevsperiode(
-            behandlingId = behandling.id,
+            behandlingId = behandlingId,
             periode = Månedsperiode(LocalDate.now(), LocalDate.now()),
             fritekst = "testverdi",
             fritekststype = Friteksttype.FAKTA,
         )
 
-    val økonomiXmlSendt =
+    fun lagØkonomiXmlSendt(behandlingId: UUID) =
         ØkonomiXmlSendt(
-            behandlingId = behandling.id,
+            behandlingId = behandlingId,
             melding = "testverdi",
             kvittering = "testverdi",
         )
 
-    val brevsporing =
+    fun lagBrevsporing(behandlingId: UUID) =
         Brevsporing(
-            behandlingId = behandling.id,
+            behandlingId = behandlingId,
             journalpostId = "testverdi",
             dokumentId = "testverdi",
             brevtype = Brevtype.VARSEL,
         )
 
-    val vedtaksbrevbehandling =
+    fun lagVedtaksbrevbehandling(behandling: Behandling) =
         Vedtaksbrevbehandling(
-            id = fagsak.id,
+            id = behandling.fagsakId,
             type = Behandlingstype.TILBAKEKREVING,
             ansvarligSaksbehandler = "saksbehandler",
             ansvarligBeslutter = "beslutter",
@@ -426,17 +374,17 @@ object Testdata {
             resultater = setOf(behandlingsresultat),
             varsler = setOf(varsel),
             verger = setOf(verge),
-            vedtaksbrevOppsummering = vedtaksbrevsoppsummering,
+            vedtaksbrevOppsummering = lagVedtaksbrevsoppsummering(behandling.id),
         )
 
-    val vedtaksbrevgrunnlag =
+    fun lagVedtaksbrevgrunnlag(behandling: Behandling) =
         Vedtaksbrevgrunnlag(
             id = behandling.id,
             bruker = bruker,
             eksternFagsakId = "testverdi",
             fagsystem = Fagsystem.BA,
             ytelsestype = Ytelsestype.BARNETRYGD,
-            behandlinger = setOf(vedtaksbrevbehandling),
+            behandlinger = setOf(lagVedtaksbrevbehandling(behandling)),
         )
 
     fun lagFeilBeløp(feilutbetaling: BigDecimal): Kravgrunnlagsbeløp433 {

--- a/src/test/kotlin/no/nav/familie/tilbake/datavarehus/saksstatistikk/BehandlingTilstandServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/datavarehus/saksstatistikk/BehandlingTilstandServiceTest.kt
@@ -31,6 +31,7 @@ import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
 import no.nav.familie.tilbake.behandlingskontroll.domain.Venteårsak
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.data.Testdata
+import no.nav.familie.tilbake.data.Testdata.behandlingsresultat
 import no.nav.familie.tilbake.faktaomfeilutbetaling.FaktaFeilutbetalingService
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
 import org.junit.jupiter.api.BeforeEach
@@ -80,7 +81,7 @@ class BehandlingTilstandServiceTest : OppslagSpringRunnerTest() {
             )
 
         fagsakRepository.insert(Testdata.fagsak)
-        behandling = behandlingRepository.insert(Testdata.behandling)
+        behandling = behandlingRepository.insert(Testdata.lagBehandling())
     }
 
     @Test
@@ -161,8 +162,8 @@ class BehandlingTilstandServiceTest : OppslagSpringRunnerTest() {
                 resultater = setOf(behandlingsresultat),
             )
         behandlingRepository.update(fattetBehandling)
-        behandlingsstegstilstandRepository.insert(Testdata.behandlingsstegstilstand.copy(behandlingssteg = Behandlingssteg.FATTE_VEDTAK))
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        behandlingsstegstilstandRepository.insert(Testdata.lagBehandlingsstegstilstand(behandling.id).copy(behandlingssteg = Behandlingssteg.FATTE_VEDTAK))
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
 
         val tilstand = service.hentBehandlingensTilstand(behandling.id)
 
@@ -191,8 +192,8 @@ class BehandlingTilstandServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentBehandlingensTilstand skal utlede behandlingstilstand for behandling på vent`() {
-        behandlingsstegstilstandRepository.insert(Testdata.behandlingsstegstilstand)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        behandlingsstegstilstandRepository.insert(Testdata.lagBehandlingsstegstilstand(behandling.id))
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         behandlingService.settBehandlingPåVent(
             behandling.id,
             BehandlingPåVentDto(
@@ -210,7 +211,7 @@ class BehandlingTilstandServiceTest : OppslagSpringRunnerTest() {
         tilstand.referertFagsaksbehandling shouldBe behandling.aktivFagsystemsbehandling.eksternId
         tilstand.behandlingstype shouldBe behandling.type
         tilstand.behandlingsstatus shouldBe behandling.status
-        tilstand.behandlingsresultat shouldBe Testdata.behandlingsresultat.type
+        tilstand.behandlingsresultat shouldBe behandlingsresultat.type
         tilstand.venterPåBruker shouldBe true
         tilstand.venterPåØkonomi shouldBe false
         tilstand.funksjoneltTidspunkt.shouldBeBetween(

--- a/src/test/kotlin/no/nav/familie/tilbake/datavarehus/saksstatistikk/VedtaksoppsummeringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/datavarehus/saksstatistikk/VedtaksoppsummeringServiceTest.kt
@@ -95,7 +95,7 @@ class VedtaksoppsummeringServiceTest : OppslagSpringRunnerTest() {
             )
 
         behandling =
-            Testdata.behandling.copy(
+            Testdata.lagBehandling().copy(
                 ansvarligSaksbehandler = ANSVARLIG_SAKSBEHANDLER,
                 ansvarligBeslutter = ANSVARLIG_BESLUTTER,
                 behandlendeEnhet = "8020",
@@ -245,7 +245,7 @@ class VedtaksoppsummeringServiceTest : OppslagSpringRunnerTest() {
                 begrunnelse = "vilkår begrunnelse",
                 aktsomhet = vilkårVurderingAktsomhet,
             )
-        val vilkårVurdering = Testdata.vilkårsvurdering.copy(perioder = setOf(vilkårVurderingPeriode))
+        val vilkårVurdering = Testdata.lagVilkårsvurdering(behandling.id).copy(perioder = setOf(vilkårVurderingPeriode))
 
         vilkårsvurderingRepository.insert(vilkårVurdering)
     }
@@ -264,7 +264,7 @@ class VedtaksoppsummeringServiceTest : OppslagSpringRunnerTest() {
                 begrunnelse = "vilkår begrunnelse",
                 godTro = vilkårVurderingGodTro,
             )
-        val vilkårsvurdering = Testdata.vilkårsvurdering.copy(perioder = setOf(vilkårVurderingPeriode))
+        val vilkårsvurdering = Testdata.lagVilkårsvurdering(behandling.id).copy(perioder = setOf(vilkårVurderingPeriode))
         vilkårsvurderingRepository.insert(vilkårsvurdering)
     }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DistribusjonshåndteringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DistribusjonshåndteringServiceTest.kt
@@ -91,7 +91,7 @@ class DistribusjonshåndteringServiceTest {
             featureToggleService = featureToggleService,
         )
 
-    private val behandling = Testdata.behandling
+    private val behandling = Testdata.lagBehandling()
     private val fagsak = Testdata.fagsak
     private val personinfoBruker = Personinfo(fagsak.bruker.ident, LocalDate.now(), navn = "brukernavn")
     private val brukerAdresse = Adresseinfo(personinfoBruker.ident, personinfoBruker.navn)
@@ -112,7 +112,7 @@ class DistribusjonshåndteringServiceTest {
         } returns vergeAdresse
         every { eksterneDataForBrevService.hentSaksbehandlernavn(any()) } returns behandling.ansvarligSaksbehandler
         every { eksterneDataForBrevService.hentPåloggetSaksbehandlernavnMedDefault(any()) } returns behandling.ansvarligSaksbehandler
-        every { brevsporingService.finnSisteVarsel(any()) } returns Testdata.brevsporing
+        every { brevsporingService.finnSisteVarsel(any()) } returns Testdata.lagBrevsporing(behandling.id)
         every { featureToggleService.isEnabled(any()) } returns false
     }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DokumentBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DokumentBehandlingServiceTest.kt
@@ -68,8 +68,8 @@ class DokumentBehandlingServiceTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun init() {
         fagsak = fagsakRepository.insert(Testdata.fagsak)
-        behandling = behandlingRepository.insert(Testdata.behandling)
-        behandlingsstegstilstandRepository.insert(Testdata.behandlingsstegstilstand)
+        behandling = behandlingRepository.insert(Testdata.lagBehandling())
+        behandlingsstegstilstandRepository.insert(Testdata.lagBehandlingsstegstilstand(behandling.id))
         dokumentBehandlingService =
             DokumentbehandlingService(
                 behandlingRepository,

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/BrevsporingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/BrevsporingRepositoryTest.kt
@@ -26,12 +26,13 @@ internal class BrevsporingRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
-    private val brevsporing = Testdata.brevsporing
+    private lateinit var brevsporing: Brevsporing
 
     @BeforeEach
     fun init() {
         fagsakRepository.insert(Testdata.fagsak)
-        behandlingRepository.insert(Testdata.behandling)
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling())
+        brevsporing = Testdata.lagBrevsporing(behandling.id)
     }
 
     @Test
@@ -71,7 +72,7 @@ internal class BrevsporingRepositoryTest : OppslagSpringRunnerTest() {
 
         val funnetBrevsporing =
             brevsporingRepository.findFirstByBehandlingIdAndBrevtypeOrderBySporbarOpprettetTidDesc(
-                Testdata.behandling.id,
+                brevsporing.behandlingId,
                 Brevtype.VARSEL,
             )
 

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/pdf/PdfBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/pdf/PdfBrevServiceTest.kt
@@ -44,7 +44,7 @@ internal class PdfBrevServiceTest {
         val brevdata = lagBrevdata()
 
         pdfBrevService.sendBrev(
-            Testdata.behandling,
+            Testdata.lagBehandling(),
             Testdata.fagsak,
             brevtype = Brevtype.VARSEL,
             brevdata,
@@ -69,7 +69,7 @@ internal class PdfBrevServiceTest {
         every { taskService.save(capture(slot)) } returns mockk()
         val brevdata = lagBrevdata()
 
-        pdfBrevService.sendBrev(Testdata.behandling, Testdata.fagsak, brevtype = Brevtype.VEDTAK, brevdata)
+        pdfBrevService.sendBrev(Testdata.lagBehandling(), Testdata.fagsak, brevtype = Brevtype.VEDTAK, brevdata)
 
         val task = slot.captured
 
@@ -86,7 +86,7 @@ internal class PdfBrevServiceTest {
         every { taskService.save(capture(slot)) } returns mockk()
         val brevdata = lagBrevdata()
 
-        pdfBrevService.sendBrev(Testdata.behandling, Testdata.fagsak, brevtype = Brevtype.HENLEGGELSE, brevdata)
+        pdfBrevService.sendBrev(Testdata.lagBehandling(), Testdata.fagsak, brevtype = Brevtype.HENLEGGELSE, brevdata)
 
         val task = slot.captured
 
@@ -106,7 +106,7 @@ internal class PdfBrevServiceTest {
                 metadata = this.metadata.copy(institusjon = Institusjon("876543210", "Foo & Bar AS"))
             }
 
-        pdfBrevService.sendBrev(Testdata.behandling, Testdata.fagsak, brevtype = Brevtype.HENLEGGELSE, brevdata)
+        pdfBrevService.sendBrev(Testdata.lagBehandling(), Testdata.fagsak, brevtype = Brevtype.HENLEGGELSE, brevdata)
 
         val task = slot.captured
 

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/task/DistribuerDokumentVedDødsfallTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/task/DistribuerDokumentVedDødsfallTaskTest.kt
@@ -43,7 +43,7 @@ internal class DistribuerDokumentVedDødsfallTaskTest : OppslagSpringRunnerTest(
 
     @BeforeEach
     fun init() {
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         behandlingId = behandling.id
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/task/LagreBrevsporingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/task/LagreBrevsporingTaskTest.kt
@@ -51,7 +51,7 @@ internal class LagreBrevsporingTaskTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun init() {
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         behandlingId = behandling.id
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/innhentdokumentasjon/InnhentDokumentasjonbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/innhentdokumentasjon/InnhentDokumentasjonbrevServiceTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Verge
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.config.FeatureToggleService
@@ -49,6 +50,8 @@ class InnhentDokumentasjonbrevServiceTest : OppslagSpringRunnerTest() {
             featureToggleService = featureToggleService,
         )
 
+    lateinit var behandling: Behandling
+
     @BeforeEach
     fun setup() {
         spyPdfBrevService = spyk(pdfBrevService)
@@ -62,8 +65,9 @@ class InnhentDokumentasjonbrevServiceTest : OppslagSpringRunnerTest() {
                 distribusjonshåndteringService,
                 brevmetadataUtil,
             )
+        behandling = Testdata.lagBehandling()
         every { fagsakRepository.findByIdOrThrow(Testdata.fagsak.id) } returns Testdata.fagsak
-        every { behandlingRepository.findByIdOrThrow(Testdata.behandling.id) } returns Testdata.behandling
+        every { behandlingRepository.findByIdOrThrow(behandling.id) } returns behandling
         val personinfo = Personinfo("DUMMY_FØDSELSNUMMER", LocalDate.now(), "Fiona")
         val ident = Testdata.fagsak.bruker.ident
         every { mockEksterneDataForBrevService.hentPerson(ident, Fagsystem.BA) } returns personinfo
@@ -76,7 +80,7 @@ class InnhentDokumentasjonbrevServiceTest : OppslagSpringRunnerTest() {
     fun `hentForhåndsvisningInnhentDokumentasjonBrev returnere pdf for innhent dokumentasjonbrev`() {
         val data =
             innhentDokumentasjonBrevService.hentForhåndsvisningInnhentDokumentasjonBrev(
-                Testdata.behandling.id,
+                behandling.id,
                 flereOpplysninger,
             )
 

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
@@ -99,7 +99,7 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun init() {
         fagsakRepository.insert(Testdata.fagsak)
-        behandling = behandlingRepository.insert(Testdata.behandling)
+        behandling = behandlingRepository.insert(Testdata.lagBehandling())
 
         manuellBrevmottakerService =
             ManuellBrevmottakerService(
@@ -260,7 +260,7 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `opprettBrevmottakerSteg skal ikke opprette steg når behandling er på vent`() {
-        val behandling = behandlingRepository.findByIdOrThrow(Testdata.behandling.id)
+        val behandling = behandlingRepository.findByIdOrThrow(behandling.id)
         lagBehandlingsstegstilstand(behandling.id, Behandlingssteg.FAKTA, Behandlingsstegstatus.KLAR)
 
         behandlingskontrollService.settBehandlingPåVent(
@@ -275,7 +275,7 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `fjernManuelleBrevmottakereOgTilbakeførSteg skal fjerne brevmottakere og tilbakeføre steget`() {
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         lagBehandlingsstegstilstand(behandling.id, Behandlingssteg.FAKTA, Behandlingsstegstatus.KLAR)
 
         manuellBrevmottakerService.opprettBrevmottakerSteg(behandling.id)

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/varsel/manuelt/ManueltVarselbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/varsel/manuelt/ManueltVarselbrevServiceTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.tilbake.api.dto.FaktaFeilutbetalingDto
 import no.nav.familie.tilbake.api.dto.FeilutbetalingsperiodeDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Varsel
 import no.nav.familie.tilbake.behandling.domain.Verge
 import no.nav.familie.tilbake.config.FeatureToggleService
@@ -59,13 +60,14 @@ class ManueltVarselbrevServiceTest : OppslagSpringRunnerTest() {
     private val mockDistribusjonshåndteringService: DistribusjonshåndteringService = mockk()
     private lateinit var spyPdfBrevService: PdfBrevService
     private lateinit var manueltVarselbrevService: ManueltVarselbrevService
-    private var behandling = Testdata.behandling
+    private lateinit var behandling: Behandling
     private var fagsak = Testdata.fagsak
     private lateinit var brevmetadataUtil: BrevmetadataUtil
     private val featureToggleService = mockk<FeatureToggleService>(relaxed = true)
 
     @BeforeEach
     fun setup() {
+        behandling = Testdata.lagBehandling()
         spyPdfBrevService = spyk(pdfBrevService)
 
         brevmetadataUtil =

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtakHjemmelTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtakHjemmelTest.kt
@@ -43,12 +43,12 @@ class VedtakHjemmelTest {
         vurderingPerioder: Set<Vilkårsvurderingsperiode>,
     ): Vedtaksbrevgrunnlag {
         val behandling =
-            Testdata.vedtaksbrevbehandling
+            Testdata.lagVedtaksbrevbehandling(Testdata.lagBehandling())
                 .copy(
                     vurderteForeldelser = vurdertForeldelse?.let { setOf(it) } ?: setOf(),
-                    vilkårsvurdering = setOf(Testdata.vilkårsvurdering.copy(perioder = vurderingPerioder)),
+                    vilkårsvurdering = setOf(Testdata.lagVilkårsvurdering(Testdata.lagBehandling().id).copy(perioder = vurderingPerioder)),
                 )
-        return Testdata.vedtaksbrevgrunnlag.copy(behandlinger = setOf(behandling), ytelsestype = Ytelsestype.OVERGANGSSTØNAD)
+        return Testdata.lagVedtaksbrevgrunnlag(Testdata.lagBehandling()).copy(behandlinger = setOf(behandling), ytelsestype = Ytelsestype.OVERGANGSSTØNAD)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevsoppsummeringRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevsoppsummeringRepositoryTest.kt
@@ -22,12 +22,15 @@ internal class VedtaksbrevsoppsummeringRepositoryTest : OppslagSpringRunnerTest(
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
-    private val vedtaksbrevsoppsummering = Testdata.vedtaksbrevsoppsummering
+    private lateinit var vedtaksbrevsoppsummering: Vedtaksbrevsoppsummering
 
     @BeforeEach
     fun init() {
         fagsakRepository.insert(Testdata.fagsak)
-        behandlingRepository.insert(Testdata.behandling)
+        Testdata.lagBehandling().apply {
+            behandlingRepository.insert(this)
+            vedtaksbrevsoppsummering = Testdata.lagVedtaksbrevsoppsummering(this.id)
+        }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevsperiodeRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevsperiodeRepositoryTest.kt
@@ -22,12 +22,13 @@ internal class VedtaksbrevsperiodeRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
-    private val vedtaksbrevsperiode = Testdata.vedtaksbrevsperiode
+    private lateinit var vedtaksbrevsperiode: Vedtaksbrevsperiode
 
     @BeforeEach
     fun init() {
         fagsakRepository.insert(Testdata.fagsak)
-        behandlingRepository.insert(Testdata.behandling)
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling())
+        vedtaksbrevsperiode = Testdata.lagVedtaksbrevsperiode(behandling.id)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/tilbake/faktaomfeilutbetaling/FaktaFeilutbetalingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/faktaomfeilutbetaling/FaktaFeilutbetalingRepositoryTest.kt
@@ -31,8 +31,8 @@ internal class FaktaFeilutbetalingRepositoryTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun init() {
         fagsak = Testdata.fagsak
-        behandling = Testdata.behandling
-        faktaFeilutbetaling = Testdata.faktaFeilutbetaling
+        behandling = Testdata.lagBehandling()
+        faktaFeilutbetaling = Testdata.lagFaktaFeilutbetaling(behandling.id)
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/faktaomfeilutbetaling/FaktaFeilutbetalingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/faktaomfeilutbetaling/FaktaFeilutbetalingServiceTest.kt
@@ -49,11 +49,11 @@ internal class FaktaFeilutbetalingServiceTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun init() {
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
         val kravgrunnlag =
-            Testdata.kravgrunnlag431
+            Testdata.lagKravgrunnlag(behandling.id)
                 .copy(
                     perioder =
                         setOf(

--- a/src/test/kotlin/no/nav/familie/tilbake/foreldelse/ForeldelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/foreldelse/ForeldelseServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.tilbake.api.dto.BehandlingsstegForeldelseDto
 import no.nav.familie.tilbake.api.dto.ForeldelsesperiodeDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.foreldelse.domain.Foreldelsesvurderingstype
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
@@ -42,14 +43,14 @@ internal class ForeldelseServiceTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var foreldelseService: ForeldelseService
 
-    private var behandling = Testdata.behandling
+    private lateinit var behandling: Behandling
 
     @BeforeEach
     fun init() {
         fagsakRepository.insert(Testdata.fagsak)
-        behandling = behandlingRepository.insert(Testdata.behandling)
+        behandling = behandlingRepository.insert(Testdata.lagBehandling())
 
-        val kravgrunnlag431 = Testdata.kravgrunnlag431
+        val kravgrunnlag431 = Testdata.lagKravgrunnlag(behandling.id)
         val feilkravgrunnlagsbeløp = Testdata.feilKravgrunnlagsbeløp433
         val yteseskravgrunnlagsbeløp = Testdata.ytelKravgrunnlagsbeløp433
         val førsteKravgrunnlagsperiode =
@@ -222,7 +223,7 @@ internal class ForeldelseServiceTest : OppslagSpringRunnerTest() {
                 Foreldelsesvurderingstype.IKKE_FORELDET,
             )
         foreldelseService.lagreVurdertForeldelse(behandling.id, BehandlingsstegForeldelseDto(listOf(forrigeForeldelsesperiode)))
-        vilkårsvurderingRepository.insert(Testdata.vilkårsvurdering)
+        vilkårsvurderingRepository.insert(Testdata.lagVilkårsvurdering(behandling.id))
 
         vilkårsvurderingRepository.findByBehandlingIdAndAktivIsTrue(behandling.id).shouldNotBeNull()
 
@@ -259,7 +260,7 @@ internal class ForeldelseServiceTest : OppslagSpringRunnerTest() {
                 Foreldelsesvurderingstype.IKKE_FORELDET,
             )
         foreldelseService.lagreVurdertForeldelse(behandling.id, BehandlingsstegForeldelseDto(listOf(forrigeForeldelsesperiode)))
-        vilkårsvurderingRepository.insert(Testdata.vilkårsvurdering)
+        vilkårsvurderingRepository.insert(Testdata.lagVilkårsvurdering(behandling.id))
 
         vilkårsvurderingRepository.findByBehandlingIdAndAktivIsTrue(behandling.id).shouldNotBeNull()
 

--- a/src/test/kotlin/no/nav/familie/tilbake/foreldelse/VurdertForeldelseRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/foreldelse/VurdertForeldelseRepositoryTest.kt
@@ -22,12 +22,13 @@ internal class VurdertForeldelseRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
-    private val vurdertForeldelse = Testdata.vurdertForeldelse
+    private lateinit var vurdertForeldelse: VurdertForeldelse
 
     @BeforeEach
     fun init() {
         fagsakRepository.insert(Testdata.fagsak)
-        behandlingRepository.insert(Testdata.behandling)
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling())
+        vurdertForeldelse = Testdata.lagVurdertForeldelse(behandling.id)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
@@ -90,7 +90,7 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun init() {
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
         behandlingsstegstilstandRepository
@@ -124,11 +124,11 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `korrigerKravgrunnlag skal hente korrigert kravgrunnlag når behandling allerede har et kravgrunnlag`() {
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
 
         forvaltningService.korrigerKravgrunnlag(
             behandling.id,
-            Testdata.kravgrunnlag431.eksternKravgrunnlagId,
+            Testdata.lagKravgrunnlag(behandling.id).eksternKravgrunnlagId,
         )
 
         val kravgrunnlagene = kravgrunnlagRepository.findByBehandlingId(behandling.id)
@@ -182,8 +182,8 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `tvingHenleggBehandling skal henlegge behandling når behandling ikke er avsluttet`() {
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
-        forvaltningService.korrigerKravgrunnlag(behandling.id, Testdata.kravgrunnlag431.eksternKravgrunnlagId)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
+        forvaltningService.korrigerKravgrunnlag(behandling.id, Testdata.lagKravgrunnlag(behandling.id).eksternKravgrunnlagId)
 
         var behandlingsstegstilstand = behandlingsstegstilstandRepository.findByBehandlingId(behandling.id)
         assertBehandlingssteg(behandlingsstegstilstand, Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
@@ -238,7 +238,7 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
             behandlingRepository.findByIdOrThrow(behandling.id)
                 .copy(status = Behandlingsstatus.IVERKSETTER_VEDTAK),
         )
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         behandlingsstegstilstandRepository
             .update(
                 behandlingsstegstilstandRepository.findByBehandlingIdAndBehandlingssteg(
@@ -248,17 +248,17 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
                     .copy(behandlingsstegsstatus = Behandlingsstegstatus.UTFØRT),
             )
 
-        faktaFeilutbetalingRepository.insert(Testdata.faktaFeilutbetaling)
+        faktaFeilutbetalingRepository.insert(Testdata.lagFaktaFeilutbetaling(behandling.id))
         lagBehandlingssteg(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
         lagBehandlingssteg(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.AUTOUTFØRT)
 
-        vilkårsvurderingRepository.insert(Testdata.vilkårsvurdering)
+        vilkårsvurderingRepository.insert(Testdata.lagVilkårsvurdering(behandling.id))
         lagBehandlingssteg(Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.UTFØRT)
 
-        vedtaksbrevsoppsummeringRepository.insert(Testdata.vedtaksbrevsoppsummering)
+        vedtaksbrevsoppsummeringRepository.insert(Testdata.lagVedtaksbrevsoppsummering(behandling.id))
         lagBehandlingssteg(Behandlingssteg.FORESLÅ_VEDTAK, Behandlingsstegstatus.UTFØRT)
 
-        totrinnRepository.insert(Testdata.totrinnsvurdering)
+        totrinnRepository.insert(Testdata.lagTotrinnsvurdering(behandling.id))
         lagBehandlingssteg(Behandlingssteg.FATTE_VEDTAK, Behandlingsstegstatus.UTFØRT)
         lagBehandlingssteg(Behandlingssteg.IVERKSETT_VEDTAK, Behandlingsstegstatus.KLAR)
 
@@ -303,7 +303,7 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `annulerKravgrunnlag skal annulere kravgrunnlag som er koblet med en behandling`() {
-        val kravgrunnlag = kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        val kravgrunnlag = kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
         shouldNotThrowAny { forvaltningService.annulerKravgrunnlag(kravgrunnlag.eksternKravgrunnlagId) }
     }
 
@@ -323,7 +323,7 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `hentForvaltningsinfo skal hente forvaltningsinfo basert på eksternFagsakId og ytelsestype`() {
         val fagsak = fagsakRepository.findByIdOrThrow(behandling.fagsakId)
-        val kravgrunnlag = Testdata.kravgrunnlag431
+        val kravgrunnlag = Testdata.lagKravgrunnlag(behandling.id)
         kravgrunnlagRepository.insert(
             kravgrunnlag.copy(
                 fagsystemId = fagsak.eksternFagsakId,

--- a/src/test/kotlin/no/nav/familie/tilbake/historikkinnslag/HistorikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/historikkinnslag/HistorikkServiceTest.kt
@@ -70,7 +70,7 @@ internal class HistorikkServiceTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun init() {
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         behandlingId = behandling.id
         fagsak = Testdata.fagsak
         fagsakRepository.insert(fagsak)

--- a/src/test/kotlin/no/nav/familie/tilbake/integration/økonomi/OppdragClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/integration/økonomi/OppdragClientTest.kt
@@ -69,7 +69,7 @@ internal class OppdragClientTest : OppslagSpringRunnerTest() {
     fun init() {
         wireMockServer.start()
         fagsak = Testdata.fagsak
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
         oppdragClient = DefaultOppdragClient(restOperations, URI.create(wireMockServer.baseUrl()))

--- a/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/AvsluttBehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/AvsluttBehandlingTaskTest.kt
@@ -48,7 +48,7 @@ internal class AvsluttBehandlingTaskTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun init() {
         fagsak = Testdata.fagsak
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         behandlingId = behandling.id
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)

--- a/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/IverksettelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/IverksettelseServiceTest.kt
@@ -108,7 +108,7 @@ internal class IverksettelseServiceTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun init() {
         fagsak = Testdata.fagsak
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         behandlingId = behandling.id
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)

--- a/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/TilbakekrevingsvedtakBeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/TilbakekrevingsvedtakBeregningServiceTest.kt
@@ -84,7 +84,7 @@ internal class TilbakekrevingsvedtakBeregningServiceTest : OppslagSpringRunnerTe
 
     @BeforeEach
     fun init() {
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         fagsak = Testdata.fagsak
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)

--- a/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/ØkonomiXmlSendtRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/ØkonomiXmlSendtRepositoryTest.kt
@@ -25,12 +25,13 @@ internal class ØkonomiXmlSendtRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
-    private val økonomiXmlSendt = Testdata.økonomiXmlSendt
+    private lateinit var økonomiXmlSendt: ØkonomiXmlSendt
 
     @BeforeEach
     fun init() {
         fagsakRepository.insert(Testdata.fagsak)
-        behandlingRepository.insert(Testdata.behandling)
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling())
+        økonomiXmlSendt = Testdata.lagØkonomiXmlSendt(behandling.id)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest.kt
@@ -77,7 +77,7 @@ class AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest : OppslagSpringRunn
     @BeforeEach
     fun init() {
         val fagsak = Testdata.fagsak
-        val behandling = Testdata.behandling
+        val behandling = Testdata.lagBehandling()
         val copyFagsystemsbehandling = behandling.fagsystemsbehandling.first().copy(tilbakekrevingsvalg = Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_AUTOMATISK)
         val automatiskBehandling = behandling.copy(fagsystemsbehandling = setOf(copyFagsystemsbehandling))
         val fagsakOvergangsstønad = fagsak.copy(ytelsestype = Ytelsestype.OVERGANGSSTØNAD)

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/BehandleKravgrunnlagTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/BehandleKravgrunnlagTaskTest.kt
@@ -116,7 +116,7 @@ internal class BehandleKravgrunnlagTaskTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun init() {
         fagsak = Testdata.fagsak
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/BehandleStatusmeldingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/BehandleStatusmeldingTaskTest.kt
@@ -80,7 +80,7 @@ internal class BehandleStatusmeldingTaskTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun init() {
         fagsak = Testdata.fagsak
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         fagsakRepository.insert(fagsak)
     }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/HentFagsystemsbehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/HentFagsystemsbehandlingTaskTest.kt
@@ -120,7 +120,7 @@ internal class HentFagsystemsbehandlingTaskTest : OppslagSpringRunnerTest() {
     @Test
     fun `doTask skal kaste exception når det allerede finnes en behandling på samme fagsak`() {
         fagsakRepository.insert(Testdata.fagsak.copy(eksternFagsakId = xmlMottatt.eksternFagsakId))
-        behandlingRepository.insert(Testdata.behandling)
+        behandlingRepository.insert(Testdata.lagBehandling())
 
         val exception = shouldThrow<UgyldigKravgrunnlagFeil> { hentFagsystemsbehandlingTask.doTask(lagTask()) }
         exception.message shouldBe "Kravgrunnlag med $mottattXmlId er ugyldig." +

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/HentKravgrunnlagTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/HentKravgrunnlagTaskTest.kt
@@ -79,8 +79,9 @@ internal class HentKravgrunnlagTaskTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun init() {
         fagsak = fagsakRepository.insert(Testdata.fagsak)
-        behandling = behandlingRepository.insert(Testdata.behandling)
-        kravgrunnlagRepository.insert(Testdata.kravgrunnlag431)
+        behandling = Testdata.lagBehandling()
+        behandlingRepository.insert(behandling)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id))
 
         behandling = behandlingRepository.findByIdOrThrow(behandling.id)
         behandlingRepository.update(behandling.copy(status = Behandlingsstatus.AVSLUTTET))
@@ -97,7 +98,7 @@ internal class HentKravgrunnlagTaskTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `doTask skal hente kravgrunnlag for revurderingstilbakekreving`() {
-        val revurdering = behandlingRepository.insert(Testdata.revurdering)
+        val revurdering = behandlingRepository.insert(Testdata.lagRevurdering(behandling.id))
         behandlingsstegstilstandRepository
             .insert(
                 Behandlingsstegstilstand(

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/HåndterGammelKravgrunnlagTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/HåndterGammelKravgrunnlagTaskTest.kt
@@ -204,9 +204,9 @@ internal class HåndterGammelKravgrunnlagTaskTest : OppslagSpringRunnerTest() {
         every { mockHentKravgrunnlagService.hentKravgrunnlagFraØkonomi(any(), any()) } returns hentetKravgrunnlag
 
         fagsakRepository.insert(Testdata.fagsak.copy(eksternFagsakId = xmlMottatt.eksternFagsakId))
-        behandlingRepository.insert(Testdata.behandling)
-        behandlingskontrollService.fortsettBehandling(Testdata.behandling.id)
-        stegService.håndterSteg(Testdata.behandling.id)
+        val lagretBehandling = behandlingRepository.insert(Testdata.lagBehandling())
+        behandlingskontrollService.fortsettBehandling(lagretBehandling.id)
+        stegService.håndterSteg(lagretBehandling.id)
 
         håndterGammelKravgrunnlagTask.doTask(lagTask())
 

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagRepositoryTest.kt
@@ -31,8 +31,9 @@ internal class KravgrunnlagRepositoryTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun init() {
         fagsak = Testdata.fagsak
-        kravgrunnlag431 = Testdata.kravgrunnlag431
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
+        kravgrunnlag431 = Testdata.lagKravgrunnlag(behandling.id)
+        behandling = behandling
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagServiceTest.kt
@@ -48,8 +48,9 @@ class KravgrunnlagServiceTest {
 
     @Test
     fun `Skal ikke oppdatere aktiv på nytt kravgrunnlag med eldre dato i kontrollfelt`() {
-        val gammeltKravgrunnlag = Testdata.kravgrunnlag431.copy(kontrollfelt = "2024-04-29-18.50.15.236317")
-        val nyttKravgrunnlag = Testdata.kravgrunnlag431.copy(kontrollfelt = "2024-04-29-18.50.15.236316")
+        val behandling = Testdata.lagBehandling()
+        val gammeltKravgrunnlag = Testdata.lagKravgrunnlag(behandling.id).copy(kontrollfelt = "2024-04-29-18.50.15.236317")
+        val nyttKravgrunnlag = Testdata.lagKravgrunnlag(behandling.id).copy(kontrollfelt = "2024-04-29-18.50.15.236316")
 
         val nyttKravgrunnlagSlot = slot<Kravgrunnlag431>()
         val gammeltKravgrunnlagSlot = slot<Kravgrunnlag431>()
@@ -61,7 +62,6 @@ class KravgrunnlagServiceTest {
         every { kravgrunnlagRepository.insert(capture(nyttKravgrunnlagSlot)) } returns mockk()
         every { kravgrunnlagRepository.update(capture(gammeltKravgrunnlagSlot)) } returns mockk()
 
-
         kravgrunnlagService.lagreKravgrunnlag(nyttKravgrunnlag, Ytelsestype.BARNETRYGD)
 
         assertThat(gammeltKravgrunnlagSlot.captured.aktiv).isTrue
@@ -70,8 +70,9 @@ class KravgrunnlagServiceTest {
 
     @Test
     fun `Skal oppdatere aktiv på nytt kravgrunnlag med nyere dato i kontrollfelt`() {
-        val gammeltKravgrunnlag = Testdata.kravgrunnlag431.copy(kontrollfelt = "2024-04-29-18.50.15.236316")
-        val nyttKravgrunnlag = Testdata.kravgrunnlag431.copy(kontrollfelt = "2024-04-29-18.50.15.236317")
+        val behandling = Testdata.lagBehandling()
+        val gammeltKravgrunnlag = Testdata.lagKravgrunnlag(behandling.id).copy(kontrollfelt = "2024-04-29-18.50.15.236316")
+        val nyttKravgrunnlag = Testdata.lagKravgrunnlag(behandling.id).copy(kontrollfelt = "2024-04-29-18.50.15.236317")
 
         val nyttKravgrunnlagSlot = slot<Kravgrunnlag431>()
         val gammeltKravgrunnlagSlot = slot<Kravgrunnlag431>()
@@ -81,7 +82,7 @@ class KravgrunnlagServiceTest {
         every { kravgrunnlagRepository.existsByBehandlingIdAndAktivTrue(any()) } returns true
         every { kravgrunnlagRepository.findByBehandlingIdAndAktivIsTrue(any()) } returns gammeltKravgrunnlag
         every { kravgrunnlagRepository.update(capture(gammeltKravgrunnlagSlot)) } returns mockk()
-        every { kravgrunnlagRepository.insert(capture(nyttKravgrunnlagSlot)) }  returns mockk()
+        every { kravgrunnlagRepository.insert(capture(nyttKravgrunnlagSlot)) } returns mockk()
 
         kravgrunnlagService.lagreKravgrunnlag(nyttKravgrunnlag, Ytelsestype.OVERGANGSSTØNAD)
 
@@ -91,7 +92,8 @@ class KravgrunnlagServiceTest {
 
     @Test
     fun `Skal lagre nytt kravgrunnlag dersom det ikke finnes et kravgrunnlag fra før`() {
-        val nyttKravgrunnlag = Testdata.kravgrunnlag431.copy(kontrollfelt = "2024-04-29-18.50.15.236317")
+        val behandling = Testdata.lagBehandling()
+        val nyttKravgrunnlag = Testdata.lagKravgrunnlag(behandling.id).copy(kontrollfelt = "2024-04-29-18.50.15.236317")
 
         val nyttKravgrunnlagSlot2 = slot<Kravgrunnlag431>()
 

--- a/src/test/kotlin/no/nav/familie/tilbake/oppgave/LagOppgaveTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/oppgave/LagOppgaveTaskTest.kt
@@ -44,14 +44,14 @@ internal class LagOppgaveTaskTest : OppslagSpringRunnerTest() {
 
     private lateinit var lagOppgaveTask: LagOppgaveTask
 
-    private val behandling: Behandling = Testdata.behandling
+    private lateinit var behandling: Behandling
 
     private val dagensDato = LocalDate.now()
 
     @BeforeEach
     fun init() {
         fagsakRepository.insert(Testdata.fagsak)
-        behandlingRepository.insert(behandling)
+        behandling = behandlingRepository.insert(Testdata.lagBehandling())
 
         every { oppgavePrioritetService.utledOppgaveprioritet(any(), any()) } returns OppgavePrioritet.NORM
 

--- a/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTaskTest.kt
@@ -23,7 +23,7 @@ internal class OppdaterAnsvarligSaksbehandlerTaskTest {
     private val fagsakRepository: FagsakRepository = mockk(relaxed = true)
     private val mockOppgaveService: OppgaveService = mockk(relaxed = true)
     private val oppgavePrioritetService = mockk<OppgavePrioritetService>()
-    private val behandling: Behandling = Testdata.behandling
+    private lateinit var behandling: Behandling
 
     private val oppdaterAnsvarligSaksbehandlerTask =
         OppdaterAnsvarligSaksbehandlerTask(mockOppgaveService, behandlingRepository, oppgavePrioritetService)
@@ -31,8 +31,9 @@ internal class OppdaterAnsvarligSaksbehandlerTaskTest {
     @BeforeEach
     fun init() {
         clearMocks(mockOppgaveService)
+        behandling = Testdata.lagBehandling()
         every { fagsakRepository.findByIdOrThrow(Testdata.fagsak.id) } returns Testdata.fagsak
-        every { behandlingRepository.findByIdOrThrow(Testdata.behandling.id) } returns Testdata.behandling
+        every { behandlingRepository.findByIdOrThrow(behandling.id) } returns behandling
         every { oppgavePrioritetService.utledOppgaveprioritet(any(), any()) } returns OppgavePrioritet.NORM
     }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppgavePrioritetServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppgavePrioritetServiceTest.kt
@@ -89,6 +89,6 @@ internal class OppgavePrioritetServiceTest {
                     ),
             )
 
-        return Testdata.kravgrunnlag431.copy(perioder = setOf(periode))
+        return Testdata.lagKravgrunnlag(Testdata.lagBehandling().id).copy(perioder = setOf(periode))
     }
 }

--- a/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppgaveServiceTest.kt
@@ -18,9 +18,10 @@ import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingsstegstilstandRepository
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
-import no.nav.familie.tilbake.data.Testdata.behandling
+import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.data.Testdata.fagsak
 import no.nav.familie.tilbake.integration.familie.IntegrasjonerClient
 import no.nav.familie.tilbake.person.PersonService
@@ -53,10 +54,12 @@ class OppgaveServiceTest {
         )
 
     private lateinit var oppgaveService: OppgaveService
+    private lateinit var behandling: Behandling
 
     @BeforeEach
     fun setUp() {
         clearMocks(integrasjonerClient)
+        behandling = Testdata.lagBehandling()
         oppgaveService =
             OppgaveService(
                 behandlingRepository,

--- a/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceTest.kt
@@ -40,7 +40,7 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun init() {
         fagsak = Testdata.fagsak
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         behandlingId = behandling.id
         fagsakRepository.insert(fagsak)
         behandlingRepository.insert(behandling)

--- a/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnsvurderingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnsvurderingRepositoryTest.kt
@@ -22,12 +22,13 @@ internal class TotrinnsvurderingRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
-    private val totrinnsvurdering = Testdata.totrinnsvurdering
+    private lateinit var totrinnsvurdering: Totrinnsvurdering
 
     @BeforeEach
     fun init() {
         fagsakRepository.insert(Testdata.fagsak)
-        behandlingRepository.insert(Testdata.behandling)
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling())
+        totrinnsvurdering = Testdata.lagTotrinnsvurdering(behandling.id)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/tilbake/vilkårsvurdering/VilkårsvurderingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/vilkårsvurdering/VilkårsvurderingRepositoryTest.kt
@@ -13,10 +13,9 @@ internal class VilkårsvurderingRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
 
-    private val vilkår = Testdata.vilkårsvurdering
-
     @Test
     fun `insert med gyldige verdier skal persistere en forekomst av Vilkårsvurdering til basen`() {
+        val vilkår = Testdata.lagVilkårsvurdering(Testdata.lagBehandling().id)
         vilkårsvurderingRepository.insert(vilkår)
 
         val lagretVilkår = vilkårsvurderingRepository.findByIdOrThrow(vilkår.id)
@@ -26,6 +25,7 @@ internal class VilkårsvurderingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `update med gyldige verdier skal oppdatere en forekomst av Vilkårsvurdering i basen`() {
+        val vilkår = Testdata.lagVilkårsvurdering(Testdata.lagBehandling().id)
         vilkårsvurderingRepository.insert(vilkår)
         var lagretVilkår = vilkårsvurderingRepository.findByIdOrThrow(vilkår.id)
         val oppdatertVilkår = lagretVilkår.copy(aktiv = false)

--- a/src/test/kotlin/no/nav/familie/tilbake/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -79,7 +79,7 @@ internal class VilkårsvurderingServiceTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun init() {
-        behandling = Testdata.behandling
+        behandling = Testdata.lagBehandling()
         fagsakRepository.insert(Testdata.fagsak)
         behandlingRepository.insert(behandling)
         val førstePeriode =
@@ -105,7 +105,7 @@ internal class VilkårsvurderingServiceTest : OppslagSpringRunnerTest() {
                         ),
                 )
 
-        val kravgrunnlag431 = Testdata.kravgrunnlag431.copy(perioder = setOf(førstePeriode, andrePeriode))
+        val kravgrunnlag431 = Testdata.lagKravgrunnlag(behandling.id).copy(perioder = setOf(førstePeriode, andrePeriode))
         kravgrunnlagRepository.insert(kravgrunnlag431)
 
         val periode =


### PR DESCRIPTION
Når man brukte Testdata.behandling så fikk man alltid samme behandling. Skrevet om til å bruke lagBehandling som i stedet gir en ny behandling. Alle steder som brukte den hardkodete behandlingen er skrevet om til en metode som tar behandligId som input.

Best å starte med Testdata
behandling -> lagBehandling
revurdering -> lagRevurdering
behandlingsstegstilstand -> lagBehandlingsstegstilstand
osv

Dette gjør testene mer uavhengig av hverandre
