### PR TITLE
Vi har en stor andel diffsjekker mot kravgrunnlag som får diff fordi …

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagUtil.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagUtil.kt
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.builder.DiffBuilder
 import org.apache.commons.lang3.builder.ToStringStyle
 import java.io.StringReader
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.util.SortedMap
 import javax.xml.XMLConstants
 import javax.xml.validation.SchemaFactory
@@ -89,7 +90,7 @@ object KravgrunnlagUtil {
                 .append("kodeFagomraade", mottattKravgrunnlag.kodeFagomraade, hentetKravgrunnlag.kodeFagomraade)
                 .append("fagsystemId", mottattKravgrunnlag.fagsystemId, hentetKravgrunnlag.fagsystemId)
                 .append("datoVedtakFagsystem", mottattKravgrunnlag.datoVedtakFagsystem, hentetKravgrunnlag.datoVedtakFagsystem)
-                .append("vedtakIdOmgjort", mottattKravgrunnlag.vedtakIdOmgjort, hentetKravgrunnlag.vedtakIdOmgjort)
+                .append("vedtakIdOmgjort", mottattKravgrunnlag.vedtakIdOmgjort ?: BigInteger.ZERO, hentetKravgrunnlag.vedtakIdOmgjort ?: BigInteger.ZERO)
                 .append("vedtakGjelderId", mottattKravgrunnlag.vedtakGjelderId, hentetKravgrunnlag.vedtakGjelderId)
                 .append("typeGjelderId", mottattKravgrunnlag.typeGjelderId, hentetKravgrunnlag.typeGjelderId)
                 .append("utbetalesTilId", mottattKravgrunnlag.utbetalesTilId, hentetKravgrunnlag.utbetalesTilId)

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagUtilTest.kt
@@ -2,19 +2,21 @@ package no.nav.familie.tilbake.kravgrunnlag
 
 import io.kotest.matchers.string.shouldBeEmpty
 import io.kotest.matchers.string.shouldNotBeEmpty
-import java.math.BigInteger
 import no.nav.tilbakekreving.kravgrunnlag.detalj.v1.DetaljertKravgrunnlagDto
 import org.junit.jupiter.api.Test
+import java.math.BigInteger
 
 class KravgrunnlagUtilTest {
     @Test
     fun `skal ikke finne diff hvis omgjortVedtakId er null og 0`() {
-        val detaljertKravgrunnlag0Verdi: DetaljertKravgrunnlagDto = KravgrunnlagUtil
-            .unmarshalKravgrunnlag(readXml("/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml"))
-        detaljertKravgrunnlag0Verdi.vedtakIdOmgjort = BigInteger.ZERO;
+        val detaljertKravgrunnlag0Verdi: DetaljertKravgrunnlagDto =
+            KravgrunnlagUtil
+                .unmarshalKravgrunnlag(readXml("/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml"))
+        detaljertKravgrunnlag0Verdi.vedtakIdOmgjort = BigInteger.ZERO
 
-        val detaljertKravgrunnlagNullVerdi = KravgrunnlagUtil
-            .unmarshalKravgrunnlag(readXml("/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml"))
+        val detaljertKravgrunnlagNullVerdi =
+            KravgrunnlagUtil
+                .unmarshalKravgrunnlag(readXml("/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml"))
         detaljertKravgrunnlagNullVerdi.vedtakIdOmgjort = null
 
         val diff = KravgrunnlagUtil.sammenlignKravgrunnlag(detaljertKravgrunnlagNullVerdi, detaljertKravgrunnlag0Verdi)
@@ -23,12 +25,14 @@ class KravgrunnlagUtilTest {
 
     @Test
     fun `skal finne diff hvis omgjortVedtakId er null og 0`() {
-        val detaljertKravgrunnlag0Verdi: DetaljertKravgrunnlagDto = KravgrunnlagUtil
-            .unmarshalKravgrunnlag(readXml("/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml"))
-        detaljertKravgrunnlag0Verdi.vedtakIdOmgjort = BigInteger.ZERO;
+        val detaljertKravgrunnlag0Verdi: DetaljertKravgrunnlagDto =
+            KravgrunnlagUtil
+                .unmarshalKravgrunnlag(readXml("/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml"))
+        detaljertKravgrunnlag0Verdi.vedtakIdOmgjort = BigInteger.ZERO
 
-        val detaljertKravgrunnlagNullVerdi = KravgrunnlagUtil
-            .unmarshalKravgrunnlag(readXml("/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml"))
+        val detaljertKravgrunnlagNullVerdi =
+            KravgrunnlagUtil
+                .unmarshalKravgrunnlag(readXml("/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml"))
         detaljertKravgrunnlagNullVerdi.vedtakIdOmgjort = BigInteger.ONE
 
         val diff = KravgrunnlagUtil.sammenlignKravgrunnlag(detaljertKravgrunnlagNullVerdi, detaljertKravgrunnlag0Verdi)
@@ -39,5 +43,4 @@ class KravgrunnlagUtilTest {
         val url = requireNotNull(this::class.java.getResource(fileName)) { "fil med filnavn=$fileName finnes ikke" }
         return url.readText()
     }
-
 }

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagUtilTest.kt
@@ -1,0 +1,43 @@
+package no.nav.familie.tilbake.kravgrunnlag
+
+import io.kotest.matchers.string.shouldBeEmpty
+import io.kotest.matchers.string.shouldNotBeEmpty
+import java.math.BigInteger
+import no.nav.tilbakekreving.kravgrunnlag.detalj.v1.DetaljertKravgrunnlagDto
+import org.junit.jupiter.api.Test
+
+class KravgrunnlagUtilTest {
+    @Test
+    fun `skal ikke finne diff hvis omgjortVedtakId er null og 0`() {
+        val detaljertKravgrunnlag0Verdi: DetaljertKravgrunnlagDto = KravgrunnlagUtil
+            .unmarshalKravgrunnlag(readXml("/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml"))
+        detaljertKravgrunnlag0Verdi.vedtakIdOmgjort = BigInteger.ZERO;
+
+        val detaljertKravgrunnlagNullVerdi = KravgrunnlagUtil
+            .unmarshalKravgrunnlag(readXml("/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml"))
+        detaljertKravgrunnlagNullVerdi.vedtakIdOmgjort = null
+
+        val diff = KravgrunnlagUtil.sammenlignKravgrunnlag(detaljertKravgrunnlagNullVerdi, detaljertKravgrunnlag0Verdi)
+        diff.shouldBeEmpty()
+    }
+
+    @Test
+    fun `skal finne diff hvis omgjortVedtakId er null og 0`() {
+        val detaljertKravgrunnlag0Verdi: DetaljertKravgrunnlagDto = KravgrunnlagUtil
+            .unmarshalKravgrunnlag(readXml("/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml"))
+        detaljertKravgrunnlag0Verdi.vedtakIdOmgjort = BigInteger.ZERO;
+
+        val detaljertKravgrunnlagNullVerdi = KravgrunnlagUtil
+            .unmarshalKravgrunnlag(readXml("/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml"))
+        detaljertKravgrunnlagNullVerdi.vedtakIdOmgjort = BigInteger.ONE
+
+        val diff = KravgrunnlagUtil.sammenlignKravgrunnlag(detaljertKravgrunnlagNullVerdi, detaljertKravgrunnlag0Verdi)
+        diff.shouldNotBeEmpty()
+    }
+
+    private fun readXml(fileName: String): String {
+        val url = requireNotNull(this::class.java.getResource(fileName)) { "fil med filnavn=$fileName finnes ikke" }
+        return url.readText()
+    }
+
+}


### PR DESCRIPTION

…vedtakIdOmgjort er _null_ i ett tilfelle og _0_ i et annet. Dette er, for alle praktiske formål, likt - og vi trenger ikke å logge warning på disse forskjellene

<img width="667" alt="Screenshot 2024-06-25 at 08 15 59" src="https://github.com/navikt/familie-tilbake/assets/402915/dc3a2553-b06e-4e67-a3cf-23c2e96ef3ea">
