### PR TITLE
Sørger for at vi setter saksbehandler til behandling.ansvarligSaksbehandler for nye BehandleSak-oppgaver

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.kt
@@ -45,7 +45,7 @@ class FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask(
             enhet = behandling.behandlendeEnhet,
             beskrivelse = payload.beskrivelse,
             fristForFerdigstillelse = payload.frist,
-            saksbehandler = null,
+            saksbehandler = behandling.ansvarligSaksbehandler,
             prioritet = prioritet
         )
     }


### PR DESCRIPTION
I de tilfellene vi blir nødt til å ferdigstille en `GodkjenneVedtak`-oppgave og opprette en ny `BehandleSak`-oppgave pga nytt kravgrunnlag etter at behandling er sendt til beslutter må vi sørge for at saksbehandler på den nye `BehandleSak`-oppgaven blir satt til `behandling.ansvarligSaksbehandler`