### PR TITLE
Kravgrunnlag som ikke har samme referanse til fagsystembehandling skal ikke behandles automatisk

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -26,6 +26,7 @@ import no.nav.familie.tilbake.behandling.domain.Behandlingstype.TILBAKEKREVING
 import no.nav.familie.tilbake.behandling.domain.Fagsak
 import no.nav.familie.tilbake.behandling.domain.Fagsystemsbehandling
 import no.nav.familie.tilbake.behandling.domain.Fagsystemskonsekvens
+import no.nav.familie.tilbake.behandling.domain.Saksbehandlingstype
 import no.nav.familie.tilbake.behandling.steg.StegService
 import no.nav.familie.tilbake.behandling.task.OpprettBehandlingManueltTask
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
@@ -420,6 +421,15 @@ class BehandlingService(
                 regelverk = respons.regelverk,
             ),
         )
+    }
+
+    @Transactional
+    fun oppdaterSaksbehandlingtype(
+        behandlingId: UUID,
+        saksbehandlingstype: Saksbehandlingstype,
+    ) {
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
+        behandlingRepository.update(behandling.copy(saksbehandlingstype = Saksbehandlingstype.ORDINÆR))
     }
 
     @Transactional

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest.kt
@@ -1,9 +1,7 @@
 package no.nav.familie.tilbake.kravgrunnlag
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
@@ -13,12 +11,13 @@ import no.nav.familie.tilbake.OppslagSpringRunnerTest
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
 import no.nav.familie.tilbake.behandling.batch.AutomatiskSaksbehandlingTask
+import no.nav.familie.tilbake.behandling.domain.Saksbehandlingstype
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingsstegstilstandRepository
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstilstand
 import no.nav.familie.tilbake.behandlingskontroll.domain.Venteårsak
-import no.nav.familie.tilbake.common.exceptionhandler.Feil
+import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.config.Constants
 import no.nav.familie.tilbake.config.Constants.AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_AKTSOMHET_BEGRUNNELSE
 import no.nav.familie.tilbake.config.Constants.AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_BEGRUNNELSE
@@ -87,7 +86,7 @@ class AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest : OppslagSpringRunn
     fun init() {
         val fagsak = Testdata.fagsak
         val behandling = Testdata.lagBehandling()
-        val copyFagsystemsbehandling = behandling.fagsystemsbehandling.first().copy(tilbakekrevingsvalg = Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_AUTOMATISK)
+        val copyFagsystemsbehandling = behandling.fagsystemsbehandling.first().copy(tilbakekrevingsvalg = Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_AUTOMATISK, eksternId = "1")
         val automatiskBehandling = behandling.copy(fagsystemsbehandling = setOf(copyFagsystemsbehandling))
         val fagsakOvergangsstønad = fagsak.copy(ytelsestype = Ytelsestype.OVERGANGSSTØNAD)
         fagsakRepository.insert(fagsakOvergangsstønad)
@@ -129,6 +128,23 @@ class AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest : OppslagSpringRunn
         automatiskSaksbehandlingTasks.size shouldBe 0
         val lagOppgaveTask = taskService.finnAlleTaskerMedPayloadOgType(behandlingId.toString(), LagOppgaveTask.TYPE)
         lagOppgaveTask.first().payload shouldBe behandlingId.toString()
+    }
+
+    @Test
+    fun `Skal ikke behandle feilutbetalinger hvis kravgrunnlag refererer til annen fagsystembehandling`() {
+        lagGrunnlagssteg()
+
+        val kravgrunnlagXml = readXml("/kravgrunnlagxml/kravgrunnlag_EF_feil_referanse.xml")
+
+        val task = opprettTask(kravgrunnlagXml)
+        behandleKravgrunnlagTask.doTask(task)
+
+        val automatiskSaksbehandlingTasks = taskService.finnAlleTaskerMedPayloadOgType(behandlingId.toString(), AutomatiskSaksbehandlingTask.TYPE)
+        automatiskSaksbehandlingTasks.size shouldBe 0
+        val lagOppgaveTask = taskService.finnAlleTaskerMedPayloadOgType(behandlingId.toString(), LagOppgaveTask.TYPE)
+        lagOppgaveTask.first().payload shouldBe behandlingId.toString()
+        val oppdatertBehandling = behandlingRepository.findByIdOrThrow(behandlingId)
+        oppdatertBehandling.saksbehandlingstype shouldBe Saksbehandlingstype.ORDINÆR
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/FinnKravgrunnlagTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/FinnKravgrunnlagTaskTest.kt
@@ -123,6 +123,7 @@ internal class FinnKravgrunnlagTaskTest : OppslagSpringRunnerTest() {
                 historikkTaskService,
                 hentFagsystemsbehandlingService,
                 endretKravgrunnlagEventPublisher,
+                behandlingService,
             )
 
         finnKravgrunnlagTask =

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.slot
 import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.tilbake.behandling.BehandlingRepository
+import no.nav.familie.tilbake.behandling.BehandlingService
 import no.nav.familie.tilbake.behandling.HentFagsystemsbehandlingService
 import no.nav.familie.tilbake.behandling.steg.StegService
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
@@ -30,6 +31,7 @@ class KravgrunnlagServiceTest {
     private val historikkTaskService: HistorikkTaskService = mockk()
     private val hentFagsystemsbehandlingService: HentFagsystemsbehandlingService = mockk()
     private val endretKravgrunnlagEventPublisher: EndretKravgrunnlagEventPublisher = mockk()
+    private val behandlingService: BehandlingService = mockk()
 
     private val kravgrunnlagService =
         KravgrunnlagService(
@@ -44,6 +46,7 @@ class KravgrunnlagServiceTest {
             historikkTaskService = historikkTaskService,
             hentFagsystemsbehandlingService = hentFagsystemsbehandlingService,
             endretKravgrunnlagEventPublisher = endretKravgrunnlagEventPublisher,
+            behandlingService = behandlingService,
         )
 
     @Test

--- a/src/test/resources/kravgrunnlagxml/kravgrunnlag_EF_feil_referanse.xml
+++ b/src/test/resources/kravgrunnlagxml/kravgrunnlag_EF_feil_referanse.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<urn:detaljertKravgrunnlagMelding xmlns:mmel="urn:no:nav:tilbakekreving:typer:v1" xmlns:urn="urn:no:nav:tilbakekreving:kravgrunnlag:detalj:v1">
+    <urn:detaljertKravgrunnlag>
+        <urn:kravgrunnlagId>0</urn:kravgrunnlagId>
+        <urn:vedtakId>0</urn:vedtakId>
+        <urn:kodeStatusKrav>NY</urn:kodeStatusKrav>
+        <urn:kodeFagomraade>EFOG</urn:kodeFagomraade>
+        <urn:fagsystemId>testverdi</urn:fagsystemId>
+        <urn:vedtakIdOmgjort>0</urn:vedtakIdOmgjort>
+        <urn:vedtakGjelderId>testverdi</urn:vedtakGjelderId>
+        <urn:typeGjelderId>PERSON</urn:typeGjelderId>
+        <urn:utbetalesTilId>testverdi</urn:utbetalesTilId>
+        <urn:typeUtbetId>PERSON</urn:typeUtbetId>
+        <urn:enhetAnsvarlig>8020</urn:enhetAnsvarlig>
+        <urn:enhetBosted>8020</urn:enhetBosted>
+        <urn:enhetBehandl>8020</urn:enhetBehandl>
+        <urn:kontrollfelt>2024-11-01-18.40.23.787834</urn:kontrollfelt>
+        <urn:saksbehId>K231B433</urn:saksbehId>
+        <urn:referanse>2</urn:referanse>
+        <urn:tilbakekrevingsPeriode>
+            <urn:periode>
+                <mmel:fom>2024-03-01</mmel:fom>
+                <mmel:tom>2024-03-31</mmel:tom>
+            </urn:periode>
+            <urn:belopSkattMnd>24300.00</urn:belopSkattMnd>
+            <urn:tilbakekrevingsBelop>
+                <urn:kodeKlasse>EFOG</urn:kodeKlasse>
+                <urn:typeKlasse>YTEL</urn:typeKlasse>
+                <urn:belopOpprUtbet>203000.00</urn:belopOpprUtbet>
+                <urn:belopNy>154400.00</urn:belopNy>
+                <urn:belopTilbakekreves>486.00</urn:belopTilbakekreves>
+                <urn:belopUinnkrevd>0.00</urn:belopUinnkrevd>
+                <urn:skattProsent>50.0000</urn:skattProsent>
+            </urn:tilbakekrevingsBelop>
+            <urn:tilbakekrevingsBelop>
+                <urn:kodeKlasse>KL_KODE_FEIL_EFOG</urn:kodeKlasse>
+                <urn:typeKlasse>FEIL</urn:typeKlasse>
+                <urn:belopOpprUtbet>0.00</urn:belopOpprUtbet>
+                <urn:belopNy>486.00</urn:belopNy>
+                <urn:belopTilbakekreves>0.00</urn:belopTilbakekreves>
+                <urn:belopUinnkrevd>0.00</urn:belopUinnkrevd>
+                <urn:skattProsent>50.0000</urn:skattProsent>
+            </urn:tilbakekrevingsBelop>
+        </urn:tilbakekrevingsPeriode>
+    </urn:detaljertKravgrunnlag>
+</urn:detaljertKravgrunnlagMelding>


### PR DESCRIPTION
Det skal ikke behandles automatisk dersom kravgrunnlag viser til en annen behandling (referanse i kravgrunnlag).