### PR TITLE
Nytt vedtak som tidligere er underkjent skal sendes til samme beslutter 

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreslåvedtakssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreslåvedtakssteg.kt
@@ -21,7 +21,7 @@ import no.nav.familie.tilbake.historikkinnslag.TilbakekrevingHistorikkinnslagsty
 import no.nav.familie.tilbake.kravgrunnlag.event.EndretKravgrunnlagEvent
 import no.nav.familie.tilbake.oppgave.OppgaveService
 import no.nav.familie.tilbake.oppgave.OppgaveTaskService
-import no.nav.familie.tilbake.totrinn.TotrinnsvurderingRepository
+import no.nav.familie.tilbake.totrinn.TotrinnService
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
 import org.springframework.http.HttpStatus
@@ -39,7 +39,7 @@ class Foreslåvedtakssteg(
     private val oppgaveTaskService: OppgaveTaskService,
     private val historikkTaskService: HistorikkTaskService,
     private val oppgaveService: OppgaveService,
-    private val totrinnsvurderingRepository: TotrinnsvurderingRepository,
+    private val totrinnService: TotrinnService,
 ) : IBehandlingssteg {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -165,18 +165,9 @@ class Foreslåvedtakssteg(
                 behandling = behandling,
                 oppgavetype = Oppgavetype.GodkjenneVedtak,
                 opprettetAv = ContextService.hentSaksbehandlerNavn(),
-                saksbehandler = finnTidligereBeslutter(behandlingId),
+                saksbehandler = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId),
             )
         }
-    }
-
-    private fun finnTidligereBeslutter(behandlingId: UUID): String? {
-        val totrinnsvurderinger = totrinnsvurderingRepository.findByBehandlingIdAndAktivIsTrue(behandlingId)
-        return totrinnsvurderinger
-            .find { it.godkjent == false }
-            ?.sporbar
-            ?.endret
-            ?.endretAv
     }
 
     private fun validerAtDetFinnesOppgave(

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreslåvedtakssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreslåvedtakssteg.kt
@@ -166,7 +166,7 @@ class Foreslåvedtakssteg(
         if (behandling.saksbehandlingstype == Saksbehandlingstype.ORDINÆR) {
             val tidligerebeslutter =
                 when (featureToggleService.isEnabled(FeatureToggleConfig.TIDLIGERE_BESLUTTER)) {
-                    true -> totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
+                    true -> totrinnService.finnForrigeBeslutterMedNyVurderingEllerNull(behandlingId)
                     false -> null
                 }
             oppgaveTaskService.opprettOppgaveTask(

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreslåvedtakssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreslåvedtakssteg.kt
@@ -42,7 +42,7 @@ class Foreslåvedtakssteg(
     private val historikkTaskService: HistorikkTaskService,
     private val oppgaveService: OppgaveService,
     private val totrinnService: TotrinnService,
-    private val featureToggleService: FeatureToggleService
+    private val featureToggleService: FeatureToggleService,
 ) : IBehandlingssteg {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -164,10 +164,11 @@ class Foreslåvedtakssteg(
     private fun opprettGodkjennevedtakOppgave(behandlingId: UUID) {
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         if (behandling.saksbehandlingstype == Saksbehandlingstype.ORDINÆR) {
-            val tidligerebeslutter = when (featureToggleService.isEnabled(FeatureToggleConfig.TIDLIGERE_BESLUTTER)) {
-                true -> totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
-                false -> null
-            }
+            val tidligerebeslutter =
+                when (featureToggleService.isEnabled(FeatureToggleConfig.TIDLIGERE_BESLUTTER)) {
+                    true -> totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
+                    false -> null
+                }
             oppgaveTaskService.opprettOppgaveTask(
                 behandling = behandling,
                 oppgavetype = Oppgavetype.GodkjenneVedtak,

--- a/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/FeatureToggleConfig.kt
@@ -29,6 +29,8 @@ class FeatureToggleConfig(
         const val KAN_SE_HISTORISKE_VURDERINGER = "familie-tilbake.se-historiske-vurderinger"
 
         const val SAKSBEHANDLER_KAN_RESETTE_BEHANDLING = "familie-tilbake-frontend.saksbehandler.kan.resette.behandling"
+
+        const val TIDLIGERE_BESLUTTER = "familie-tilbake.tidligere-beslutter"
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/totrinn/TotrinnService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/totrinn/TotrinnService.kt
@@ -97,7 +97,8 @@ class TotrinnService(
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         behandlingRepository.update(behandling.copy(ansvarligBeslutter = null))
     }
-        // finnTidligereBeslutterHvisUnderkjentVurdering
+
+    // finnTidligereBeslutterHvisUnderkjentVurdering
     fun finnForrigeBeslutterMedNyVurderingEllerNull(behandlingId: UUID): String? =
         totrinnsvurderingRepository
             .findByBehandlingIdAndAktivIsTrue(behandlingId)

--- a/src/main/kotlin/no/nav/familie/tilbake/totrinn/TotrinnService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/totrinn/TotrinnService.kt
@@ -98,17 +98,19 @@ class TotrinnService(
         behandlingRepository.update(behandling.copy(ansvarligBeslutter = null))
     }
 
-    fun finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId: UUID): String? {
-        return totrinnsvurderingRepository.findByBehandlingIdAndAktivIsTrue(behandlingId)
+    fun finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId: UUID): String? =
+        totrinnsvurderingRepository
+            .findByBehandlingIdAndAktivIsTrue(behandlingId)
             .find { !it.godkjent }
             ?.takeIf { erEndretTidUnder1Mnd(it) }
             ?.sporbar
             ?.endret
             ?.endretAv
-    }
 
     private fun erEndretTidUnder1Mnd(totrinnsvurdering: Totrinnsvurdering): Boolean {
-        val endretTid = totrinnsvurdering.sporbar.endret.endretTid.toLocalDate()
+        val endretTid =
+            totrinnsvurdering.sporbar.endret.endretTid
+                .toLocalDate()
         return endretTid.isAfter(LocalDate.now().minusMonths(1))
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/totrinn/TotrinnService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/totrinn/TotrinnService.kt
@@ -97,8 +97,8 @@ class TotrinnService(
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         behandlingRepository.update(behandling.copy(ansvarligBeslutter = null))
     }
-
-    fun finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId: UUID): String? =
+        // finnTidligereBeslutterHvisUnderkjentVurdering
+    fun finnForrigeBeslutterMedNyVurderingEllerNull(behandlingId: UUID): String? =
         totrinnsvurderingRepository
             .findByBehandlingIdAndAktivIsTrue(behandlingId)
             .find { !it.godkjent }

--- a/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceTest.kt
@@ -228,9 +228,8 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
         assertThat(tidligerebeslutter).isNotNull
 
     }
-
     @Test
-    fun `tidligere beslutter skal bli null hvis alle vurderingene er godkjente`() {
+    fun `tidligere beslutter skal bli lik null hvis alle vurderinger er godkjente`() {
 
         lagBehandlingsstegstilstand(Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
@@ -260,6 +259,23 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
                 ),
             ),
         )
+
+        val tidligerebeslutter = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
+
+        assertThat(tidligerebeslutter).isNull()
+
+    }
+
+    @Test
+    fun `tidligere beslutter skal bli null hvis det ikke finnes totrinnsvurderinger`() {
+
+        lagBehandlingsstegstilstand(Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
+        lagBehandlingsstegstilstand(Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
+        lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
+        lagBehandlingsstegstilstand(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.AUTOUTFØRT)
+        lagBehandlingsstegstilstand(Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.UTFØRT)
+        lagBehandlingsstegstilstand(Behandlingssteg.FORESLÅ_VEDTAK, Behandlingsstegstatus.UTFØRT)
+        lagBehandlingsstegstilstand(Behandlingssteg.FATTE_VEDTAK, Behandlingsstegstatus.KLAR)
 
         val tidligerebeslutter = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
 

--- a/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceTest.kt
@@ -70,13 +70,7 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentTotrinnsvurderinger skal hente totrinnsvurdering etter beslutters vurdering`() {
-        lagBehandlingsstegstilstand(Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.AUTOUTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FORESLÅ_VEDTAK, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FATTE_VEDTAK, Behandlingsstegstatus.KLAR)
+        lagBehandlingKlarForFatteVedtak()
 
         totrinnService.lagreTotrinnsvurderinger(
             behandlingId,
@@ -116,13 +110,7 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentTotrinnsvurderinger skal hente totrinnsvurdering etter beslutters vurdering med nytt behandlingssteg`() {
-        lagBehandlingsstegstilstand(Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.AUTOUTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FORESLÅ_VEDTAK, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FATTE_VEDTAK, Behandlingsstegstatus.KLAR)
+        lagBehandlingKlarForFatteVedtak()
 
         totrinnService.lagreTotrinnsvurderinger(
             behandlingId,
@@ -193,13 +181,7 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `tidligere beslutter skal bli satt hvis en vurdering er underkjent og har blitt fattet tidlig nok`() {
-        lagBehandlingsstegstilstand(Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.AUTOUTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FORESLÅ_VEDTAK, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FATTE_VEDTAK, Behandlingsstegstatus.KLAR)
+        lagBehandlingKlarForFatteVedtak()
 
         totrinnService.lagreTotrinnsvurderinger(
             behandlingId,
@@ -229,13 +211,7 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `tidligere beslutter skal bli lik null hvis alle vurderinger er godkjente`() {
-        lagBehandlingsstegstilstand(Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.AUTOUTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FORESLÅ_VEDTAK, Behandlingsstegstatus.UTFØRT)
-        lagBehandlingsstegstilstand(Behandlingssteg.FATTE_VEDTAK, Behandlingsstegstatus.KLAR)
+        lagBehandlingKlarForFatteVedtak()
 
         totrinnService.lagreTotrinnsvurderinger(
             behandlingId,
@@ -265,6 +241,14 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `tidligere beslutter skal bli null hvis det ikke finnes totrinnsvurderinger`() {
+        lagBehandlingKlarForFatteVedtak()
+
+        val tidligerebeslutter = totrinnService.finnForrigeBeslutterMedNyVurderingEllerNull(behandlingId)
+
+        assertThat(tidligerebeslutter).isNull()
+    }
+
+    private fun lagBehandlingKlarForFatteVedtak() {
         lagBehandlingsstegstilstand(Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
@@ -272,10 +256,6 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
         lagBehandlingsstegstilstand(Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FORESLÅ_VEDTAK, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FATTE_VEDTAK, Behandlingsstegstatus.KLAR)
-
-        val tidligerebeslutter = totrinnService.finnForrigeBeslutterMedNyVurderingEllerNull(behandlingId)
-
-        assertThat(tidligerebeslutter).isNull()
     }
 
     private fun lagBehandlingsstegstilstand(

--- a/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceTest.kt
@@ -222,7 +222,7 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
             ),
         )
 
-        val tidligerebeslutter = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
+        val tidligerebeslutter = totrinnService.finnForrigeBeslutterMedNyVurderingEllerNull(behandlingId)
 
         assertThat(tidligerebeslutter).isNotNull
     }
@@ -258,7 +258,7 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
             ),
         )
 
-        val tidligerebeslutter = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
+        val tidligerebeslutter = totrinnService.finnForrigeBeslutterMedNyVurderingEllerNull(behandlingId)
 
         assertThat(tidligerebeslutter).isNull()
     }
@@ -273,7 +273,7 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
         lagBehandlingsstegstilstand(Behandlingssteg.FORESLÅ_VEDTAK, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FATTE_VEDTAK, Behandlingsstegstatus.KLAR)
 
-        val tidligerebeslutter = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
+        val tidligerebeslutter = totrinnService.finnForrigeBeslutterMedNyVurderingEllerNull(behandlingId)
 
         assertThat(tidligerebeslutter).isNull()
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceTest.kt
@@ -193,7 +193,6 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `tidligere beslutter skal bli satt hvis en vurdering er underkjent og har blitt fattet tidlig nok`() {
-
         lagBehandlingsstegstilstand(Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
@@ -226,11 +225,10 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
         val tidligerebeslutter = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
 
         assertThat(tidligerebeslutter).isNotNull
-
     }
+
     @Test
     fun `tidligere beslutter skal bli lik null hvis alle vurderinger er godkjente`() {
-
         lagBehandlingsstegstilstand(Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
@@ -263,12 +261,10 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
         val tidligerebeslutter = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
 
         assertThat(tidligerebeslutter).isNull()
-
     }
 
     @Test
     fun `tidligere beslutter skal bli null hvis det ikke finnes totrinnsvurderinger`() {
-
         lagBehandlingsstegstilstand(Behandlingssteg.VARSEL, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.GRUNNLAG, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
@@ -280,7 +276,6 @@ internal class TotrinnServiceTest : OppslagSpringRunnerTest() {
         val tidligerebeslutter = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
 
         assertThat(tidligerebeslutter).isNull()
-
     }
 
     private fun lagBehandlingsstegstilstand(

--- a/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceUnitTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceUnitTest.kt
@@ -1,0 +1,59 @@
+package no.nav.familie.tilbake.totrinn
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.tilbake.behandling.BehandlingRepository
+import no.nav.familie.tilbake.behandlingskontroll.BehandlingsstegstilstandRepository
+import no.nav.familie.tilbake.common.repository.Endret
+import no.nav.familie.tilbake.common.repository.Sporbar
+import no.nav.familie.tilbake.totrinn.domain.Totrinnsvurdering
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.UUID
+
+class TotrinnServiceUnitTest {
+
+    private val behandlingRepository = mockk<BehandlingRepository>()
+    private val behandlingsstegstilstandRepository = mockk<BehandlingsstegstilstandRepository>()
+    private val totrinnsvurderingRepository = mockk<TotrinnsvurderingRepository>()
+
+    private val totrinnService = TotrinnService(behandlingRepository, behandlingsstegstilstandRepository, totrinnsvurderingRepository)
+
+    val behandlingId = UUID.randomUUID()
+
+    @Test
+    fun `skal returnere tidligere beslutter lik null når underkjenningen er over 1 mnd tilbake i tid  `() {
+        val toMndTilbakeITid = LocalDateTime.now().minusMonths(2)
+        val totrinnsvurdering = Totrinnsvurdering(
+            behandlingId = behandlingId,
+            behandlingssteg = mockk(),
+            godkjent = false,
+            begrunnelse = "begrunnelse",
+            sporbar = Sporbar(endret = Endret(endretTid = toMndTilbakeITid, endretAv = "endretAv"))
+        )
+        every { totrinnsvurderingRepository.findByBehandlingIdAndAktivIsTrue(any()) } returns listOf(totrinnsvurdering)
+
+        val beslutter = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
+
+        assertThat(beslutter).isNull()
+    }
+
+    @Test
+    fun `skal returnere tidligere beslutter hvis en vurdering er underkjent og det er under 1 mnd siden`() {
+        val treUkerTilbakeITid = LocalDateTime.now().minusWeeks(3)
+        val totrinnsvurdering = Totrinnsvurdering(
+            behandlingId = behandlingId,
+            behandlingssteg = mockk(),
+            godkjent = false,
+            begrunnelse = "begrunnelse",
+            sporbar = Sporbar(endret = Endret(endretTid = treUkerTilbakeITid, endretAv = "endretAv"))
+        )
+        every { totrinnsvurderingRepository.findByBehandlingIdAndAktivIsTrue(behandlingId) } returns listOf(totrinnsvurdering)
+
+        val result = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
+
+        assertEquals("endretAv", result)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceUnitTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceUnitTest.kt
@@ -14,7 +14,6 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 class TotrinnServiceUnitTest {
-
     private val behandlingRepository = mockk<BehandlingRepository>()
     private val behandlingsstegstilstandRepository = mockk<BehandlingsstegstilstandRepository>()
     private val totrinnsvurderingRepository = mockk<TotrinnsvurderingRepository>()
@@ -26,13 +25,14 @@ class TotrinnServiceUnitTest {
     @Test
     fun `skal returnere tidligere beslutter lik null når underkjenningen er over 1 mnd tilbake i tid  `() {
         val toMndTilbakeITid = LocalDateTime.now().minusMonths(2)
-        val totrinnsvurdering = Totrinnsvurdering(
-            behandlingId = behandlingId,
-            behandlingssteg = mockk(),
-            godkjent = false,
-            begrunnelse = "begrunnelse",
-            sporbar = Sporbar(endret = Endret(endretTid = toMndTilbakeITid, endretAv = "endretAv"))
-        )
+        val totrinnsvurdering =
+            Totrinnsvurdering(
+                behandlingId = behandlingId,
+                behandlingssteg = mockk(),
+                godkjent = false,
+                begrunnelse = "begrunnelse",
+                sporbar = Sporbar(endret = Endret(endretTid = toMndTilbakeITid, endretAv = "endretAv")),
+            )
         every { totrinnsvurderingRepository.findByBehandlingIdAndAktivIsTrue(any()) } returns listOf(totrinnsvurdering)
 
         val beslutter = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
@@ -43,13 +43,14 @@ class TotrinnServiceUnitTest {
     @Test
     fun `skal returnere tidligere beslutter hvis en vurdering er underkjent og det er under 1 mnd siden`() {
         val treUkerTilbakeITid = LocalDateTime.now().minusWeeks(3)
-        val totrinnsvurdering = Totrinnsvurdering(
-            behandlingId = behandlingId,
-            behandlingssteg = mockk(),
-            godkjent = false,
-            begrunnelse = "begrunnelse",
-            sporbar = Sporbar(endret = Endret(endretTid = treUkerTilbakeITid, endretAv = "endretAv"))
-        )
+        val totrinnsvurdering =
+            Totrinnsvurdering(
+                behandlingId = behandlingId,
+                behandlingssteg = mockk(),
+                godkjent = false,
+                begrunnelse = "begrunnelse",
+                sporbar = Sporbar(endret = Endret(endretTid = treUkerTilbakeITid, endretAv = "endretAv")),
+            )
         every { totrinnsvurderingRepository.findByBehandlingIdAndAktivIsTrue(behandlingId) } returns listOf(totrinnsvurdering)
 
         val result = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)

--- a/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceUnitTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/totrinn/TotrinnServiceUnitTest.kt
@@ -35,7 +35,7 @@ class TotrinnServiceUnitTest {
             )
         every { totrinnsvurderingRepository.findByBehandlingIdAndAktivIsTrue(any()) } returns listOf(totrinnsvurdering)
 
-        val beslutter = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
+        val beslutter = totrinnService.finnForrigeBeslutterMedNyVurderingEllerNull(behandlingId)
 
         assertThat(beslutter).isNull()
     }
@@ -53,7 +53,7 @@ class TotrinnServiceUnitTest {
             )
         every { totrinnsvurderingRepository.findByBehandlingIdAndAktivIsTrue(behandlingId) } returns listOf(totrinnsvurdering)
 
-        val result = totrinnService.finnTidligereBeslutterEllerNullHvisEldreEnn1mnd(behandlingId)
+        val result = totrinnService.finnForrigeBeslutterMedNyVurderingEllerNull(behandlingId)
 
         assertEquals("endretAv", result)
     }


### PR DESCRIPTION
Nytt vedtak som tidligere er underkjent skal sendes tilbake til samme beslutter. Dette er gjort i EF Sak. Nå ønsker man også dette i feilutbetalingsløsningen.

Ref slack: https://nav-it.slack.com/archives/GSWTAT0PP/p1727356409730059?thread_ts=1727355600.727169&cid=GSWTAT0PP

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20719