### PR TITLE
FIX: Vise korrekt tekst på vedtak for særlige grunner

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/AvsnittUtil.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/AvsnittUtil.kt
@@ -6,6 +6,7 @@ import no.nav.familie.tilbake.dokumentbestilling.vedtak.handlebars.dto.HbVedtaks
 import no.nav.familie.tilbake.dokumentbestilling.vedtak.handlebars.dto.HbVedtaksbrevPeriodeOgFelles
 import no.nav.familie.tilbake.dokumentbestilling.vedtak.handlebars.dto.HbVedtaksbrevsdata
 import no.nav.familie.tilbake.dokumentbestilling.vedtak.handlebars.dto.Vedtaksbrevstype
+import no.nav.familie.tilbake.dokumentbestilling.vedtak.handlebars.dto.periode.HbKravgrunnlag
 import no.nav.familie.tilbake.dokumentbestilling.vedtak.handlebars.dto.periode.HbResultat
 import no.nav.familie.tilbake.dokumentbestilling.vedtak.handlebars.dto.periode.HbVedtaksbrevsperiode
 import java.math.BigDecimal
@@ -108,10 +109,15 @@ internal object AvsnittUtil {
         val totalrente = vedtaksbrevsdata.perioder.sumOf { it.resultat.rentebeløp }
         val totalForeldetBeløp = vedtaksbrevsdata.perioder.sumOf { it.resultat.foreldetBeløp ?: BigDecimal.ZERO }
         val totalTilbakekrevesBeløpUtenSkattMedRenter = vedtaksbrevsdata.perioder.sumOf { it.resultat.tilbakekrevesBeløpUtenSkattMedRenter }
+        val totalFeilutbetaltBeløp = vedtaksbrevsdata.perioder.sumOf { it.kravgrunnlag.feilutbetaltBeløp }
+        val sammenslåttPeriodeKravgrunnlag = HbKravgrunnlag(
+            riktigBeløp = førstePeriode.kravgrunnlag.riktigBeløp,
+            utbetaltBeløp = førstePeriode.kravgrunnlag.utbetaltBeløp,
+            feilutbetaltBeløp = totalFeilutbetaltBeløp,
+        )
         val sammenslåttResultat = HbResultat(totalTilbakekrevesBeløp, totalrente, totalForeldetBeløp, totalTilbakekrevesBeløpUtenSkattMedRenter)
-        val hbVedtaksbrevsperiode = HbVedtaksbrevsperiode(sammenslåttDatoperiode, førstePeriode.kravgrunnlag, førstePeriode.fakta, førstePeriode.vurderinger, sammenslåttResultat, true, førstePeriode.grunnbeløp)
+        val hbVedtaksbrevsperiode = HbVedtaksbrevsperiode(sammenslåttDatoperiode, sammenslåttPeriodeKravgrunnlag, førstePeriode.fakta, førstePeriode.vurderinger, sammenslåttResultat, true, førstePeriode.grunnbeløp)
         val hbVedtaksbrevPeriodeOgFelles = HbVedtaksbrevPeriodeOgFelles(vedtaksbrevsdata.felles, hbVedtaksbrevsperiode)
-
         var avsnitt =
             Avsnitt(
                 avsnittstype = Avsnittstype.SAMMENSLÅTT_PERIODE,

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/AvsnittUtil.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/AvsnittUtil.kt
@@ -110,11 +110,12 @@ internal object AvsnittUtil {
         val totalForeldetBeløp = vedtaksbrevsdata.perioder.sumOf { it.resultat.foreldetBeløp ?: BigDecimal.ZERO }
         val totalTilbakekrevesBeløpUtenSkattMedRenter = vedtaksbrevsdata.perioder.sumOf { it.resultat.tilbakekrevesBeløpUtenSkattMedRenter }
         val totalFeilutbetaltBeløp = vedtaksbrevsdata.perioder.sumOf { it.kravgrunnlag.feilutbetaltBeløp }
-        val sammenslåttPeriodeKravgrunnlag = HbKravgrunnlag(
-            riktigBeløp = førstePeriode.kravgrunnlag.riktigBeløp,
-            utbetaltBeløp = førstePeriode.kravgrunnlag.utbetaltBeløp,
-            feilutbetaltBeløp = totalFeilutbetaltBeløp,
-        )
+        val sammenslåttPeriodeKravgrunnlag =
+            HbKravgrunnlag(
+                riktigBeløp = førstePeriode.kravgrunnlag.riktigBeløp,
+                utbetaltBeløp = førstePeriode.kravgrunnlag.utbetaltBeløp,
+                feilutbetaltBeløp = totalFeilutbetaltBeløp,
+            )
         val sammenslåttResultat = HbResultat(totalTilbakekrevesBeløp, totalrente, totalForeldetBeløp, totalTilbakekrevesBeløpUtenSkattMedRenter)
         val hbVedtaksbrevsperiode = HbVedtaksbrevsperiode(sammenslåttDatoperiode, sammenslåttPeriodeKravgrunnlag, førstePeriode.fakta, førstePeriode.vurderinger, sammenslåttResultat, true, førstePeriode.grunnbeløp)
         val hbVedtaksbrevPeriodeOgFelles = HbVedtaksbrevPeriodeOgFelles(vedtaksbrevsdata.felles, hbVedtaksbrevsperiode)

--- a/src/main/resources/templates/nb/vedtak/periode_særlige_grunner_sammenslått.hbs
+++ b/src/main/resources/templates/nb/vedtak/periode_særlige_grunner_sammenslått.hbs
@@ -4,18 +4,18 @@
 {{#if vurderinger.særligeGrunner}}
 __Er det særlige grunner til å redusere beløpet?
     {{#if vurderinger.særligeGrunner.fritekst}}
-        {{{vurderinger.særligeGrunner.fritekst}}}
+{{{vurderinger.særligeGrunner.fritekst}}}
 
     {{/if}}
     {{#if (not gjelderDødsfall)}}
         {{#if (eq vurderinger.vilkårsvurderingsresultat "FORSTO_BURDE_FORSTÅTT") }}
-            {{> nb/vedtak/periode-særlige-grunner/periode_særlige_grunner_forstod}}
+{{> nb/vedtak/periode-særlige-grunner/periode_særlige_grunner_forstod}}
         {{else}}
-            {{> nb/vedtak/periode-særlige-grunner/periode_særlige_grunner_feilaktig_mangelfull}}
+{{> nb/vedtak/periode-særlige-grunner/periode_særlige_grunner_feilaktig_mangelfull}}
         {{/if}}
         {{#if (neq totaltFeilutbetaltBeløp totalresultat.totaltTilbakekrevesBeløp)}}
 
-            Du må betale {{{kroner totalresultat.totaltTilbakekrevesBeløpMedRenter}}}{{> før-skatt}}.
+Du må betale {{{kroner totalresultat.totaltTilbakekrevesBeløpMedRenter}}}{{> før-skatt}}.
         {{/if}}
     {{/if}}
 {{/if}}


### PR DESCRIPTION
Summerer feilutbetaltBeløp og bruker den verdien til å sette feilutbetaltBeløp. Dette er fordi 'reduksjon' i 'periode_særlige_grunner_feilaktig_mangelfull.hbs' blir utledet med den verdien, og den blir alltid feil når det er sammenslått. Feil tekst blir derfor vist frem i på `Vedtak`

Koden for å utlede reduksjon: `reduksjon=(neq kravgrunnlag.feilutbetaltBeløp resultat.tilbakekrevesBeløp)`

Feil tekst blir vist: 
![image](https://github.com/user-attachments/assets/636cda73-125a-4307-b41a-2bbf910f5b39)

Korrekt tekst:
![image](https://github.com/user-attachments/assets/faced0d8-fbae-4e99-83b5-5447d016469f)

![image](https://github.com/user-attachments/assets/97546da1-4e95-4d56-adc1-cc1245995946)

![image](https://github.com/user-attachments/assets/8418d6ea-555d-455a-96c5-e6993b15fd0a)