### PR TITLE
Kjør Ktlint i PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ktlint:
+    name: Ktlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      - name: Kjør ktlint
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mvn -B --no-transfer-progress antrun:run@ktlint --settings .m2/maven-settings.xml
   build-jar-docker:
     if: github.event.pull_request.draft == false
     name: Bygg app/image, push til github


### PR DESCRIPTION
Dette for å unngå at man sjekker inn kode som ikke er lintet. Det kan være litt kjedelig å få med irrelevante linterendringer i en PR for nestemann dersom dette er glemt.