### PR TITLE
Oppretter en dummy behandling for lokal kjøring

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ For å kjøre opp appen lokalt kan en kjøre `LauncherLocalPostgres.kt`, eller `
 databasen selv. Begge krever at du har logget deg på gcloud `gcloud auth login` og at du er på Naisdevice.  
 Appen tilgjengeliggjøres da på `localhost:8030`.
 
-Det opprettes en dummy behandling ved oppstart, link til behandling skrives i console på formen (søk på "dummy-behandling"). Linken vil se slik ut: http://localhost:8000/fagsystem/EF/fagsak/1234567/behandling/{generertBehandlingId}
+Det opprettes en dummy behandling ved oppstart, link til behandling skrives i console og vil se slik ut: http://localhost:8000/fagsystem/EF/fagsak/1234567/behandling/{generertBehandlingId}
+Søk på `dummy-behandling` for å finne linken i console.
 
 ### Lokale avhengigheter
 For å teste tilbakekreving lokalt må du mest sannsynlig også sette opp disse repoene

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ For å kjøre opp appen lokalt kan en kjøre `LauncherLocalPostgres.kt`, eller `
 databasen selv. Begge krever at du har logget deg på gcloud `gcloud auth login` og at du er på Naisdevice.  
 Appen tilgjengeliggjøres da på `localhost:8030`.
 
+Det opprettes en dummy behandling ved oppstart, link til behandling skrives i console på formen (søk på "dummy-behandling"). Linken vil se slik ut: http://localhost:8000/fagsystem/EF/fagsak/1234567/behandling/{generertBehandlingId}
+
 ### Lokale avhengigheter
 For å teste tilbakekreving lokalt må du mest sannsynlig også sette opp disse repoene
 * [Familie-tilbake-frontend](https://github.com/navikt/familie-tilbake-frontend)

--- a/src/test/kotlin/no/nav/familie/tilbake/database/TestdataInitializer.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/database/TestdataInitializer.kt
@@ -63,7 +63,7 @@ class TestdataInitializer : ApplicationListener<ContextRefreshedEvent> {
 
             val mottattXml = readXml("/kravgrunnlagxml/kravgrunnlag_EF_over_4x_rettsgebyr.xml")
 
-            kravgrunnlagService.håndterMottattKravgrunnlag(mottattXml.replace("<urn:fagsystemId>testverdi</urn:fagsystemId>", "<urn:fagsystemId>testverdi</urn:fagsystemId>"))
+            kravgrunnlagService.håndterMottattKravgrunnlag(mottattXml.replace("<urn:fagsystemId>testverdi</urn:fagsystemId>", "<urn:fagsystemId>1234567</urn:fagsystemId>"))
         } else {
             logger.info("Opprettet dummy-behandling. Hvis frontend kjøres lokalt kan du gå til: http://localhost:8000/fagsystem/${opprettTilbakekrevingRequest.fagsystem}/fagsak/${opprettTilbakekrevingRequest.eksternFagsakId}/behandling/${åpenTilbakekrevingsbehandling.eksternBrukId}")
         }

--- a/src/test/kotlin/no/nav/familie/tilbake/database/TestdataInitializer.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/database/TestdataInitializer.kt
@@ -37,7 +37,7 @@ class TestdataInitializer : ApplicationListener<ContextRefreshedEvent> {
             fagsystem = Fagsystem.EF,
             eksternFagsakId = "1234567",
             personIdent = "321321322",
-            eksternId = "f5ed9439-54da-4f50-8457-534c417e3430", // Brukes ikke - det blir generert ny UUID
+            eksternId = "f5ed9439-54da-4f50-8457-534c417e3430",
             manueltOpprettet = false,
             språkkode = Språkkode.NB,
             enhetId = "8020",

--- a/src/test/kotlin/no/nav/familie/tilbake/database/TestdataInitializer.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/database/TestdataInitializer.kt
@@ -1,0 +1,76 @@
+package no.nav.familie.tilbake.database
+
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.Språkkode
+import no.nav.familie.kontrakter.felles.tilbakekreving.Faktainfo
+import no.nav.familie.kontrakter.felles.tilbakekreving.OpprettTilbakekrevingRequest
+import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_UTEN_VARSEL
+import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype.OVERGANGSSTØNAD
+import no.nav.familie.tilbake.behandling.BehandlingRepository
+import no.nav.familie.tilbake.behandling.BehandlingService
+import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagService
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationListener
+import org.springframework.context.annotation.Profile
+import org.springframework.context.event.ContextRefreshedEvent
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+@Component
+@Profile("local")
+class TestdataInitializer : ApplicationListener<ContextRefreshedEvent> {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    @Autowired
+    lateinit var behandlingService: BehandlingService
+
+    @Autowired
+    lateinit var behandlingRepository: BehandlingRepository
+
+    @Autowired
+    lateinit var kravgrunnlagService: KravgrunnlagService
+
+    val opprettTilbakekrevingRequest =
+        OpprettTilbakekrevingRequest(
+            ytelsestype = OVERGANGSSTØNAD,
+            fagsystem = Fagsystem.EF,
+            eksternFagsakId = "1234567",
+            personIdent = "321321322",
+            eksternId = "f5ed9439-54da-4f50-8457-534c417e3430", // Brukes ikke - det blir generert ny UUID
+            manueltOpprettet = false,
+            språkkode = Språkkode.NB,
+            enhetId = "8020",
+            enhetsnavn = "Oslo",
+            varsel = null,
+            revurderingsvedtaksdato = LocalDate.now().minusDays(10),
+            verge = null,
+            faktainfo = Faktainfo("årsak", "resultat", OPPRETT_TILBAKEKREVING_UTEN_VARSEL, setOf("ENF")),
+            saksbehandlerIdent = "Z0000",
+            institusjon = null,
+            manuelleBrevmottakere = emptySet(),
+            begrunnelseForTilbakekreving = null,
+        )
+
+    override fun onApplicationEvent(event: ContextRefreshedEvent) {
+        val åpenTilbakekrevingsbehandling = behandlingRepository.finnÅpenTilbakekrevingsbehandling(OVERGANGSSTØNAD, "1234567")
+
+        if (åpenTilbakekrevingsbehandling == null) {
+            behandlingService.opprettBehandling(opprettTilbakekrevingRequest)
+
+            val behandling = behandlingRepository.finnNyesteTilbakekrevingsbehandlingForYtelsestypeAndEksternFagsakId(opprettTilbakekrevingRequest.ytelsestype, opprettTilbakekrevingRequest.eksternFagsakId)
+            logger.info("Opprettet dummy-behandling. Hvis frontend kjøres lokalt kan du gå til: http://localhost:8000/fagsystem/${opprettTilbakekrevingRequest.fagsystem}/fagsak/${opprettTilbakekrevingRequest.eksternFagsakId}/behandling/${behandling?.eksternBrukId}")
+
+            val mottattXml = readXml("/kravgrunnlagxml/kravgrunnlag_EF_over_4x_rettsgebyr.xml")
+
+            kravgrunnlagService.håndterMottattKravgrunnlag(mottattXml.replace("<urn:fagsystemId>testverdi</urn:fagsystemId>", "<urn:fagsystemId>testverdi</urn:fagsystemId>"))
+        } else {
+            logger.info("Opprettet dummy-behandling. Hvis frontend kjøres lokalt kan du gå til: http://localhost:8000/fagsystem/${opprettTilbakekrevingRequest.fagsystem}/fagsak/${opprettTilbakekrevingRequest.eksternFagsakId}/behandling/${åpenTilbakekrevingsbehandling.eksternBrukId}")
+        }
+    }
+
+    fun readXml(fileName: String): String {
+        val url = requireNotNull(this::class.java.getResource(fileName)) { "fil med filnavn=$fileName finnes ikke" }
+        return url.readText()
+    }
+}


### PR DESCRIPTION
Oppretter en dummy-behandling med kravgrunnlag ved oppstart av app. Hadde håpet på at det kunne bli en fast URL som kunne stått i readme, men eksternId i opprettTilbakekrevingRequest bruker ikke verdien videre, og det blir dermed generert en ny UUID. Mulig det er en bug. Tenkte å se på det i egen PR.