### PR TITLE
Tar i bruk github.event.pull_request.user.login ved sjekk av om bygg er dependabot

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -28,7 +28,6 @@ jobs:
         run: mvn -B --no-transfer-progress package verify -Dmaven.test.skip=true --settings .m2/maven-settings.xml -DtrimStackTrace=false --file pom.xml -Dchangelist= -Dsha1=-$TIMESTAMP-$(echo $GITHUB_SHA | cut -c1-7)
       - uses: nais/docker-build-push@v0
         id: docker-push
-        if: github.triggering_actor != 'dependabot[bot]'
         with:
           team: teamfamilie
           push_image: true
@@ -41,7 +40,6 @@ jobs:
       image: ${{ steps.docker-push.outputs.image }}
 
   run-junit:
-    if: github.event.pull_request.draft == false
     name: Kjøre junit tester
     runs-on: ubuntu-latest
     steps:
@@ -53,14 +51,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
           cache: 'maven'
-      - name: Bygg (dependabot)
-        if: github.actor == 'dependabot[bot]'
-        env:
-          GITHUB_USERNAME: x-access-token
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn verify --settings .m2/maven-settings.xml --file pom.xml
       - name: Bygg med maven + sonar
-        if: github.actor != 'dependabot[bot]'
         env:
           SONAR_PROJECTKEY: ${{ secrets.SONAR_PROJECTKEY }}
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
@@ -69,7 +60,6 @@ jobs:
         run: mvn -B --no-transfer-progress package --settings .m2/maven-settings.xml -DtrimStackTrace=false --file pom.xml -Dchangelist= -Dsha1=-$TIMESTAMP-$(echo $GITHUB_SHA | cut -c1-7)
 
   run-e2e:
-    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
     name: Kjør e2e tester
     permissions:
       contents: "read"
@@ -144,7 +134,6 @@ jobs:
           retention-days: 2
 
   deploy-to-dev:
-    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
     name: Deploy til dev-gcp
     runs-on: ubuntu-latest
     needs: [ build-jar-docker, run-junit ]

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -31,7 +31,6 @@ jobs:
         run: mvn -B --no-transfer-progress package --settings .m2/maven-settings.xml -DtrimStackTrace=false --file pom.xml -Dchangelist= -Dsha1=-$TIMESTAMP-$(echo $GITHUB_SHA | cut -c1-7)
       - uses: nais/docker-build-push@v0
         id: docker-push
-        if: github.triggering_actor != 'dependabot[bot]'
         with:
           team: teamfamilie
           tag: latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: mvn -B --no-transfer-progress package verify -Dmaven.test.skip=true --settings .m2/maven-settings.xml -DtrimStackTrace=false --file pom.xml -Dchangelist= -Dsha1=-$TIMESTAMP-$(echo $GITHUB_SHA | cut -c1-7)
       - uses: nais/docker-build-push@v0
         id: docker-push
-        if: github.triggering_actor != 'dependabot[bot]'
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         with:
           team: teamfamilie
           push_image: true
@@ -86,7 +86,7 @@ jobs:
         run: mvn --version && mvn -B --no-transfer-progress verify --settings .m2/maven-settings.xml --file pom.xml
 
   run-e2e:
-    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
     name: Kjør e2e tester
     runs-on: ubuntu-latest
     needs: build-jar-docker

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -6,7 +6,6 @@ env:
   IMAGE: ghcr.io/navikt/familie-tilbake:${{ github.sha }}
 jobs:
   run-e2e:
-    if: github.event.pull_request.draft == false
     name: Bygg app/image, push til github
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
NAV-22116
Anbefalt å sjekke på måten
github.event.pull_request.user.login != 'dependabot[bot]'


Pluss litt opprydding
- ** endrer build-pr jobb til å bruke github.event.pull_request.user.login != 'dependabot[bot]'**
- **Fjerner unødvendig dependabot-sjekker i jobb som kun trigges av workflow_dispatch**
- **Fjerner unødvendige sjekker i andre jobber også**
