### PR TITLE
Justerer ventetid for kontantstøtte fra 1 dag til 56 dager (8 uker).

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HåndterGamleKravgrunnlagBatch.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/batch/HåndterGamleKravgrunnlagBatch.kt
@@ -158,7 +158,7 @@ class HåndterGamleKravgrunnlagBatch(
                 BARNETILSYN to 56,
                 OVERGANGSSTØNAD to 56,
                 SKOLEPENGER to 56,
-                KONTANTSTØTTE to 1,
+                KONTANTSTØTTE to 56,
             )
     }
 }


### PR DESCRIPTION
Justerer ventetiden tilbake til 8 uker for kontantstøtte nå som vi har fått opprettet tilbakekrevingsbehandlinger for alle fagsakene vi fikk feilutbetaling på i forbindelse med lovendring.