### PR TITLE
Forbedret henting av forvaltningsinfo

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
+import no.nav.familie.tilbake.behandling.domain.Behandlingsstatus
 import no.nav.familie.tilbake.datavarehus.saksstatistikk.BehandlingTilstandService
 import no.nav.familie.tilbake.forvaltning.ForvaltningService
 import no.nav.familie.tilbake.oppgave.OppgaveTaskService
@@ -175,11 +176,29 @@ class ForvaltningController(
         AuditLoggerEvent.NONE,
         HenteParam.YTELSESTYPE_OG_EKSTERN_FAGSAK_ID,
     )
-    fun hentForvaltningsinfo(
+    fun hentOppdragStatus(
         @PathVariable ytelsestype: Ytelsestype,
         @PathVariable behandlingId: UUID,
     ): Ressurs<String> {
         return Ressurs.success(forvaltningService.hentOppdragStatus(ytelsestype, behandlingId = behandlingId))
+    }
+
+    @Operation(summary = "Hent ikke arkiverte kravgrunnlag")
+    @GetMapping(
+        path = ["/ytelsestype/{ytelsestype}/fagsak/{eksternFagsakId}/ikke-arkivert-kravgrunnlag"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+    )
+    @Rolletilgangssjekk(
+        Behandlerrolle.FORVALTER,
+        "Henter ikke arkiverte kravgrunnlag",
+        AuditLoggerEvent.NONE,
+        HenteParam.YTELSESTYPE_OG_EKSTERN_FAGSAK_ID,
+    )
+    fun hentKravgrunnlagsinfo(
+        @PathVariable ytelsestype: Ytelsestype,
+        @PathVariable eksternFagsakId: String,
+    ): Ressurs<List<Kravgrunnlagsinfo>> {
+        return Ressurs.success(forvaltningService.hentIkkeArkiverteKravgrunnlag(ytelsestype, eksternFagsakId))
     }
 
     @Operation(summary = "Oppretter FinnGammelBehandlingUtenOppgaveTask som logger ut gamle behandlinger uten åpen oppgave")
@@ -240,8 +259,16 @@ data class Forvaltningsinfo(
     val eksternKravgrunnlagId: BigInteger,
     val kravgrunnlagId: UUID?,
     val kravgrunnlagKravstatuskode: String?,
-    val mottattXmlId: UUID?,
     val eksternId: String,
     val opprettetTid: LocalDateTime,
     val behandlingId: UUID?,
+    val behandlingstatus: Behandlingsstatus?,
+)
+
+data class Kravgrunnlagsinfo(
+    val eksternKravgrunnlagId: BigInteger,
+    val kravgrunnlagKravstatuskode: String?,
+    val mottattXmlId: UUID?,
+    val eksternId: String,
+    val opprettetTid: LocalDateTime,
 )

--- a/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
@@ -161,7 +161,7 @@ class ForvaltningController(
     fun hentForvaltningsinfo(
         @PathVariable ytelsestype: Ytelsestype,
         @PathVariable eksternFagsakId: String,
-    ): Ressurs<List<Forvaltningsinfo>> {
+    ): Ressurs<List<Behandlingsinfo>> {
         return Ressurs.success(forvaltningService.hentForvaltningsinfo(ytelsestype, eksternFagsakId))
     }
 
@@ -237,8 +237,8 @@ class ForvaltningController(
     }
 }
 
-data class Forvaltningsinfo(
-    val eksternKravgrunnlagId: BigInteger,
+data class Behandlingsinfo(
+    val eksternKravgrunnlagId: BigInteger?,
     val kravgrunnlagId: UUID?,
     val kravgrunnlagKravstatuskode: String?,
     val eksternId: String,
@@ -249,7 +249,7 @@ data class Forvaltningsinfo(
 
 data class Kravgrunnlagsinfo(
     val eksternKravgrunnlagId: BigInteger,
-    val kravgrunnlagKravstatuskode: String?,
+    val kravgrunnlagKravstatuskode: String,
     val mottattXmlId: UUID?,
     val eksternId: String,
     val opprettetTid: LocalDateTime,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingRepository.kt
@@ -28,6 +28,18 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         eksternFagsakId: String,
     ): Behandling?
 
+    @Query(
+        """
+            SELECT beh.* FROM behandling beh JOIN fagsak f ON beh.fagsak_id = f.id 
+             WHERE f.ytelsestype=:ytelsestype AND f.ekstern_fagsak_id=:eksternFagsakId
+             ORDER BY beh.opprettet_tid DESC LIMIT 1
+        """,
+    )
+    fun finnNyesteTilbakekrevingsbehandlingForYtelsestypeAndEksternFagsakId(
+        ytelsestype: Ytelsestype,
+        eksternFagsakId: String,
+    ): Behandling?
+
     // language=PostgreSQL
     @Query(
         """

--- a/src/main/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningService.kt
@@ -4,7 +4,7 @@ import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.familie.tilbake.api.forvaltning.Forvaltningsinfo
+import no.nav.familie.tilbake.api.forvaltning.Behandlingsinfo
 import no.nav.familie.tilbake.api.forvaltning.Kravgrunnlagsinfo
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.BehandlingsvedtakService
@@ -215,12 +215,12 @@ class ForvaltningService(
     fun hentForvaltningsinfo(
         ytelsestype: Ytelsestype,
         eksternFagsakId: String,
-    ): List<Forvaltningsinfo> {
+    ): List<Behandlingsinfo> {
         val behandling = behandlingRepository.finnNyesteTilbakekrevingsbehandlingForYtelsestypeAndEksternFagsakId(ytelsestype, eksternFagsakId)
         if (behandling != null) {
             val kravgrunnlag431 = kravgrunnlagRepository.findByBehandlingId(behandling.id).filter { it.aktiv }
             return kravgrunnlag431.map { kravgrunnlag ->
-                Forvaltningsinfo(
+                Behandlingsinfo(
                     eksternKravgrunnlagId = kravgrunnlag.eksternKravgrunnlagId,
                     kravgrunnlagId = kravgrunnlag.id,
                     kravgrunnlagKravstatuskode = kravgrunnlag.kravstatuskode.kode,
@@ -242,7 +242,7 @@ class ForvaltningService(
             økonomiXmlMottattRepository.findByEksternFagsakIdAndYtelsestype(eksternFagsakId, ytelsestype)
         if (økonomiXmlMottatt.isEmpty()) {
             throw Feil(
-                "Finnes ikke data i systemet for ytelsestype=$ytelsestype og eksternFagsakId=$eksternFagsakId",
+                "Finnes ikke kravgrunnlag som ikke er arkivert for ytelsestype=$ytelsestype og eksternFagsakId=$eksternFagsakId",
                 httpStatus = HttpStatus.BAD_REQUEST,
             )
         }

--- a/src/main/kotlin/no/nav/familie/tilbake/integration/økonomi/OppdragClient.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/integration/økonomi/OppdragClient.kt
@@ -66,9 +66,7 @@ interface OppdragClient {
     )
 
     fun hentFeilutbetalingerFraSimulering(request: HentFeilutbetalingerFraSimuleringRequest): FeilutbetalingerFraSimulering
-
 }
-
 
 @Service
 @Profile("!e2e & !mock-økonomi")

--- a/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
@@ -364,7 +364,7 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
                     fagsak.eksternFagsakId,
                 )
             }
-        exception.message shouldBe "Finnes ikke data i systemet for ytelsestype=${fagsak.ytelsestype} " +
+        exception.message shouldBe "Finnes ikke kravgrunnlag som ikke er arkivert for ytelsestype=${fagsak.ytelsestype} " +
             "og eksternFagsakId=${fagsak.eksternFagsakId}"
     }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningServiceTest.kt
@@ -335,12 +335,11 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
         val forvaltningsinfo =
             forvaltningService.hentForvaltningsinfo(fagsak.ytelsestype, fagsak.eksternFagsakId).first()
         forvaltningsinfo.eksternKravgrunnlagId shouldBe kravgrunnlag.eksternKravgrunnlagId
-        forvaltningsinfo.mottattXmlId.shouldBeNull()
         forvaltningsinfo.eksternId shouldBe kravgrunnlag.referanse
     }
 
     @Test
-    fun `hentForvaltningsinfo skal hente forvaltningsinfo basert på eksternFagsakId og ytelsestype fra mottattXml`() {
+    fun `hentIkkeArkiverteKravgrunnlag skal hente Kravgrunnlagsinfo basert på eksternFagsakId og ytelsestype fra mottattXml`() {
         val fagsak = fagsakRepository.findByIdOrThrow(behandling.fagsakId)
         val mottattXml = Testdata.økonomiXmlMottatt
         økonomiXmlMottattRepository.insert(
@@ -350,18 +349,17 @@ internal class ForvaltningServiceTest : OppslagSpringRunnerTest() {
             ),
         )
         val forvaltningsinfo =
-            forvaltningService.hentForvaltningsinfo(fagsak.ytelsestype, fagsak.eksternFagsakId).first()
+            forvaltningService.hentIkkeArkiverteKravgrunnlag(fagsak.ytelsestype, fagsak.eksternFagsakId).first()
         forvaltningsinfo.eksternKravgrunnlagId shouldBe mottattXml.eksternKravgrunnlagId
-        forvaltningsinfo.mottattXmlId shouldBe mottattXml.id
         forvaltningsinfo.eksternId shouldBe mottattXml.referanse
     }
 
     @Test
-    fun `hentForvaltningsinfo skal ikke hente forvaltningsinfo når behandling venter på kravgrunnlag`() {
+    fun `hentIkkeArkiverteKravgrunnlag skal ikke hente kravgrunnlagsinfo når behandling venter på kravgrunnlag`() {
         val fagsak = fagsakRepository.findByIdOrThrow(behandling.fagsakId)
         val exception =
             shouldThrow<RuntimeException> {
-                forvaltningService.hentForvaltningsinfo(
+                forvaltningService.hentIkkeArkiverteKravgrunnlag(
                     fagsak.ytelsestype,
                     fagsak.eksternFagsakId,
                 )


### PR DESCRIPTION
Endret Forvaltningsinfo-endepunktet til å også hente behandlinger som er åpne.
Splittet endepunkt til å ha eget endepunkt for henting av ikke-arkiverte kravgrunnlag.
