### PR TITLE
Fix: Ferdigstill korrekt oppgavetype når behandling sendes til beslutter

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreslåvedtakssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreslåvedtakssteg.kt
@@ -69,7 +69,7 @@ class Foreslåvedtakssteg(
 
         flyttBehandlingVidere(behandlingId)
 
-        ferdigstillOppgave(behandlingId)
+        ferdigstillOppgave(behandling)
         opprettGodkjennevedtakOppgave(behandlingId)
 
         historikkTaskService.lagHistorikkTask(
@@ -139,23 +139,22 @@ class Foreslåvedtakssteg(
 
     // Her vet vi ikke hvorvidt vi skal ferdigstille en BehandleSak- eller en BehandleUnderkjentVedtak-oppgave.
     // Må derfor sjekke hva slags oppgave som ligger åpen og ferdigstille denne.
-    private fun ferdigstillOppgave(behandlingId: UUID) {
+    private fun ferdigstillOppgave(behandling: Behandling) {
         val muligeOppgavetyper = mapOf(
             Oppgavetype.BehandleSak.value to Oppgavetype.BehandleSak,
             Oppgavetype.BehandleUnderkjentVedtak.value to Oppgavetype.BehandleUnderkjentVedtak
         )
 
-        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
-        val fagsak = fagsakRepository.finnFagsakForBehandlingId(behandlingId)
+        val fagsak = fagsakRepository.finnFagsakForBehandlingId(behandling.id)
 
         val (_, finnOppgaveResponse) = oppgaveService.finnOppgave(behandling = behandling, oppgavetype = null, fagsak = fagsak)
         val oppgave = finnOppgaveResponse.oppgaver.singleOrNull { muligeOppgavetyper.containsKey(it.oppgavetype) }
 
         if (oppgave != null) {
             val oppgavetype = muligeOppgavetyper.getValue(oppgave.oppgavetype!!)
-            oppgaveTaskService.ferdigstilleOppgaveTask(behandlingId = behandlingId, oppgavetype = oppgavetype.name)
+            oppgaveTaskService.ferdigstilleOppgaveTask(behandlingId = behandling.id, oppgavetype = oppgavetype.name)
         } else {
-            logger.warn("Finnes ingen ${Oppgavetype.BehandleSak.name} eller ${Oppgavetype.BehandleUnderkjentVedtak.name} -oppgave å ferdigstille for behandling ${behandlingId}")
+            logger.warn("Finnes ingen ${Oppgavetype.BehandleSak.name} eller ${Oppgavetype.BehandleUnderkjentVedtak.name} -oppgave å ferdigstille for behandling ${behandling.id}")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreslåvedtakssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreslåvedtakssteg.kt
@@ -21,7 +21,6 @@ import no.nav.familie.tilbake.historikkinnslag.TilbakekrevingHistorikkinnslagsty
 import no.nav.familie.tilbake.kravgrunnlag.event.EndretKravgrunnlagEvent
 import no.nav.familie.tilbake.oppgave.OppgaveService
 import no.nav.familie.tilbake.oppgave.OppgaveTaskService
-import no.nav.familie.tilbake.totrinn.TotrinnService
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
 import org.springframework.http.HttpStatus
@@ -37,7 +36,6 @@ class Foreslåvedtakssteg(
     private val behandlingskontrollService: BehandlingskontrollService,
     private val vedtaksbrevService: VedtaksbrevService,
     private val oppgaveTaskService: OppgaveTaskService,
-    private val totrinnService: TotrinnService,
     private val historikkTaskService: HistorikkTaskService,
     private val oppgaveService: OppgaveService,
 ) : IBehandlingssteg {
@@ -95,7 +93,7 @@ class Foreslåvedtakssteg(
         // lukker BehandleSak oppgave og oppretter GodkjenneVedtak oppgave
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         if (behandling.saksbehandlingstype != Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR) {
-            ferdigstillOppgave(behandlingId)
+            ferdigstillOppgave(behandling)
             opprettGodkjennevedtakOppgave(behandlingId)
             historikkTaskService.lagHistorikkTask(
                 behandlingId = behandlingId,

--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravvedtakstatusService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravvedtakstatusService.kt
@@ -182,7 +182,7 @@ class KravvedtakstatusService(
         val aktivtBehandlingssteg = behandlingskontrollService.finnAktivtSteg(behandlingId)
         if (aktivtBehandlingssteg?.let { it != Behandlingssteg.VARSEL } == true) {
             val oppgave = oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandlingId)
-            val behandleSakOppgavetyper = listOf(Oppgavetype.BehandleSak.name, Oppgavetype.BehandleUnderkjentVedtak.name)
+            val behandleSakOppgavetyper = listOf(Oppgavetype.BehandleSak.value, Oppgavetype.BehandleUnderkjentVedtak.value)
             if (behandleSakOppgavetyper.contains(oppgave.oppgavetype)) {
                 oppgaveTaskService.oppdaterOppgaveTask(
                     behandlingId = behandlingId,

--- a/src/test/kotlin/no/nav/familie/tilbake/config/IntegrasjonerClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/config/IntegrasjonerClientConfig.kt
@@ -279,7 +279,7 @@ class IntegrasjonerClientConfig {
                 } else {
                     FinnOppgaveResponseDto(
                         antallTreffTotalt = 1,
-                        oppgaver = listOf(Oppgave(id = 1, oppgavetype = Oppgavetype.BehandleSak.name)),
+                        oppgaver = listOf(Oppgave(id = 1, oppgavetype = Oppgavetype.BehandleSak.value)),
                     )
                 }
             }

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravvedtakstatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravvedtakstatusServiceTest.kt
@@ -85,7 +85,7 @@ class KravvedtakstatusServiceTest {
     fun `håndterSperMeldingMedBehandling - skal oppdatere oppgave dersom nåværende oppgave er BehandleSak, så lenge behandlingen ikke står på behandlingsteg VARSEL`(behandlingssteg: Behandlingssteg) {
         // Arrange
         every { behandlingskontrollService.finnAktivtSteg(any()) } returns behandlingssteg
-        every { oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(any()) } returns Oppgave(oppgavetype = Oppgavetype.BehandleSak.name)
+        every { oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(any()) } returns Oppgave(oppgavetype = Oppgavetype.BehandleSak.value)
 
         // Act
         kravvedtakstatusService.håndterSperMeldingMedBehandling(behandlingId = behandling.id, kravgrunnlag431 = kravgrunnlag)


### PR DESCRIPTION
Favro: [NAV-21928](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21928)

Tidligere når en behandling ble sendt til beslutter forsøkte vi å finne ut om vi skulle ferdigstille en `BehandleUnderkjentVedtak` eller en `BehandleSak` oppgave basert på om det fantes underkjente steg i behandlingen eller ikke. Dette ble ikke alltid riktig da saksbehandler kan ha en `BehandleSak` oppgave til tross for at det finnes underkjente steg i behandlingen. 

For å fikse dette sjekker vi nå hva slags oppgave (`BehandleSak` eller `BehandleUnderkjentVedtak`) som ligger åpen og ferdigstiller denne spesifikt.

I tillegg har jeg fikset en bug hvor vi forsøker å sammenligne feltet `oppgavetype` i `Oppgave` med `Oppgavetype.name`, når vi egentlig må sammenligne feltet `oppgavetype` med `Oppgavetype.value`.