### PR TITLE
Skipper å lese melding med id 19527f36-bc9b-494a-b8f1-f54c3dc5e968

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/consumer/HentFagsystemsbehandlingResponsConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/consumer/HentFagsystemsbehandlingResponsConsumer.kt
@@ -30,6 +30,12 @@ class HentFagsystemsbehandlingResponsConsumer(private val fagsystemsbehandlingSe
     ) {
         logger.info("Fagsystemsbehandlingsdata er mottatt i kafka med key=${consumerRecord.key()}")
         secureLogger.info("Fagsystemsbehandlingsdata er mottatt i kafka $consumerRecord")
+        if (consumerRecord.key().toString() == "19527f36-bc9b-494a-b8f1-f54c3dc5e968") {
+            logger.error("Skipper melding med key 19527f36-bc9b-494a-b8f1-f54c3dc5e968")
+            latch.countDown()
+            ack.acknowledge()
+            return
+        }
 
         val requestId = UUID.fromString(consumerRecord.key())
         val data: String = consumerRecord.value()


### PR DESCRIPTION
https://nav-it.slack.com/archives/CJN0STWB0/p1724661202417699
Får feil med prosessering av melding, siden man ikke finner requestId med denne fagsystem.  Som da det blir kastet exception på.

Vi velger å skippe akkurat denne meldingen for å få lest resten av meldingene

![Screenshot 2024-08-26 at 10 37 02](https://github.com/user-attachments/assets/457952bd-4724-4ce3-9b58-541cd9025fe0)
