### PR TITLE
Behandlingssteg i test lagres av og til på samme millisekund

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
@@ -354,9 +354,10 @@ class BehandlingskontrollService(
             return lagBehandlingsstegsinfo(avbruttSteg.behandlingssteg, KLAR)
         }
 
+        //Finn sisteUtførteSteg. Dersom tidspunkt for to steg er likt, bruk den med høyest sekvensnummer.
         val sisteUtførteSteg =
             stegstilstand.filter { Behandlingsstegstatus.erStegUtført(it.behandlingsstegsstatus) }
-                .maxByOrNull { it.behandlingssteg.sekvens }!!.behandlingssteg
+                .maxWithOrNull(compareBy({ it.sporbar.endret.endretTid }, { it.behandlingssteg.sekvens }))!!.behandlingssteg
 
         if (Behandlingssteg.VARSEL == sisteUtførteSteg) {
             return håndterOmSisteUtførteStegErVarsel(behandling)

--- a/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
@@ -356,7 +356,7 @@ class BehandlingskontrollService(
 
         val sisteUtførteSteg =
             stegstilstand.filter { Behandlingsstegstatus.erStegUtført(it.behandlingsstegsstatus) }
-                .maxByOrNull { it.sporbar.endret.endretTid }!!.behandlingssteg
+                .maxByOrNull { it.behandlingssteg.sekvens }!!.behandlingssteg
 
         if (Behandlingssteg.VARSEL == sisteUtførteSteg) {
             return håndterOmSisteUtførteStegErVarsel(behandling)

--- a/src/test/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollServiceTest.kt
@@ -478,7 +478,7 @@ internal class BehandlingskontrollServiceTest : OppslagSpringRunnerTest() {
     }
 
     private fun lagBehandlingsstegstilstand(stegMetadata: Set<Behandlingsstegsinfo>) {
-        stegMetadata.map {
+        stegMetadata.forEach {
             behandlingsstegstilstandRepository.insert(
                 Behandlingsstegstilstand(
                     behandlingId = behandling.id,

--- a/src/test/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollServiceTest.kt
@@ -31,7 +31,6 @@ import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.data.Testdata.lagBehandling
 import no.nav.familie.tilbake.data.Testdata.lagKravgrunnlag
-import no.nav.familie.tilbake.integration.pdl.internal.logger
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -252,15 +251,11 @@ internal class BehandlingskontrollServiceTest : OppslagSpringRunnerTest() {
                 Behandlingsstegsinfo(FORELDELSE, UTFØRT),
             ),
         )
-        var behandlingsstegstilstand = behandlingsstegstilstandRepository.findByBehandlingId(behandling.id)
-        logger.info("første behandlingsstegtilstand før fortsett behandling: " + behandlingsstegstilstand[0])
-        logger.info("andre behandlingsstegtilstand før fortsett behandling" + behandlingsstegstilstand[1])
         kravgrunnlagRepository.insert(lagKravgrunnlag(behandling.id))
+
         behandlingskontrollService.fortsettBehandling(behandlingId = behandling.id)
 
-        behandlingsstegstilstand = behandlingsstegstilstandRepository.findByBehandlingId(behandling.id)
-        logger.info("første behandlingsstegtilstand: " + behandlingsstegstilstand[0])
-        logger.info("andre behandlingsstegtilstand: " + behandlingsstegstilstand[1])
+        val behandlingsstegstilstand = behandlingsstegstilstandRepository.findByBehandlingId(behandling.id)
         behandlingsstegstilstand.size shouldBe 3
         val sisteStegstilstand = behandlingskontrollService.finnAktivStegstilstand(behandlingsstegstilstand)
         sisteStegstilstand.shouldNotBeNull()


### PR DESCRIPTION
Behandlingsstegene lagres på et såpass likt tidspunkt at Sporbar sin endret tid kan være på samme millisekund.
Dette gjør at testen av og til kan finne første behandlingssteg (Fakta) selv om den skulle funnet siste (Foreldet).
Resultatet av dette blir at `fortsettBehandling` tror at siste behandlingssteg som er utført er `Fakta`, og gjør dermed neste steg til `KLAR` som er behandlingssteg `Foreldet`, i stedet for å opprette behandlingssteg `Vilkårsvurdering`.

Logg fra GHA når testen feilet. Her er Sporbar Endret tid lik for begge behandlingsstegtilstandene før fortsettBehandling utføres:
```
2024-05-03 11:04:54,321 [INFO ] [main] PdlUtil - første behandlingsstegtilstand før fortsett behandling: Behandlingsstegstilstand(id=f4e07edd-2eef-47b4-b070-3f8ecb0d97f8, behandlingId=9f970b40-9fcc-472c-8991-8858affa2acf, behandlingssteg=FAKTA, behandlingsstegsstatus=UTFØRT, venteårsak=null, tidsfrist=null, versjon=1, sporbar=Sporbar(opprettetAv=VL, opprettetTid=2024-05-03T11:04:54.315, endret=Endret(endretAv=VL, endretTid=2024-05-03T11:04:54.315)))
2024-05-03 11:04:54,322 [INFO ] [main] PdlUtil - andre behandlingsstegtilstand før fortsett behandlingBehandlingsstegstilstand(id=34659333-4e56-4a67-9ae7-769edcfc6b75, behandlingId=9f970b40-9fcc-472c-8991-8858affa2acf, behandlingssteg=FORELDELSE, behandlingsstegsstatus=UTFØRT, venteårsak=null, tidsfrist=null, versjon=1, sporbar=Sporbar(opprettetAv=VL, opprettetTid=2024-05-03T11:04:54.315, endret=Endret(endretAv=VL, endretTid=2024-05-03T11:04:54.315)))

//Fortsett behandling utføres

2024-05-03 11:04:54,371 [INFO ] [main] PdlUtil - første behandlingsstegtilstand: Behandlingsstegstilstand(id=f4e07edd-2eef-47b4-b070-3f8ecb0d97f8, behandlingId=9f970b40-9fcc-472c-8991-8858affa2acf, behandlingssteg=FAKTA, behandlingsstegsstatus=UTFØRT, venteårsak=null, tidsfrist=null, versjon=1, sporbar=Sporbar(opprettetAv=VL, opprettetTid=2024-05-03T11:04:54.315, endret=Endret(endretAv=VL, endretTid=2024-05-03T11:04:54.315)))
2024-05-03 11:04:54,371 [INFO ] [main] PdlUtil - andre behandlingsstegtilstand: Behandlingsstegstilstand(id=34659333-4e56-4a67-9ae7-769edcfc6b75, behandlingId=9f970b40-9fcc-472c-8991-8858affa2acf, behandlingssteg=FORELDELSE, behandlingsstegsstatus=KLAR, venteårsak=null, tidsfrist=null, versjon=2, sporbar=Sporbar(opprettetAv=VL, opprettetTid=2024-05-03T11:04:54.315, endret=Endret(endretAv=VL, endretTid=2024-05-03T11:04:54.337)))
```

Vurderte å legge inn en Thread.sleep ved lagring av behandlingssteg i test, men tenkte sekvens vil være riktigere å bruke. Kan dette ødelegge ved redigering i tidligere steg ved behandling?