### PR TITLE
Må sammenligne Oppgave.oppgavetype med Oppgavetype.GodkjenneVedtak.value

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/FinnBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/FinnBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgaveTask.kt
@@ -48,7 +48,7 @@ class FinnBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgaveTas
 
     private fun Behandlingssteg?.erPåStegFørFatteVedtak(): Boolean = this != null && this.sekvens < Behandlingssteg.FATTE_VEDTAK.sekvens
 
-    private fun Oppgave?.erNullEllerGodkjenneVedtak(): Boolean = this == null || this.oppgavetype == Oppgavetype.GodkjenneVedtak.name
+    private fun Oppgave?.erNullEllerGodkjenneVedtak(): Boolean = this == null || this.oppgavetype == Oppgavetype.GodkjenneVedtak.value
 
     companion object {
         const val TYPE = "finnBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave"


### PR DESCRIPTION
Får bare treff på behandlinger som mangler oppgave, og ser at sjekken på om en oppgave er av typen GodkjenneVedtak aldri vil kunne bli true fordi vi forsøker å sammenligne Oppgavetype-enumen sin value mot Oppgavetype-enumens name. "GodkjenneVedtak" vil aldri kunne bli lik "GOD_VED".