### PR TITLE
Vil behandle "under fire rettsgebyr" behandlinger automatisk selv om …

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingService.kt
@@ -13,7 +13,6 @@ import no.nav.familie.tilbake.dokumentbestilling.felles.BrevsporingRepository
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
 import no.nav.familie.tilbake.kravgrunnlag.domain.Klassetype
 import no.nav.familie.tilbake.kravgrunnlag.domain.Kravgrunnlagsbeløp433
-import no.nav.familie.unleash.UnleashService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -39,7 +38,6 @@ class AutomatiskSaksbehandlingService(
     private val alderGrenseSkolepenger: Long,
     @Value("\${AUTOMATISK_SAKSBEHANDLING_ALDERGRENSE_KONTANTSTØTTE}")
     private val alderGrenseKontantstøtte: Long,
-    private val unleashService: UnleashService,
 ) {
     fun hentAlleBehandlingerSomKanBehandleAutomatisk(): List<Behandling> {
         val behandlinger =
@@ -83,11 +81,7 @@ class AutomatiskSaksbehandlingService(
 
     @Transactional
     fun behandleAutomatisk(behandlingId: UUID) {
-        if (unleashService.isEnabled("familie-tilbake.bruk-ny-haandterStegAutomatisk")) {
-            stegService.håndterStegAutomatisk(behandlingId)
-        } else {
-            stegService.håndterStegAutomatiskGAMMEL(behandlingId)
-        }
+        stegService.håndterStegAutomatisk(behandlingId)
     }
 
     private val aldersgrenseIUker =

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingTask.kt
@@ -10,8 +10,6 @@ import no.nav.familie.tilbake.behandling.domain.Saksbehandlingstype
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.config.Constants
-import no.nav.familie.tilbake.config.FeatureToggleConfig
-import no.nav.familie.tilbake.config.FeatureToggleService
 import no.nav.familie.tilbake.config.PropertyName
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagService
 import org.slf4j.LoggerFactory
@@ -30,7 +28,6 @@ class AutomatiskSaksbehandlingTask(
     private val automatiskSaksbehandlingService: AutomatiskSaksbehandlingService,
     private val kravgrunnlagService: KravgrunnlagService,
     private val behandlingRepository: BehandlingRepository,
-    private val featureToggleService: FeatureToggleService,
 ) : AsyncTaskStep {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -52,15 +49,6 @@ class AutomatiskSaksbehandlingTask(
             behandling.saksbehandlingstype == Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR
         ) {
             throw Feil("Skal ikke behandle beløp over 4x rettsgebyr automatisk")
-        }
-
-        if (!featureToggleService.isEnabled(FeatureToggleConfig.AUTOMATISK_BEHANDLE_TILBAKEKREVING_UNDER_4X_RETTSGEBYR) &&
-            behandling.saksbehandlingstype == Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR
-        ) {
-            throw Feil(
-                "Behandler ikke feilutbetalinger under 4 rettsgebyr automatisk da featuretoggle for dette er skrudd av " +
-                    "(${FeatureToggleConfig.AUTOMATISK_BEHANDLE_TILBAKEKREVING_UNDER_4X_RETTSGEBYR})",
-            )
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/StegService.kt
@@ -1,13 +1,11 @@
 package no.nav.familie.tilbake.behandling.steg
 
-import no.nav.familie.kontrakter.felles.Regelverk
 import no.nav.familie.tilbake.api.dto.BehandlingsstegDto
 import no.nav.familie.tilbake.api.dto.BehandlingsstegFatteVedtaksstegDto
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.ValiderBrevmottakerService
 import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Behandlingsstatus
-import no.nav.familie.tilbake.behandling.domain.Saksbehandlingstype
 import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
@@ -84,37 +82,6 @@ class StegService(
             )
         ) {
             hentStegInstans(aktivtBehandlingssteg).utførSteg(behandlingId)
-        }
-    }
-
-    @Deprecated("Skal bruke håndterStegAutomatisk. Kan fjernes når den er testet OK")
-    @Transactional
-    fun håndterStegAutomatiskGAMMEL(behandlingId: UUID) {
-        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
-        if (behandling.erSaksbehandlingAvsluttet) {
-            throw Feil("Behandling med id=$behandlingId er allerede ferdig behandlet")
-        }
-        if (behandling.regelverk == Regelverk.EØS) {
-            throw Feil("Behandling med id=$behandlingId behandles etter EØS-regelverket, og skal dermed ikke behandles automatisk.")
-        }
-        var aktivtBehandlingssteg = hentAktivBehandlingssteg(behandlingId)
-        val behandledeSteg = aktivtBehandlingssteg.name
-        if (behandlingskontrollService.erBehandlingPåVent(behandlingId)) {
-            throw Feil(message = "Behandling med id=$behandlingId er på vent, kan ikke behandle steg $behandledeSteg")
-        }
-        if (behandling.saksbehandlingstype == Saksbehandlingstype.ORDINÆR) {
-            throw Feil(
-                message =
-                    "Behandling med id=$behandlingId er satt til ordinær saksbehandling. " +
-                        "Kan ikke saksbehandle den automatisk",
-            )
-        }
-        while (aktivtBehandlingssteg != Behandlingssteg.AVSLUTTET) {
-            hentStegInstans(aktivtBehandlingssteg).utførStegAutomatisk(behandlingId)
-            if (aktivtBehandlingssteg == Behandlingssteg.IVERKSETT_VEDTAK) {
-                break
-            }
-            aktivtBehandlingssteg = hentAktivBehandlingssteg(behandlingId)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/ValiderStegUtil.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/ValiderStegUtil.kt
@@ -13,7 +13,7 @@ fun validerAtBehandlingIkkeErAvsluttet(behandling: Behandling) {
 }
 
 fun validerAtUtomatiskBehandlingIkkeErEøs(behandling: Behandling) {
-    if (behandling.regelverk == Regelverk.EØS) {
+    if (behandling.regelverk == Regelverk.EØS && behandling.saksbehandlingstype != Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR) {
         throw Feil("Behandling med id=${behandling.id} behandles etter EØS-regelverket, og skal dermed ikke behandles automatisk.")
     }
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
@@ -26,7 +26,6 @@ class FeatureToggleConfig(
         const val IKKE_VALIDER_SÆRLIG_GRUNNET_ANNET_FRITEKST =
             "familie-tilbake.ikke-valider-saerlig-grunnet-annet-fritekst"
 
-        const val AUTOMATISK_BEHANDLE_TILBAKEKREVING_UNDER_4X_RETTSGEBYR = "familie-tilbake.automatisk-behandle-under-4x-rettsgebyr"
         const val KAN_SE_HISTORISKE_VURDERINGER = "familie-tilbake.se-historiske-vurderinger"
 
         const val SAKSBEHANDLER_KAN_RESETTE_BEHANDLING = "familie-tilbake-frontend.saksbehandler.kan.resette.behandling"

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/BehandlingServiceTest.kt
@@ -425,7 +425,6 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
                 6,
                 integrasjonerClient,
                 validerBehandlingService,
-                featureToggleService,
                 oppgaveService,
             )
         justRun { validerBehandlingService.validerOpprettBehandling(any()) }
@@ -489,7 +488,6 @@ internal class BehandlingServiceTest : OppslagSpringRunnerTest() {
                 6,
                 integrasjonerClient,
                 validerBehandlingService,
-                featureToggleService,
                 oppgaveService,
             )
         justRun { validerBehandlingService.validerOpprettBehandling(any()) }

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.tilbake.kravgrunnlag
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.mockk.every
+import no.nav.familie.kontrakter.felles.Regelverk
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import no.nav.familie.prosessering.domene.Task
@@ -21,8 +21,6 @@ import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.config.Constants
 import no.nav.familie.tilbake.config.Constants.AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_AKTSOMHET_BEGRUNNELSE
 import no.nav.familie.tilbake.config.Constants.AUTOMATISK_SAKSBEHANDLING_UNDER_4X_RETTSGEBYR_VILKÅRSVURDERING_BEGRUNNELSE
-import no.nav.familie.tilbake.config.FeatureToggleConfig
-import no.nav.familie.tilbake.config.FeatureToggleService
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.dokumentbestilling.felles.task.PubliserJournalpostTask
 import no.nav.familie.tilbake.dokumentbestilling.vedtak.SendVedtaksbrevTask
@@ -74,22 +72,17 @@ class AutomatiskBehandlingAvKravgrunnlagUnder4RettsgebyrTest : OppslagSpringRunn
     @Autowired
     private lateinit var vilkårsvurderingService: VilkårsvurderingService
 
-    @Autowired
-    private lateinit var featureToggleService: FeatureToggleService
-
     private lateinit var behandlingId: UUID
 
     @BeforeEach
     fun init() {
         val fagsak = Testdata.fagsak
-        val behandling = Testdata.lagBehandling()
+        val behandling = Testdata.lagBehandling().copy(regelverk = Regelverk.EØS)
         val copyFagsystemsbehandling = behandling.fagsystemsbehandling.first().copy(tilbakekrevingsvalg = Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_AUTOMATISK, eksternId = "1")
         val automatiskBehandling = behandling.copy(saksbehandlingstype = Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR, fagsystemsbehandling = setOf(copyFagsystemsbehandling))
         val fagsakOvergangsstønad = fagsak.copy(ytelsestype = Ytelsestype.OVERGANGSSTØNAD)
         fagsakRepository.insert(fagsakOvergangsstønad)
         behandlingId = behandlingRepository.insert(automatiskBehandling).id
-
-        every { featureToggleService.isEnabled(FeatureToggleConfig.AUTOMATISK_BEHANDLE_TILBAKEKREVING_UNDER_4X_RETTSGEBYR) } returns true
     }
 
     @Test


### PR DESCRIPTION
…de er EØS saker. Vil fjerne toggles som ikke brukes.

For å slippe å legge inn samme endring flere steder sletter jeg nå deprecadted kode som har ligget bak påskrudd toggle i noen mnd. 

Den eneste reelle endringen er denne: 
src/main/kotlin/no/nav/familie/tilbake/behandling/steg/ValiderStegUtil.kt

&& behandling.saksbehandlingstype != Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR

```
fun validerAtUtomatiskBehandlingIkkeErEøs(behandling: Behandling) {
    if (behandling.regelverk == Regelverk.EØS && behandling.saksbehandlingstype != Saksbehandlingstype.AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR) {
        throw Feil("Behandling med id=${behandling.id} behandles etter EØS-regelverket, og skal dermed ikke behandles automatisk.")
    }
}
```