### PR TITLE
Postnummer og poststed skal kunne være tomme

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <main-class>no.nav.familie.tilbake.LauncherKt</main-class>
         <kotlin.version>2.0.21</kotlin.version>
         <common-java-modules.version>2.2021.09.17_07.09-67428a6422cc</common-java-modules.version>
-        <kontrakter.version>3.0_20241009100044_c0fcd51</kontrakter.version>
+        <kontrakter.version>3.0_20241030123037_58542dd</kontrakter.version>
         <felles.version>3.20240913110742_adb42f8</felles.version>
         <!-- kotest.properties kan antakelig fjernes i versjon 6, for autoscan blir default false -->
         <kotest.version>5.9.1</kotest.version>

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/pdf/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/felles/pdf/JournalføringService.kt
@@ -8,6 +8,7 @@ import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Dokument
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Filtype
+import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 import no.nav.familie.kontrakter.felles.journalpost.Bruker
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.JournalposterForBrukerRequest
@@ -131,8 +132,8 @@ class JournalføringService(
     private fun utledIdType(mottagerIdent: String?) =
         when (mottagerIdent?.length) {
             0, null -> null
-            9 -> BrukerIdType.ORGNR
-            11 -> BrukerIdType.FNR
+            9 -> AvsenderMottakerIdType.ORGNR
+            11 -> AvsenderMottakerIdType.FNR
             else -> throw IllegalArgumentException("Ugyldig idType")
         }
 
@@ -146,7 +147,7 @@ class JournalføringService(
                     "Fagsak ${behandling.fagsakId} og behandling ${behandling.id}",
             )
         return AvsenderMottaker(
-            idType = BrukerIdType.ORGNR,
+            idType = AvsenderMottakerIdType.ORGNR,
             id = institusjon.organisasjonsnummer,
             navn = institusjon.navn,
         )
@@ -161,13 +162,13 @@ class JournalføringService(
                 )
         return if (verge.orgNr != null) {
             AvsenderMottaker(
-                idType = BrukerIdType.ORGNR,
+                idType = AvsenderMottakerIdType.ORGNR,
                 id = verge.orgNr,
                 navn = verge.navn,
             )
         } else {
             AvsenderMottaker(
-                idType = BrukerIdType.FNR,
+                idType = AvsenderMottakerIdType.FNR,
                 id = verge.ident!!,
                 navn = verge.navn,
             )

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerService.kt
@@ -181,14 +181,14 @@ class ManuellBrevmottakerService(
     }
 
     private fun lagHistorikkBeskrivelseForBrevmottaker(brevmottaker: ManuellBrevmottaker) =
-        listOfNotNull(
+        listOf(
             brevmottaker.navn,
             brevmottaker.adresselinje1,
             brevmottaker.adresselinje2,
             brevmottaker.postnummer,
             brevmottaker.poststed,
             brevmottaker.landkode,
-        ).joinToString(separator = System.lineSeparator())
+        ).filter { it != null && it != "" }.joinToString(separator = System.lineSeparator())
 
     private fun hentPersonEllerOrganisasjonNavnFraRegister(
         dto: ManuellBrevmottakerRequestDto,

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerService.kt
@@ -188,7 +188,7 @@ class ManuellBrevmottakerService(
             brevmottaker.postnummer,
             brevmottaker.poststed,
             brevmottaker.landkode,
-        ).filter { it != null && it != "" }.joinToString(separator = System.lineSeparator())
+        ).filter { !it.isNullOrEmpty() }.joinToString(separator = System.lineSeparator())
 
     private fun hentPersonEllerOrganisasjonNavnFraRegister(
         dto: ManuellBrevmottakerRequestDto,

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/domene/ManuellBrevmottaker.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/domene/ManuellBrevmottaker.kt
@@ -36,8 +36,6 @@ data class ManuellBrevmottaker(
     fun hasManuellAdresse(): Boolean =
         !(
             adresselinje1.isNullOrBlank() ||
-                postnummer.isNullOrBlank() ||
-                poststed.isNullOrBlank() ||
                 landkode.isNullOrBlank()
         )
 

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
@@ -90,6 +90,20 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
                 ),
         )
 
+    private val manuellBrevmottakerIUtlandetRequestDto =
+        ManuellBrevmottakerRequestDto(
+            type = DØDSBO,
+            navn = "John Doe",
+            manuellAdresseInfo =
+            ManuellAdresseInfo(
+                adresselinje1 = "test adresse1",
+                adresselinje2 = "0000 Stockholm",
+                postnummer = "",
+                poststed = "",
+                landkode = "SE",
+            ),
+        )
+
     private val mockPdlClient: PdlClient = mockk()
 
     private val mockIntegrasjonerClient: IntegrasjonerClient = mockk()
@@ -191,6 +205,54 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
     }
 
     @Test
+    fun `leggTilBrevmottaker skal legge til brevmottakere i utlandet uten postadresse og oppdatere med oppdaterBrevmottaker`() {
+        shouldNotThrow<RuntimeException> {
+            manuellBrevmottakerService.leggTilBrevmottaker(behandling.id, manuellBrevmottakerIUtlandetRequestDto)
+        }
+
+        var manuellBrevmottakere = manuellBrevmottakerService.hentBrevmottakere(behandling.id)
+
+        manuellBrevmottakere.shouldHaveSize(1)
+        val dbManuellBrevmottaker = manuellBrevmottakere.first()
+        assertEqualsManuellBrevmottaker(dbManuellBrevmottaker, manuellBrevmottakerIUtlandetRequestDto)
+
+        verify(exactly = 1) {
+            mockHistorikkService.lagHistorikkinnslag(
+                behandlingId = behandling.id,
+                historikkinnslagstype = TilbakekrevingHistorikkinnslagstype.BREVMOTTAKER_LAGT_TIL,
+                aktør = Aktør.SAKSBEHANDLER,
+                opprettetTidspunkt = opprettetTidspunktSlot[0],
+                beskrivelse = any(),
+                tittel = any(),
+            )
+        }
+
+        val oppdatertManuellBrevmottaker =
+            manuellBrevmottakerIUtlandetRequestDto.copy(
+                manuellAdresseInfo =
+                ManuellAdresseInfo(
+                    adresselinje1 = "Ny adresse",
+                    adresselinje2 = "0001 Stockholm",
+                    postnummer = "",
+                    poststed = "",
+                    landkode = "SE",
+                ),
+            )
+        shouldNotThrow<RuntimeException> {
+            manuellBrevmottakerService.oppdaterBrevmottaker(
+                behandling.id,
+                dbManuellBrevmottaker.id,
+                oppdatertManuellBrevmottaker,
+            )
+        }
+
+        manuellBrevmottakere = manuellBrevmottakerService.hentBrevmottakere(behandling.id)
+        manuellBrevmottakere.shouldHaveSize(1)
+        val dbOppdatertManuellBrevmottaker = manuellBrevmottakere.first()
+        assertEqualsManuellBrevmottaker(dbOppdatertManuellBrevmottaker, oppdatertManuellBrevmottaker)
+    }
+
+    @Test
     fun `fjernBrevmottaker fjerner brevmottaker`() {
         shouldNotThrow<RuntimeException> {
             manuellBrevmottakerService.leggTilBrevmottaker(behandling.id, manuellBrevmottakerRequestDto)
@@ -234,6 +296,49 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
                 historikkinnslagstype = TilbakekrevingHistorikkinnslagstype.BREVMOTTAKER_FJERNET,
                 aktør = Aktør.SAKSBEHANDLER,
                 opprettetTidspunkt = opprettetTidspunktSlot[2],
+                beskrivelse = any(),
+                tittel = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `fjernBrevmottaker fjerner brevmottaker i utlandet`() {
+        shouldNotThrow<RuntimeException> {
+            manuellBrevmottakerService.leggTilBrevmottaker(behandling.id, manuellBrevmottakerIUtlandetRequestDto)
+        }
+
+        val manuellBrevmottakere = manuellBrevmottakerService.hentBrevmottakere(behandling.id)
+
+        manuellBrevmottakere.shouldHaveSize(1)
+        val dbManuellBrevmottaker = manuellBrevmottakere.first()
+        assertEqualsManuellBrevmottaker(dbManuellBrevmottaker, manuellBrevmottakerIUtlandetRequestDto)
+
+        verify(exactly = 1) {
+            mockHistorikkService.lagHistorikkinnslag(
+                behandlingId = behandling.id,
+                historikkinnslagstype = TilbakekrevingHistorikkinnslagstype.BREVMOTTAKER_LAGT_TIL,
+                aktør = Aktør.SAKSBEHANDLER,
+                opprettetTidspunkt = opprettetTidspunktSlot[0],
+                beskrivelse = any(),
+                tittel = any(),
+            )
+        }
+
+        shouldNotThrow<RuntimeException> {
+            manuellBrevmottakerService.fjernBrevmottaker(behandling.id, dbManuellBrevmottaker.id)
+        }
+
+        manuellBrevmottakerService
+            .hentBrevmottakere(behandling.id)
+            .shouldBeEmpty()
+
+        verify(exactly = 1) {
+            mockHistorikkService.lagHistorikkinnslag(
+                behandlingId = behandling.id,
+                historikkinnslagstype = TilbakekrevingHistorikkinnslagstype.BREVMOTTAKER_FJERNET,
+                aktør = Aktør.SAKSBEHANDLER,
+                opprettetTidspunkt = opprettetTidspunktSlot[1],
                 beskrivelse = any(),
                 tittel = any(),
             )

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
@@ -210,7 +210,7 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
             manuellBrevmottakerService.leggTilBrevmottaker(behandling.id, manuellBrevmottakerIUtlandetRequestDto)
         }
 
-        var manuellBrevmottakere = manuellBrevmottakerService.hentBrevmottakere(behandling.id)
+        val manuellBrevmottakere = manuellBrevmottakerService.hentBrevmottakere(behandling.id)
 
         manuellBrevmottakere.shouldHaveSize(1)
         val dbManuellBrevmottaker = manuellBrevmottakere.first()
@@ -246,9 +246,9 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
             )
         }
 
-        manuellBrevmottakere = manuellBrevmottakerService.hentBrevmottakere(behandling.id)
-        manuellBrevmottakere.shouldHaveSize(1)
-        val dbOppdatertManuellBrevmottaker = manuellBrevmottakere.first()
+        val oppdaterteBrevmottakere = manuellBrevmottakerService.hentBrevmottakere(behandling.id)
+        oppdaterteBrevmottakere.shouldHaveSize(1)
+        val dbOppdatertManuellBrevmottaker = oppdaterteBrevmottakere.first()
         assertEqualsManuellBrevmottaker(dbOppdatertManuellBrevmottaker, oppdatertManuellBrevmottaker)
     }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/ManuellBrevmottakerServiceTest.kt
@@ -95,13 +95,13 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
             type = DØDSBO,
             navn = "John Doe",
             manuellAdresseInfo =
-            ManuellAdresseInfo(
-                adresselinje1 = "test adresse1",
-                adresselinje2 = "0000 Stockholm",
-                postnummer = "",
-                poststed = "",
-                landkode = "SE",
-            ),
+                ManuellAdresseInfo(
+                    adresselinje1 = "test adresse1",
+                    adresselinje2 = "0000 Stockholm",
+                    postnummer = "",
+                    poststed = "",
+                    landkode = "SE",
+                ),
         )
 
     private val mockPdlClient: PdlClient = mockk()
@@ -230,13 +230,13 @@ class ManuellBrevmottakerServiceTest : OppslagSpringRunnerTest() {
         val oppdatertManuellBrevmottaker =
             manuellBrevmottakerIUtlandetRequestDto.copy(
                 manuellAdresseInfo =
-                ManuellAdresseInfo(
-                    adresselinje1 = "Ny adresse",
-                    adresselinje2 = "0001 Stockholm",
-                    postnummer = "",
-                    poststed = "",
-                    landkode = "SE",
-                ),
+                    ManuellAdresseInfo(
+                        adresselinje1 = "Ny adresse",
+                        adresselinje2 = "0001 Stockholm",
+                        postnummer = "",
+                        poststed = "",
+                        landkode = "SE",
+                    ),
             )
         shouldNotThrow<RuntimeException> {
             manuellBrevmottakerService.oppdaterBrevmottaker(


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23072
Frontend-pr: https://github.com/navikt/familie-tilbake-frontend/pull/1974
Relatert til denne PRen i kontrakter: https://github.com/navikt/familie-kontrakter/pull/959

På adresser i utlandet ønsker vi ikke å sende med postnummer og poststed, siden Dokdist ikke tar hensyn til disse feltene. All informasjon skal da legges i adresselinjene. Fikser dermed validering og historikkinnslag som også godtar tomme postnummr og poststed.

Jeg setter ikke disse feltene til nullable fordi vi da også må gjøre en jobb med databasen. Og i de fleste tilfellene ønsker vi jo at postnummer og poststed skal inkluderes. Har forankret dette med @bragejahren.