### PR TITLE
Ikke lag oppgave i oppdaterOppgaveTask, da denne går i beina på LagOppgaveTask som gjøres på et senere tidspunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/api/dto/BehandlingDto.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/dto/BehandlingDto.kt
@@ -1,10 +1,10 @@
 package no.nav.familie.tilbake.api.dto
 
-import no.nav.familie.tilbake.behandling.domain.Saksbehandlingstype
 import no.nav.familie.tilbake.behandling.domain.Behandlingsresultatstype
 import no.nav.familie.tilbake.behandling.domain.Behandlingsstatus
 import no.nav.familie.tilbake.behandling.domain.Behandlingstype
 import no.nav.familie.tilbake.behandling.domain.Behandlingsårsakstype
+import no.nav.familie.tilbake.behandling.domain.Saksbehandlingstype
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
 import no.nav.familie.tilbake.behandlingskontroll.domain.Venteårsak

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapper.kt
@@ -121,7 +121,7 @@ object BehandlingMapper {
             støtterManuelleBrevmottakere = støtterManuelleBrevmottakere,
             manuelleBrevmottakere = manuelleBrevmottakere.map { ManuellBrevmottakerMapper.tilRespons(it) },
             begrunnelseForTilbakekreving = behandling.begrunnelseForTilbakekreving,
-            saksbehandlingstype = behandling.saksbehandlingstype
+            saksbehandlingstype = behandling.saksbehandlingstype,
         )
     }
 


### PR DESCRIPTION
Hvis dette skjer får vi to oppgaver på samme behandling. Det er bedre å feile dersom oppgave ikke finnes, og så er det heller mulig å opprette en oppgave via forvaltningsendepunkt dersom det trengs. Vi har sett i loggene at dette ikke har skjedd i prod de siste 3 månedene.