### PR TITLE
Lagt til manglende PathVariable for forvalter-endepunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
@@ -238,13 +238,8 @@ class ForvaltningController(
 
     @Operation(summary = "Henter behandlinger med åpen GodkjennVedtak-oppgave som burde hatt åpen BehandleSak-oppgave")
     @GetMapping(
-        path = ["/hentBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave"],
+        path = ["/hentBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave/{fagsystem}"],
         produces = [MediaType.APPLICATION_JSON_VALUE],
-    )
-    @Rolletilgangssjekk(
-        Behandlerrolle.FORVALTER,
-        "Henter behandlinger med åpen GodkjennVedtak-oppgave som burde hatt åpen BehandleSak-oppgave",
-        AuditLoggerEvent.NONE,
     )
     fun hentBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave(@PathVariable fagsystem: Fagsystem): Ressurs<List<UUID>> {
         return Ressurs.success(forvaltningService.hentBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave(fagsystem))


### PR DESCRIPTION
Legger til PathVariable i Path for at endepunktet skal fungere og fjerner @Rolletilgangssjekk da det føles unødvendig for et midlertidig endepunkt som ikke returnerer noe sensitiv data.