### PR TITLE
Bruk saksbehandlingstype, ikke tilbakekrevingsvalg

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.tilbake.behandling.batch
 
 import no.nav.familie.kontrakter.felles.Regelverk
-import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
@@ -68,20 +67,17 @@ class AutomatiskSaksbehandlingService(
     }
 
     @Transactional
-    fun oppdaterBehandling(behandlingId: UUID) {
+    fun settSaksbehandlingstypeTilAutomatiskHvisOrdinær(behandlingId: UUID) {
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
-        val saksbehandlingstype =
-            if (behandling.aktivFagsystemsbehandling.tilbakekrevingsvalg == Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_AUTOMATISK) {
-                Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR
-            } else {
-                Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_LAVT_BELØP
-            }
-        behandlingRepository.update(
-            behandling.copy(
-                saksbehandlingstype = saksbehandlingstype,
-                ansvarligSaksbehandler = "VL",
-            ),
-        )
+
+        if(behandling.saksbehandlingstype == Saksbehandlingstype.ORDINÆR){
+            behandlingRepository.update(
+                behandling.copy(
+                    saksbehandlingstype = Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_LAVT_BELØP,
+                    ansvarligSaksbehandler = "VL",
+                ),
+            )
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingService.kt
@@ -70,14 +70,15 @@ class AutomatiskSaksbehandlingService(
     fun settSaksbehandlingstypeTilAutomatiskHvisOrdinær(behandlingId: UUID) {
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
 
-        if(behandling.saksbehandlingstype == Saksbehandlingstype.ORDINÆR){
-            behandlingRepository.update(
-                behandling.copy(
-                    saksbehandlingstype = Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_LAVT_BELØP,
-                    ansvarligSaksbehandler = "VL",
-                ),
-            )
-        }
+        if (behandling.saksbehandlingstype == Saksbehandlingstype.ORDINÆR)
+            {
+                behandlingRepository.update(
+                    behandling.copy(
+                        saksbehandlingstype = Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_LAVT_BELØP,
+                        ansvarligSaksbehandler = "VL",
+                    ),
+                )
+            }
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingTask.kt
@@ -1,11 +1,12 @@
 package no.nav.familie.tilbake.behandling.batch
 
 import no.nav.familie.kontrakter.felles.Fagsystem
-import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.tilbake.behandling.BehandlingRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
+import no.nav.familie.tilbake.behandling.domain.Saksbehandlingstype
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.config.Constants
@@ -37,23 +38,29 @@ class AutomatiskSaksbehandlingTask(
         logger.info("AutomatiskSaksbehandlingTask prosesserer med id=${task.id} og metadata ${task.metadata}")
         val behandlingId = UUID.fromString(task.payload)
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
+        validerOmAutomatiskBehandlingUnder4RettsgebyrErMulig(behandlingId, behandling)
+        automatiskSaksbehandlingService.settSaksbehandlingstypeTilAutomatiskHvisOrdinær(behandlingId)
+
+        automatiskSaksbehandlingService.behandleAutomatisk(behandlingId)
+    }
+
+
+
+    private fun validerOmAutomatiskBehandlingUnder4RettsgebyrErMulig(behandlingId: UUID, behandling: Behandling) {
         if (kravgrunnlagService.sumFeilutbetalingsbeløpForBehandlingId(behandlingId) > Constants.FIRE_X_RETTSGEBYR &&
-            behandling.aktivFagsystemsbehandling.tilbakekrevingsvalg == Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_AUTOMATISK
+            behandling.saksbehandlingstype == Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR
         ) {
             throw Feil("Skal ikke behandle beløp over 4x rettsgebyr automatisk")
         }
 
         if (!featureToggleService.isEnabled(FeatureToggleConfig.AUTOMATISK_BEHANDLE_TILBAKEKREVING_UNDER_4X_RETTSGEBYR) &&
-            behandling.aktivFagsystemsbehandling.tilbakekrevingsvalg == Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_AUTOMATISK
+            behandling.saksbehandlingstype == Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR
         ) {
             throw Feil(
                 "Behandler ikke feilutbetalinger under 4 rettsgebyr automatisk da featuretoggle for dette er skrudd av " +
-                    "(${FeatureToggleConfig.AUTOMATISK_BEHANDLE_TILBAKEKREVING_UNDER_4X_RETTSGEBYR})",
+                        "(${FeatureToggleConfig.AUTOMATISK_BEHANDLE_TILBAKEKREVING_UNDER_4X_RETTSGEBYR})",
             )
         }
-        automatiskSaksbehandlingService.oppdaterBehandling(behandlingId)
-
-        automatiskSaksbehandlingService.behandleAutomatisk(behandlingId)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingTask.kt
@@ -44,9 +44,10 @@ class AutomatiskSaksbehandlingTask(
         automatiskSaksbehandlingService.behandleAutomatisk(behandlingId)
     }
 
-
-
-    private fun validerOmAutomatiskBehandlingUnder4RettsgebyrErMulig(behandlingId: UUID, behandling: Behandling) {
+    private fun validerOmAutomatiskBehandlingUnder4RettsgebyrErMulig(
+        behandlingId: UUID,
+        behandling: Behandling,
+    ) {
         if (kravgrunnlagService.sumFeilutbetalingsbeløpForBehandlingId(behandlingId) > Constants.FIRE_X_RETTSGEBYR &&
             behandling.saksbehandlingstype == Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR
         ) {
@@ -58,7 +59,7 @@ class AutomatiskSaksbehandlingTask(
         ) {
             throw Feil(
                 "Behandler ikke feilutbetalinger under 4 rettsgebyr automatisk da featuretoggle for dette er skrudd av " +
-                        "(${FeatureToggleConfig.AUTOMATISK_BEHANDLE_TILBAKEKREVING_UNDER_4X_RETTSGEBYR})",
+                    "(${FeatureToggleConfig.AUTOMATISK_BEHANDLE_TILBAKEKREVING_UNDER_4X_RETTSGEBYR})",
             )
         }
     }

--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.tilbake.kravgrunnlag
 
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
-import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
@@ -121,7 +120,7 @@ class KravgrunnlagService(
         }
 
         stegService.håndterSteg(behandling.id) // Kjører automatisk frem til fakta-steg = KLAR
-        if (behandling.aktivFagsystemsbehandling.tilbakekrevingsvalg == Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_AUTOMATISK) {
+        if (behandling.saksbehandlingstype == Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR) {
             if (skalBehandlesAutomatisk(kravgrunnlag431, behandling)) {
                 taskService.save(AutomatiskSaksbehandlingTask.opprettTask(behandling.id, fagsystem))
             } else {

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest.kt
@@ -31,7 +31,6 @@ import no.nav.familie.tilbake.foreldelse.ForeldelseService
 import no.nav.familie.tilbake.iverksettvedtak.task.SendØkonomiTilbakekrevingsvedtakTask
 import no.nav.familie.tilbake.kravgrunnlag.task.BehandleKravgrunnlagTask
 import no.nav.familie.tilbake.oppgave.LagOppgaveTask
-import no.nav.familie.tilbake.oppgave.OppdaterOppgaveTask
 import no.nav.familie.tilbake.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.tilbake.vilkårsvurdering.domain.Aktsomhet
 import no.nav.familie.tilbake.vilkårsvurdering.domain.Vilkårsvurderingsresultat
@@ -78,9 +77,6 @@ class AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest : OppslagSpringRunn
     @Autowired
     private lateinit var featureToggleService: FeatureToggleService
 
-    @Autowired
-    private lateinit var oppdaterOppgaveTask: OppdaterOppgaveTask
-
     private lateinit var behandlingId: UUID
 
     @BeforeEach
@@ -88,7 +84,7 @@ class AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest : OppslagSpringRunn
         val fagsak = Testdata.fagsak
         val behandling = Testdata.lagBehandling()
         val copyFagsystemsbehandling = behandling.fagsystemsbehandling.first().copy(tilbakekrevingsvalg = Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_AUTOMATISK, eksternId = "1")
-        val automatiskBehandling = behandling.copy(fagsystemsbehandling = setOf(copyFagsystemsbehandling))
+        val automatiskBehandling = behandling.copy(saksbehandlingstype = Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR, fagsystemsbehandling = setOf(copyFagsystemsbehandling))
         val fagsakOvergangsstønad = fagsak.copy(ytelsestype = Ytelsestype.OVERGANGSSTØNAD)
         fagsakRepository.insert(fagsakOvergangsstønad)
         behandlingId = behandlingRepository.insert(automatiskBehandling).id


### PR DESCRIPTION
En behandling kan endre saksbehandlingstype fra automatisk til ordinær i enkelte tilfeller, men tilbakekrevingsvalget om automatisk behandling blir ikke endret. Saksbehandlingstype skal derfor regnes som "fasit" og feltet burde derfor brukes i alle sammenhenger hvor det er avgjørende for funksjonalitet. Dette er en utvidelse og forbedring av PR https://github.com/navikt/familie-tilbake/pull/1480 hvor det kan bli feil funksjonalitet dersom tilbakekrevingsvalg brukes fremfor saksbehandlingstype.