### PR TITLE
Bruk ekstern id fra opprett tilbakekreving request

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/forvaltning/ForvaltningController.kt
@@ -242,7 +242,9 @@ class ForvaltningController(
         path = ["/finnBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave/{fagsystem}"],
         produces = [MediaType.APPLICATION_JSON_VALUE],
     )
-    fun finnBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave(@PathVariable fagsystem: Fagsystem) {
+    fun finnBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave(
+        @PathVariable fagsystem: Fagsystem,
+    ) {
         oppgaveTaskService.finnBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave(fagsystem)
     }
 
@@ -251,12 +253,13 @@ class ForvaltningController(
         path = ["/ferdigstillGodkjenneVedtakOppgaveOgOpprettBehandleSakOppgave"],
         produces = [MediaType.APPLICATION_JSON_VALUE],
     )
-    fun ferdigstillGodkjenneVedtakOppgaveOgOpprettBehandleSakOppgave(@RequestBody behandlingIder: List<UUID>) {
+    fun ferdigstillGodkjenneVedtakOppgaveOgOpprettBehandleSakOppgave(
+        @RequestBody behandlingIder: List<UUID>,
+    ) {
         behandlingIder.forEach {
             oppgaveTaskService.ferdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgave(it, "--- Opprettet av familie-tilbake ${LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)} --- \n", LocalDate.now())
         }
     }
-
 }
 
 data class Behandlingsinfo(

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingMapper.kt
@@ -36,6 +36,7 @@ import no.nav.familie.tilbake.behandlingskontroll.Behandlingsstegsinfo
 import no.nav.familie.tilbake.common.ContextService
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerMapper
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.domene.ManuellBrevmottaker
+import java.util.UUID
 
 object BehandlingMapper {
     fun tilDomeneBehandling(
@@ -67,6 +68,7 @@ object BehandlingMapper {
             behandlendeEnhet = opprettTilbakekrevingRequest.enhetId,
             behandlendeEnhetsNavn = opprettTilbakekrevingRequest.enhetsnavn,
             manueltOpprettet = opprettTilbakekrevingRequest.manueltOpprettet,
+            eksternBrukId = UUID.fromString(opprettTilbakekrevingRequest.eksternId),
             fagsystemsbehandling = setOf(fagsystemsbehandling),
             varsler = varsler,
             verger = verger,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingRepository.kt
@@ -112,7 +112,7 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
             JOIN behandling b ON bst.behandling_id = b.id
             JOIN fagsak f ON b.fagsak_id = f.id
             WHERE f.fagsystem = :fagsystem AND bst.behandlingssteg = 'FATTE_VEDTAK' AND bst.behandlingsstegsstatus = 'TILBAKEFØRT' AND b.status != 'AVSLUTTET'
-        """
+        """,
     )
     fun hentÅpneBehandlingerMedTilbakeførtFatteVedtakSteg(fagsystem: Fagsystem): List<Behandling>
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.kt
@@ -24,8 +24,7 @@ class FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask(
     val fagsakRepository: FagsakRepository,
     val oppgaveService: OppgaveService,
     val oppgavePrioritetService: OppgavePrioritetService,
-): AsyncTaskStep {
-
+) : AsyncTaskStep {
     override fun doTask(task: Task) {
         val payload = objectMapper.readValue(task.payload, FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveDto::class.java)
         val behandling = behandlingRepository.findByIdOrThrow(payload.behandlingId)
@@ -46,7 +45,7 @@ class FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask(
             beskrivelse = payload.beskrivelse,
             fristForFerdigstillelse = payload.frist,
             saksbehandler = behandling.ansvarligSaksbehandler,
-            prioritet = prioritet
+            prioritet = prioritet,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/FinnBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/FinnBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgaveTask.kt
@@ -24,25 +24,27 @@ import org.springframework.stereotype.Service
 class FinnBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgaveTask(
     val behandlingRepository: BehandlingRepository,
     val oppgaveService: OppgaveService,
-    val behandlingskontrollService: BehandlingskontrollService
-): AsyncTaskStep {
+    val behandlingskontrollService: BehandlingskontrollService,
+) : AsyncTaskStep {
     override fun doTask(task: Task) {
         val fagsystem = Fagsystem.valueOf(task.payload)
         val behandlingerMedTilbakeførtFatteVedtakSteg = behandlingRepository.hentÅpneBehandlingerMedTilbakeførtFatteVedtakSteg(fagsystem)
-        val behandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave = behandlingerMedTilbakeførtFatteVedtakSteg.filter {
-            val aktivOppgave = try {
-                oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(it.id)
-            } catch (e: ManglerOppgaveFeil) {
-                null
-            }
-            val aktivtSteg = behandlingskontrollService.finnAktivtSteg(it.id)
-            aktivtSteg.erPåStegFørFatteVedtak() && aktivOppgave.erNullEllerGodkjenneVedtak()
-        }.map { it.id }
+        val behandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave =
+            behandlingerMedTilbakeførtFatteVedtakSteg.filter {
+                val aktivOppgave =
+                    try {
+                        oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(it.id)
+                    } catch (e: ManglerOppgaveFeil) {
+                        null
+                    }
+                val aktivtSteg = behandlingskontrollService.finnAktivtSteg(it.id)
+                aktivtSteg.erPåStegFørFatteVedtak() && aktivOppgave.erNullEllerGodkjenneVedtak()
+            }.map { it.id }
 
         if (behandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave.isNotEmpty()) {
-            secureLogger.info("Behandlinger som mangler oppgave eller har feil åpen oppgave for fagsystem ${fagsystem}: ${objectMapper.writeValueAsString(behandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave)}")
+            secureLogger.info("Behandlinger som mangler oppgave eller har feil åpen oppgave for fagsystem $fagsystem: ${objectMapper.writeValueAsString(behandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgave)}")
         } else {
-            secureLogger.info("Ingen behandlinger for fagsystem ${fagsystem} mangler oppgave eller har feil åpen oppgave.")
+            secureLogger.info("Ingen behandlinger for fagsystem $fagsystem mangler oppgave eller har feil åpen oppgave.")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveTaskService.kt
@@ -202,18 +202,23 @@ class OppgaveTaskService(
     }
 
     @Transactional
-    fun ferdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgave(behandlingId: UUID, beskrivelse: String, frist: LocalDate) {
+    fun ferdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgave(
+        behandlingId: UUID,
+        beskrivelse: String,
+        frist: LocalDate,
+    ) {
         taskService.save(
             Task(
                 type = FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.TYPE,
-                payload = objectMapper.writeValueAsString(
-                    FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveDto(
-                        behandlingId = behandlingId,
-                        beskrivelse = beskrivelse,
-                        frist = frist
-                    )
-                )
-            )
+                payload =
+                    objectMapper.writeValueAsString(
+                        FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveDto(
+                            behandlingId = behandlingId,
+                            beskrivelse = beskrivelse,
+                            frist = frist,
+                        ),
+                    ),
+            ),
         )
     }
 
@@ -222,8 +227,8 @@ class OppgaveTaskService(
         taskService.save(
             Task(
                 type = FinnBehandlingerMedGodkjennVedtakOppgaveSomSkulleHattBehandleSakOppgaveTask.TYPE,
-                payload = fagsystem.name
-            )
+                payload = fagsystem.name,
+            ),
         )
     }
 }

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingServiceTest.kt
@@ -367,7 +367,7 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
         behandlingRepository.update(lagretBehandling.copy(status = Behandlingsstatus.AVSLUTTET))
 
         val kontantstøtteOpprettTilbakekrevingRequest =
-            opprettTilbakekrevingRequest.copy(fagsystem = Fagsystem.KONT, ytelsestype = KONTANTSTØTTE)
+            opprettTilbakekrevingRequest.copy(fagsystem = Fagsystem.KONT, ytelsestype = KONTANTSTØTTE, eksternId = UUID.randomUUID().toString())
 
         val opprettetBehandling =
             behandlingService.opprettBehandling(

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/task/OpprettBehandlingManuellTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/task/OpprettBehandlingManuellTaskTest.kt
@@ -80,7 +80,7 @@ internal class OpprettBehandlingManuellTaskTest : OppslagSpringRunnerTest() {
 
     private val eksternFagsakId = "testverdi"
     private val ytelsestype = Ytelsestype.BARNETRYGD
-    private val eksternId = "testverdi"
+    private val eksternId = UUID.randomUUID().toString()
     private val ansvarligSaksbehandler = "Z0000"
 
     @BeforeEach

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/BehandleKravgrunnlagTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/BehandleKravgrunnlagTaskTest.kt
@@ -706,7 +706,7 @@ internal class BehandleKravgrunnlagTaskTest : OppslagSpringRunnerTest() {
                 BigInteger.ZERO,
                 BigInteger.ZERO,
             )
-        assertOkoXmlMottattData(mottattKravgrunnlagListe, kravgrunnlagXml, Kravstatuskode.NYTT, "0", "2021-03-02-18.50.15.236315")
+        assertOkoXmlMottattData(mottattKravgrunnlagListe, kravgrunnlagXml, Kravstatuskode.NYTT, "3bfda9a8-49f6-4c0d-aedd-d844a038c2ad", "2021-03-02-18.50.15.236315")
 
         mottattXmlArkivRepository.findAll().toList().shouldBeEmpty()
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/FinnKravgrunnlagTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/FinnKravgrunnlagTaskTest.kt
@@ -252,7 +252,7 @@ internal class FinnKravgrunnlagTaskTest : OppslagSpringRunnerTest() {
                 fagsystem = Fagsystem.BA,
                 eksternFagsakId = eksternFagsakId,
                 personIdent = "321321322",
-                eksternId = "0",
+                eksternId = UUID.randomUUID().toString(),
                 manueltOpprettet = false,
                 språkkode = Språkkode.NB,
                 enhetId = "8020",

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravvedtakstatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravvedtakstatusServiceTest.kt
@@ -35,18 +35,19 @@ class KravvedtakstatusServiceTest {
     private val historikkTaskService: HistorikkTaskService = mockk()
     private val oppgaveTaskService: OppgaveTaskService = mockk()
     private val oppgaveService: OppgaveService = mockk()
-    private val kravvedtakstatusService = KravvedtakstatusService(
-        kravgrunnlagRepository = kravgrunnlagRepository,
-        behandlingRepository = behandlingRepository,
-        mottattXmlService = mottattXmlService,
-        stegService = stegService,
-        tellerService = tellerService,
-        behandlingskontrollService = behandlingskontrollService,
-        behandlingService = behandlingService,
-        historikkTaskService = historikkTaskService,
-        oppgaveTaskService = oppgaveTaskService,
-        oppgaveService = oppgaveService
-    )
+    private val kravvedtakstatusService =
+        KravvedtakstatusService(
+            kravgrunnlagRepository = kravgrunnlagRepository,
+            behandlingRepository = behandlingRepository,
+            mottattXmlService = mottattXmlService,
+            stegService = stegService,
+            tellerService = tellerService,
+            behandlingskontrollService = behandlingskontrollService,
+            behandlingService = behandlingService,
+            historikkTaskService = historikkTaskService,
+            oppgaveTaskService = oppgaveTaskService,
+            oppgaveService = oppgaveService,
+        )
 
     val behandling = lagBehandling()
     val kravgrunnlag = mockk<Kravgrunnlag431>(relaxed = true)

--- a/src/test/kotlin/no/nav/familie/tilbake/oppgave/FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/oppgave/FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakTaskTest.kt
@@ -29,12 +29,13 @@ class FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakTaskTest {
     val oppgaveService: OppgaveService = mockk()
     val oppgavePrioritetService: OppgavePrioritetService = mockk()
 
-    val ferdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask = FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask(
-        behandlingRepository = behandlingRepository,
-        fagsakRepository = fagsakRepository,
-        oppgaveService = oppgaveService,
-        oppgavePrioritetService = oppgavePrioritetService
-    )
+    val ferdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask =
+        FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask(
+            behandlingRepository = behandlingRepository,
+            fagsakRepository = fagsakRepository,
+            oppgaveService = oppgaveService,
+            oppgavePrioritetService = oppgavePrioritetService,
+        )
 
     @AfterEach
     fun afterEach() {
@@ -58,29 +59,35 @@ class FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakTaskTest {
         val fristSlot = slot<LocalDate>()
         val frist = LocalDate.now()
         // Act
-        ferdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.doTask(Task(
-            type = FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.TYPE,
-            payload = objectMapper.writeValueAsString(
-                FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveDto(
-                    behandlingId = behandling.id,
-                    beskrivelse = Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG.beskrivelse,
-                    frist = frist
-                ))
-        ))
+        ferdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.doTask(
+            Task(
+                type = FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.TYPE,
+                payload =
+                    objectMapper.writeValueAsString(
+                        FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveDto(
+                            behandlingId = behandling.id,
+                            beskrivelse = Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG.beskrivelse,
+                            frist = frist,
+                        ),
+                    ),
+            ),
+        )
 
         // Assert
-        verify (exactly = 1) {oppgaveService.ferdigstillOppgave(any(), capture(oppgavetypeFerdigstillSlot))}
+        verify(exactly = 1) { oppgaveService.ferdigstillOppgave(any(), capture(oppgavetypeFerdigstillSlot)) }
         assertThat(oppgavetypeFerdigstillSlot.captured).isEqualTo(Oppgavetype.GodkjenneVedtak)
 
-        verify(exactly = 1) {oppgaveService.opprettOppgave(
-            behandlingId = any(),
-            oppgavetype = capture(oppgavetypeOpprettSlot),
-            enhet = any(),
-            beskrivelse = capture(beskrivelseSlot),
-            fristForFerdigstillelse = capture(fristSlot),
-            saksbehandler = any(),
-            prioritet = any()
-        )}
+        verify(exactly = 1) {
+            oppgaveService.opprettOppgave(
+                behandlingId = any(),
+                oppgavetype = capture(oppgavetypeOpprettSlot),
+                enhet = any(),
+                beskrivelse = capture(beskrivelseSlot),
+                fristForFerdigstillelse = capture(fristSlot),
+                saksbehandler = any(),
+                prioritet = any(),
+            )
+        }
         assertThat(oppgavetypeOpprettSlot.captured).isEqualTo(Oppgavetype.BehandleSak)
         assertThat(beskrivelseSlot.captured).isEqualTo(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG.beskrivelse)
         assertThat(fristSlot.captured).isEqualTo(frist)
@@ -96,18 +103,22 @@ class FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakTaskTest {
         every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), any(), any()) } just runs
         every { oppgavePrioritetService.utledOppgaveprioritet(any()) } returns OppgavePrioritet.NORM
         // Act
-        ferdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.doTask(Task(
-            type = FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.TYPE,
-            payload = objectMapper.writeValueAsString(
-                FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveDto(
-                    behandlingId = behandling.id,
-                    beskrivelse = Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG.beskrivelse,
-                    frist = LocalDate.now()
-                ))
-        ))
+        ferdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.doTask(
+            Task(
+                type = FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.TYPE,
+                payload =
+                    objectMapper.writeValueAsString(
+                        FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveDto(
+                            behandlingId = behandling.id,
+                            beskrivelse = Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG.beskrivelse,
+                            frist = LocalDate.now(),
+                        ),
+                    ),
+            ),
+        )
 
         // Assert
-        verify (exactly = 0) {oppgaveService.ferdigstillOppgave(any(), any())}
-        verify(exactly = 1) {oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), any(), any())}
+        verify(exactly = 0) { oppgaveService.ferdigstillOppgave(any(), any()) }
+        verify(exactly = 1) { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), any(), any()) }
     }
 }

--- a/src/test/resources/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml
+++ b/src/test/resources/kravgrunnlagxml/kravgrunnlag_BA_riktig_eksternfagsakId_ytelsestype.xml
@@ -17,7 +17,7 @@
         <urn:enhetBehandl>8020</urn:enhetBehandl>
         <urn:kontrollfelt>2021-03-02-18.50.15.236315</urn:kontrollfelt>
         <urn:saksbehId>K231B433</urn:saksbehId>
-        <urn:referanse>0</urn:referanse>
+        <urn:referanse>3bfda9a8-49f6-4c0d-aedd-d844a038c2ad</urn:referanse>
         <urn:tilbakekrevingsPeriode>
             <urn:periode>
                 <mmel:fom>2020-08-01</mmel:fom>


### PR DESCRIPTION
OpprettTilbakekrevingRequest inneholder feltet eksternId som ikke blir brukt ved opprettelse av behandling. Alternativet er å fjerne feltet fra request.