### PR TITLE
Sett lik regel for når foreldelse-steget skal autoutføres i dev som i prod

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -38,7 +38,6 @@ SECURITYTOKENSERVICE_URL: https://api-gw-q1.oera.no/security-token-service/Secur
 
 PDL_URL: https://pdl-api.dev-fss-pub.nais.io
 PDL_SCOPE: api://dev-fss.pdl.pdl-api/.default
-FORELDELSE_ANTALL_MÅNED: 3
 OPPRETTELSE_DAGER_BEGRENSNING: 1
 CRON_HÅNDTER_GAMMEL_KRAVGRUNNLAG: 0 10 * ? * MON-FRI
 CRON_AUTOMATISK_SAKSBEHANDLING: 0 20 * ? * MON-FRI


### PR DESCRIPTION
Kan være forvirrende ved testing at prod og dev oppfører seg ulikt.