### PR TITLE
Skrudd ned ventetid for når vi oppretter ny behandling basert på mottatt kravgrunnlag for kontantstøtte

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HåndterGamleKravgrunnlagBatch.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HåndterGamleKravgrunnlagBatch.kt
@@ -39,7 +39,7 @@ class HåndterGamleKravgrunnlagBatch(
         if (erLederEllerLokaltMiljø()) {
             logger.info("Starter HåndterGamleKravgrunnlagBatch..")
 
-            logger.info("Henter kravgrunnlag som er eldre enn $ALDERSGRENSE_I_UKER uker")
+            logger.info("Henter kravgrunnlag som er eldre enn $ALDERSGRENSE_I_DAGER uker")
 
             val frakobletKravgrunnlag =
                 mottattXmlService.hentFrakobletKravgrunnlag(
@@ -50,17 +50,17 @@ class HåndterGamleKravgrunnlagBatch(
                     beregnBestemtDato(KONTANTSTØTTE),
                 )
 
-            val frakobletKravgrunnlagGruppertPåEksternFagsakId = frakobletKravgrunnlag.groupBy { it.eksternFagsakId }
+            val frakobletKravgrunnlagGruppertPåEksternFagsakId = frakobletKravgrunnlag.groupBy { Pair(it.eksternFagsakId, it.ytelsestype) }
 
             if (frakobletKravgrunnlagGruppertPåEksternFagsakId.isEmpty()) {
-                logger.info("Det finnes ingen kravgrunnlag som er eldre enn $ALDERSGRENSE_I_UKER uker fra dagens dato")
+                logger.info("Det finnes ingen kravgrunnlag som er eldre enn $ALDERSGRENSE_I_DAGER dager fra dagens dato")
                 logger.info("Stopper HåndterGamleKravgrunnlagBatch..")
                 return
             }
 
             logger.info(
                 "Det finnes ${frakobletKravgrunnlag.size} kravgrunnlag som er eldre enn " +
-                    "$ALDERSGRENSE_I_UKER uker fra dagens dato",
+                    "$ALDERSGRENSE_I_DAGER dager fra dagens dato",
             )
 
             val taskerMedStatus =
@@ -104,7 +104,7 @@ class HåndterGamleKravgrunnlagBatch(
     }
 
     private fun beregnBestemtDato(ytelsestype: Ytelsestype): LocalDate {
-        return LocalDate.now().minusWeeks(ALDERSGRENSE_I_UKER.getValue(ytelsestype))
+        return LocalDate.now().minusDays(ALDERSGRENSE_I_DAGER.getValue(ytelsestype))
     }
 
     private fun sorterKravgrunnlagPåKontrollfelt(kravgrunnlagerPåFagsak: List<ØkonomiXmlMottatt>) =
@@ -152,13 +152,13 @@ class HåndterGamleKravgrunnlagBatch(
                 Status.MANUELL_OPPFØLGING,
             )
 
-        val ALDERSGRENSE_I_UKER =
+        val ALDERSGRENSE_I_DAGER =
             mapOf<Ytelsestype, Long>(
-                BARNETRYGD to 8,
-                BARNETILSYN to 8,
-                OVERGANGSSTØNAD to 8,
-                SKOLEPENGER to 8,
-                KONTANTSTØTTE to 8,
+                BARNETRYGD to 56,
+                BARNETILSYN to 56,
+                OVERGANGSSTØNAD to 56,
+                SKOLEPENGER to 56,
+                KONTANTSTØTTE to 1,
             )
     }
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HåndterGamleKravgrunnlagBatch.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HåndterGamleKravgrunnlagBatch.kt
@@ -39,7 +39,7 @@ class HåndterGamleKravgrunnlagBatch(
         if (erLederEllerLokaltMiljø()) {
             logger.info("Starter HåndterGamleKravgrunnlagBatch..")
 
-            logger.info("Henter kravgrunnlag som er eldre enn $ALDERSGRENSE_I_DAGER uker")
+            logger.info("Henter kravgrunnlag som er eldre enn $ALDERSGRENSE_I_DAGER dager")
 
             val frakobletKravgrunnlag =
                 mottattXmlService.hentFrakobletKravgrunnlag(
@@ -50,9 +50,9 @@ class HåndterGamleKravgrunnlagBatch(
                     beregnBestemtDato(KONTANTSTØTTE),
                 )
 
-            val frakobletKravgrunnlagGruppertPåEksternFagsakId = frakobletKravgrunnlag.groupBy { Pair(it.eksternFagsakId, it.ytelsestype) }
+            val frakobletKravgrunnlagGruppertPåEksternFagsakIdOgYtelsetype = frakobletKravgrunnlag.groupBy { Pair(it.eksternFagsakId, it.ytelsestype) }
 
-            if (frakobletKravgrunnlagGruppertPåEksternFagsakId.isEmpty()) {
+            if (frakobletKravgrunnlagGruppertPåEksternFagsakIdOgYtelsetype.isEmpty()) {
                 logger.info("Det finnes ingen kravgrunnlag som er eldre enn $ALDERSGRENSE_I_DAGER dager fra dagens dato")
                 logger.info("Stopper HåndterGamleKravgrunnlagBatch..")
                 return
@@ -69,9 +69,9 @@ class HåndterGamleKravgrunnlagBatch(
                     Pageable.unpaged(),
                 )
 
-            frakobletKravgrunnlagGruppertPåEksternFagsakId.forEach { (_, kravgrunnlagerPåFagsak) ->
+            frakobletKravgrunnlagGruppertPåEksternFagsakIdOgYtelsetype.forEach { (_, kravgrunnlagForFagsak) ->
 
-                val kravgrunnlagSortertEtterKontrollfelt = sorterKravgrunnlagPåKontrollfelt(kravgrunnlagerPåFagsak)
+                val kravgrunnlagSortertEtterKontrollfelt = sorterKravgrunnlagPåKontrollfelt(kravgrunnlagForFagsak)
 
                 kravgrunnlagSortertEtterKontrollfelt.forEachIndexed { index, kravgrunnlagPåFagsak ->
 


### PR DESCRIPTION
Favro: [NAV-22118](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22118)

Vi har 49 behandlinger i `ks-sak`, som kommer til å gi feilutbetalinger og dermed kravgrunnlag. Disse kravgrunnlagene ønsker vi at det skal opprettes tilbakekrevingsbehandlinger for så fort som mulig. Endrer derfor ventetiden fra 8 uker til 1 dag. Feilutbetalingene kommer fra automatiske revurderinger hvor tilbakekreving egentlig ikke skal forekomme, og `ks-sak` oppretter derfor heller ikke tilbakekrevingsbehandlingene selv.

Med en gang vi har fått opprettet de 49 behandlingene vil vi skru ventetiden tilbake til 8 uker. 