### PR TITLE
Forvalter-endepunkt for å finne alle behandlinger med åpen GodkjenneVedtak-oppgave som skulle hatt BehandleSak-oppgave

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
@@ -235,6 +235,21 @@ class ForvaltningController(
             behandlingTilstandService.opprettSendingAvBehandlingenManuellt(behandlingId = behandlingID)
         }
     }
+
+    @Operation(summary = "Henter behandlinger med åpen GodkjennVedtak-oppgave som burde hatt åpen BehandleSak-oppgave")
+    @GetMapping(
+        path = ["/hentBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+    )
+    @Rolletilgangssjekk(
+        Behandlerrolle.FORVALTER,
+        "Henter behandlinger med åpen GodkjennVedtak-oppgave som burde hatt åpen BehandleSak-oppgave",
+        AuditLoggerEvent.NONE,
+    )
+    fun hentBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave(@PathVariable fagsystem: Fagsystem): Ressurs<List<UUID>> {
+        return Ressurs.success(forvaltningService.hentBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave(fagsystem))
+    }
+
 }
 
 data class Behandlingsinfo(

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingRepository.kt
@@ -104,4 +104,15 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
     """,
     )
     fun finnAlleBehandlingerKlarForGjenoppta(dagensdato: LocalDate): List<Behandling>
+
+    // language=PostgreSQL
+    @Query(
+        """
+            SELECT b.* FROM behandlingsstegstilstand bst
+            JOIN behandling b ON bst.behandling_id = b.id
+            JOIN fagsak f ON b.fagsak_id = f.id
+            WHERE f.fagsystem = :fagsystem AND bst.behandlingssteg = 'FATTE_VEDTAK' AND bst.behandlingsstegsstatus = 'TILBAKEFØRT' AND b.status != 'AVSLUTTET'
+        """
+    )
+    fun hentÅpneBehandlingerMedTilbakeførtFatteVedtakSteg(fagsystem: Fagsystem): List<Behandling>
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningService.kt
@@ -260,7 +260,7 @@ class ForvaltningService(
     fun hentBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave(fagsystem: Fagsystem): List<UUID> {
         val behandlingerMedTilbakeførtFatteVedtakSteg = behandlingRepository.hentÅpneBehandlingerMedTilbakeførtFatteVedtakSteg(fagsystem)
         return behandlingerMedTilbakeførtFatteVedtakSteg.filter {
-            val aktivOppgave =         oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(it.id)
+            val aktivOppgave = oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(it.id)
             val aktivtSteg = behandlingskontrollService.finnAktivtSteg(it.id)
             aktivtSteg != null && aktivtSteg.sekvens < Behandlingssteg.FATTE_VEDTAK.sekvens && aktivOppgave.oppgavetype == Oppgavetype.GodkjenneVedtak.name
         }.map { it.id }

--- a/src/main/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningService.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.tilbake.forvaltning
 
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
@@ -34,6 +36,7 @@ import no.nav.familie.tilbake.kravgrunnlag.event.EndretKravgrunnlagEventPublishe
 import no.nav.familie.tilbake.kravgrunnlag.ØkonomiXmlMottattRepository
 import no.nav.familie.tilbake.kravgrunnlag.ØkonomiXmlMottattService
 import no.nav.familie.tilbake.micrometer.TellerService
+import no.nav.familie.tilbake.oppgave.OppgaveService
 import no.nav.familie.tilbake.oppgave.OppgaveTaskService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -61,6 +64,7 @@ class ForvaltningService(
     private val tellerService: TellerService,
     private val taskService: TaskService,
     private val endretKravgrunnlagEventPublisher: EndretKravgrunnlagEventPublisher,
+    private val oppgaveService: OppgaveService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this.javaClass)
 
@@ -251,6 +255,15 @@ class ForvaltningService(
                 opprettetTid = xml.sporbar.opprettetTid,
             )
         }
+    }
+
+    fun hentBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave(fagsystem: Fagsystem): List<UUID> {
+        val behandlingerMedTilbakeførtFatteVedtakSteg = behandlingRepository.hentÅpneBehandlingerMedTilbakeførtFatteVedtakSteg(fagsystem)
+        return behandlingerMedTilbakeførtFatteVedtakSteg.filter {
+            val aktivOppgave =         oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(it.id)
+            val aktivtSteg = behandlingskontrollService.finnAktivtSteg(it.id)
+            aktivtSteg != null && aktivtSteg.sekvens < Behandlingssteg.FATTE_VEDTAK.sekvens && aktivOppgave.oppgavetype == Oppgavetype.GodkjenneVedtak.name
+        }.map { it.id }
     }
 
     private fun sjekkOmBehandlingErAvsluttet(behandling: Behandling) {


### PR DESCRIPTION
Favro: [NAV-22019](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22019)

Endepunkt som returnerer alle behandlinger hvor steget `FATTER_VEDTAK`  har status `TILBAKEFØRT`, aktivt steg kommer før `FATTER_VEDTAK` og åpen oppgave på behandlingen er av typen `GodkjenneVedtak`. Disse behandlingene er "låst" fra å bli sendt til beslutter. 

Legger her kun inn endepunkt for å finne ut hvor mange behandlinger dette gjelder for å finne ut om det er bedre å manuelt fikse de eller om vi burde skrive kode for dette. 

I nye behandlinger vil ikke lenger behandlinger kunne havne i denne tilstanden.