### PR TITLE
Fix: Må sette oppgavetype spesifikt til GodkjenneVedtak ved ferdigstilling

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.kt
@@ -35,7 +35,7 @@ class FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask(
         godkjennVedtakOppgave?.let {
             oppgaveService.ferdigstillOppgave(
                 behandlingId = behandling.id,
-                oppgavetype = it.oppgavetype?.let { oppgavetype -> Oppgavetype.valueOf(oppgavetype) },
+                oppgavetype = Oppgavetype.GodkjenneVedtak,
             )
         }
 


### PR DESCRIPTION
Tasken `ferdigstillEksisterendeOppgaverOgOpprettNyBehandleSakTask` feiler fordi vi prøver å utlede Oppgavetype fra hentet Oppgave sin oppgavetype når vi skal ferdigstille oppgave. Oppgavetype fra Oppgave er `GOD_VED` og det vi forventer er `GodkjenneVedtak` og da feiler det. 

Fikser ved å eksplisitt sette oppgavetype til `Oppgavetype.GodkjenneVedtak` ved ferdigstillelse da vi vet at det er den typen vi skal ferdigstille uansett.