### PR TITLE
Vil fjerne ubrukt val (dødsdato)

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevgeneratorService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevgeneratorService.kt
@@ -344,7 +344,6 @@ class VedtaksbrevgeneratorService(
     private fun utledSøker(personinfo: Personinfo): HbPerson {
         return HbPerson(
             navn = WordUtils.capitalizeFully(personinfo.navn, ' ', '-'),
-            dødsdato = null,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/handlebars/dto/HbPerson.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/handlebars/dto/HbPerson.kt
@@ -1,9 +1,6 @@
 package no.nav.familie.tilbake.dokumentbestilling.vedtak.handlebars.dto
 
-import java.time.LocalDate
-
 @Suppress("unused") // Handlebars
 class HbPerson(
     private val navn: String,
-    private val dødsdato: LocalDate? = null,
 )

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/TekstformatererVedtaksbrevAllePermutasjonerAvFaktaTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/TekstformatererVedtaksbrevAllePermutasjonerAvFaktaTest.kt
@@ -224,7 +224,6 @@ class TekstformatererVedtaksbrevAllePermutasjonerAvFaktaTest {
             søker =
                 HbPerson(
                     navn = "Søker Søkersen",
-                    dødsdato = LocalDate.of(2018, 3, 1),
                 ),
             fagsaksvedtaksdato = LocalDate.now(),
             behandling = HbBehandling(),

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/TekstformatererVedtaksbrevTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/TekstformatererVedtaksbrevTest.kt
@@ -280,7 +280,6 @@ class TekstformatererVedtaksbrevTest {
                     søker =
                         HbPerson(
                             navn = "Søker Søkersen",
-                            dødsdato = LocalDate.of(2018, 3, 1),
                         ),
                     hjemmel = HbHjemmel("Folketrygdloven § 22-15"),
                     datoer = HbVedtaksbrevDatoer(perioder = perioder),
@@ -430,7 +429,6 @@ class TekstformatererVedtaksbrevTest {
                     søker =
                         HbPerson(
                             navn = "Søker Søkersen",
-                            dødsdato = LocalDate.of(2018, 3, 1),
                         ),
                     hjemmel = HbHjemmel("Folketrygdloven § 22-15"),
                     varsel =
@@ -717,7 +715,6 @@ class TekstformatererVedtaksbrevTest {
                         søker =
                             HbPerson(
                                 navn = "Søker Søkersen",
-                                dødsdato = LocalDate.of(2018, 3, 1),
                             ),
                         datoer = HbVedtaksbrevDatoer(perioder = perioder),
                     )
@@ -786,7 +783,6 @@ class TekstformatererVedtaksbrevTest {
                         søker =
                             HbPerson(
                                 navn = "Søker Søkersen",
-                                dødsdato = LocalDate.of(2018, 3, 1),
                             ),
                         datoer = HbVedtaksbrevDatoer(perioder = perioder),
                     )
@@ -853,7 +849,6 @@ class TekstformatererVedtaksbrevTest {
                         søker =
                             HbPerson(
                                 navn = "Søker Søkersen",
-                                dødsdato = LocalDate.of(2018, 3, 1),
                             ),
                         datoer = HbVedtaksbrevDatoer(perioder = perioder),
                     )
@@ -922,7 +917,6 @@ class TekstformatererVedtaksbrevTest {
                         søker =
                             HbPerson(
                                 navn = "Søker Søkersen",
-                                dødsdato = LocalDate.of(2018, 3, 1),
                             ),
                         datoer = HbVedtaksbrevDatoer(perioder = perioder),
                     )
@@ -1168,7 +1162,6 @@ class TekstformatererVedtaksbrevTest {
                         søker =
                             HbPerson(
                                 navn = "Søker Søkersen",
-                                dødsdato = LocalDate.of(2018, 3, 1),
                             ),
                         vedtaksbrevstype = Vedtaksbrevstype.ORDINÆR,
                         datoer = HbVedtaksbrevDatoer(perioder = perioder),
@@ -1233,7 +1226,6 @@ class TekstformatererVedtaksbrevTest {
                         søker =
                             HbPerson(
                                 navn = "Søker Søkersen",
-                                dødsdato = LocalDate.of(2018, 3, 1),
                             ),
                         vedtaksbrevstype = Vedtaksbrevstype.ORDINÆR,
                         datoer = HbVedtaksbrevDatoer(perioder = perioder),

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/TekstformatererVedtaksbrevVedleggTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/TekstformatererVedtaksbrevVedleggTest.kt
@@ -190,7 +190,6 @@ class TekstformatererVedtaksbrevVedleggTest {
             søker =
                 HbPerson(
                     navn = "Søker Søkersen",
-                    dødsdato = LocalDate.of(2018, 3, 1),
                 ),
             fagsaksvedtaksdato = LocalDate.now(),
             behandling = HbBehandling(),


### PR DESCRIPTION
Denne er så vidt jeg kan se ikke i bruk. Personinfo fra PDL blir brukt for å finne evt. dødsdato. 