### PR TITLE
Skal perioder sammenslås verdi settes til ikke_aktuell dersom det bare finnes en periode

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeService.kt
@@ -28,10 +28,12 @@ class PeriodeService(
         return SkalSammenslåPerioder.IKKE_AKTUELT
     }
 
-    private fun harMerEnnEnPeriode(behandlingId: UUID) =
-        faktaFeilutbetalingService.hentFaktaomfeilutbetaling(behandlingId).feilutbetaltePerioder.size > 1 &&
-            (foreldelseService.hentAktivVurdertForeldelse(behandlingId)?.foreldelsesperioder?.size ?: 0) > 1 &&
-            vilkårsvurderingService.hentVilkårsvurdering(behandlingId).perioder.size > 1
+    private fun harMerEnnEnPeriode(behandlingId: UUID): Boolean {
+        val foreldelsesperioder = foreldelseService.hentAktivVurdertForeldelse(behandlingId)?.foreldelsesperioder
+        return faktaFeilutbetalingService.hentFaktaomfeilutbetaling(behandlingId).feilutbetaltePerioder.size > 1 ||
+                (foreldelsesperioder == null || foreldelsesperioder.size > 1) ||
+                vilkårsvurderingService.hentVilkårsvurdering(behandlingId).perioder.size > 1
+    }
 
     private fun erPerioderLike(behandlingId: UUID) =
         faktaFeilutbetalingService.sjekkOmFaktaPerioderErLike(behandlingId) &&

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeService.kt
@@ -33,7 +33,7 @@ class PeriodeService(
 
         val harEnFaktaPeriode = faktaFeilutbetalingService.hentFaktaomfeilutbetaling(behandlingId).feilutbetaltePerioder.size == 1
         val harEnVilkårsperiode = vilkårsvurderingService.hentVilkårsvurdering(behandlingId).perioder.size == 1
-        val harEnForeldelseperiode = foreldelsesperioder == null || foreldelsesperioder.size == 1
+        val harEnForeldelseperiode = foreldelsesperioder?.size == 1
 
         return harEnFaktaPeriode && harEnVilkårsperiode && harEnForeldelseperiode
     }

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeService.kt
@@ -19,11 +19,19 @@ class PeriodeService(
 ) {
     fun erEnsligForsørgerOgPerioderLike(behandlingId: UUID): SkalSammenslåPerioder {
         val fagsak = fagsakRepository.finnFagsakForBehandlingId(behandlingId)
-        if (erPerioderLike(behandlingId) && fagsak.ytelsestype.tilTema() == Tema.ENF) {
+        if (harMerEnnEnPeriode(behandlingId) &&
+            erPerioderLike(behandlingId) &&
+            fagsak.ytelsestype.tilTema() == Tema.ENF
+        ) {
             return SkalSammenslåPerioder.JA
         }
         return SkalSammenslåPerioder.IKKE_AKTUELT
     }
+
+    private fun harMerEnnEnPeriode(behandlingId: UUID) =
+        faktaFeilutbetalingService.hentFaktaomfeilutbetaling(behandlingId).feilutbetaltePerioder.size > 1 &&
+            (foreldelseService.hentAktivVurdertForeldelse(behandlingId)?.foreldelsesperioder?.size ?: 0) > 1 &&
+            vilkårsvurderingService.hentVilkårsvurdering(behandlingId).perioder.size > 1
 
     private fun erPerioderLike(behandlingId: UUID) =
         faktaFeilutbetalingService.sjekkOmFaktaPerioderErLike(behandlingId) &&

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeService.kt
@@ -29,13 +29,10 @@ class PeriodeService(
     }
 
     private fun harKunEnPeriode(behandlingId: UUID): Boolean {
-        val foreldelsesperioder = foreldelseService.hentAktivVurdertForeldelse(behandlingId)?.foreldelsesperioder
-
         val harEnFaktaPeriode = faktaFeilutbetalingService.hentFaktaomfeilutbetaling(behandlingId).feilutbetaltePerioder.size == 1
         val harEnVilkårsperiode = vilkårsvurderingService.hentVilkårsvurdering(behandlingId).perioder.size == 1
-        val harEnForeldelseperiode = foreldelsesperioder?.size == 1
 
-        return harEnFaktaPeriode && harEnVilkårsperiode && harEnForeldelseperiode
+        return harEnFaktaPeriode || harEnVilkårsperiode
     }
 
     private fun erPerioderLike(behandlingId: UUID) =

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingBatchTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingBatchTest.kt
@@ -74,9 +74,9 @@ internal class AutomatiskSaksbehandlingBatchTest : OppslagSpringRunnerTest() {
                 status = Behandlingsstatus.UTREDES,
             ),
         )
-        val feilKravgrunnlagBeløp = Testdata.feilKravgrunnlagsbeløp433.copy(nyttBeløp = BigDecimal("100"))
+        val feilKravgrunnlagBeløp = Testdata.lagFeilKravgrunnlagsbeløp(nyttBeløp = BigDecimal("100"))
         val ytelKravgrunnlagsbeløp433 =
-            Testdata.ytelKravgrunnlagsbeløp433.copy(
+            Testdata.lagYtelKravgrunnlagsbeløp().copy(
                 opprinneligUtbetalingsbeløp = BigDecimal("100"),
                 tilbakekrevesBeløp = BigDecimal("100"),
             )

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingTaskTest.kt
@@ -108,9 +108,9 @@ internal class AutomatiskSaksbehandlingTaskTest : OppslagSpringRunnerTest() {
                 status = Behandlingsstatus.UTREDES,
             ),
         )
-        val feilKravgrunnlagBeløp = Testdata.feilKravgrunnlagsbeløp433.copy(nyttBeløp = BigDecimal("100"))
+        val feilKravgrunnlagBeløp = Testdata.lagFeilKravgrunnlagsbeløp().copy(nyttBeløp = BigDecimal("100"))
         val ytelKravgrunnlagsbeløp433 =
-            Testdata.ytelKravgrunnlagsbeløp433.copy(
+            Testdata.lagYtelKravgrunnlagsbeløp().copy(
                 opprinneligUtbetalingsbeløp = BigDecimal("100"),
                 tilbakekrevesBeløp = BigDecimal("100"),
             )

--- a/src/test/kotlin/no/nav/familie/tilbake/data/Testdata.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/data/Testdata.kt
@@ -206,9 +206,39 @@ object Testdata {
             skatteprosent = BigDecimal("35.1100"),
         )
 
+    fun lagFeilKravgrunnlagsbeløp(
+        klassekode: Klassekode = Klassekode.KL_KODE_FEIL_BA,
+        nyttBeløp: BigDecimal = BigDecimal("10000"),
+    ) = Kravgrunnlagsbeløp433(
+        klassekode = klassekode,
+        klassetype = Klassetype.FEIL,
+        opprinneligUtbetalingsbeløp = BigDecimal.ZERO,
+        nyttBeløp = nyttBeløp,
+        tilbakekrevesBeløp = BigDecimal.ZERO,
+        uinnkrevdBeløp = BigDecimal.ZERO,
+        resultatkode = "testverdi",
+        årsakskode = "testverdi",
+        skyldkode = "testverdi",
+        skatteprosent = BigDecimal("35.1100"),
+    )
+
     val ytelKravgrunnlagsbeløp433 =
         Kravgrunnlagsbeløp433(
             klassekode = Klassekode.BATR,
+            klassetype = Klassetype.YTEL,
+            opprinneligUtbetalingsbeløp = BigDecimal("10000"),
+            nyttBeløp = BigDecimal.ZERO,
+            tilbakekrevesBeløp = BigDecimal("10000"),
+            uinnkrevdBeløp = BigDecimal.ZERO,
+            resultatkode = "testverdi",
+            årsakskode = "testverdi",
+            skyldkode = "testverdi",
+            skatteprosent = BigDecimal("35.1100"),
+        )
+
+    fun lagYtelKravgrunnlagsbeløp(klassekode: Klassekode = Klassekode.BATR) =
+        Kravgrunnlagsbeløp433(
+            klassekode = klassekode,
             klassetype = Klassetype.YTEL,
             opprinneligUtbetalingsbeløp = BigDecimal("10000"),
             nyttBeløp = BigDecimal.ZERO,
@@ -229,8 +259,8 @@ object Testdata {
                 ),
             beløp =
                 setOf(
-                    feilKravgrunnlagsbeløp433,
-                    ytelKravgrunnlagsbeløp433,
+                    lagFeilKravgrunnlagsbeløp(),
+                    lagYtelKravgrunnlagsbeløp(),
                 ),
             månedligSkattebeløp = BigDecimal("123.11"),
         )
@@ -238,6 +268,7 @@ object Testdata {
     fun lagKravgrunnlagsperiode(
         fom: LocalDate,
         tom: LocalDate,
+        klassekode: Klassekode = Klassekode.KL_KODE_FEIL_BA,
     ): Kravgrunnlagsperiode432 =
         Kravgrunnlagsperiode432(
             periode =
@@ -247,8 +278,8 @@ object Testdata {
                 ),
             beløp =
                 setOf(
-                    feilKravgrunnlagsbeløp433.copy(id = UUID.randomUUID()),
-                    ytelKravgrunnlagsbeløp433.copy(id = UUID.randomUUID()),
+                    lagFeilKravgrunnlagsbeløp(klassekode),
+                    lagYtelKravgrunnlagsbeløp(klassekode),
                 ),
             månedligSkattebeløp = BigDecimal("123.11"),
         )
@@ -256,11 +287,12 @@ object Testdata {
     fun lagKravgrunnlag(
         behandlingId: UUID,
         perioder: Set<Kravgrunnlagsperiode432> = setOf(kravgrunnlagsperiode432),
+        fagområdekode: Fagområdekode = Fagområdekode.EFOG,
     ) = Kravgrunnlag431(
         behandlingId = behandlingId,
         vedtakId = BigInteger.ZERO,
         kravstatuskode = Kravstatuskode.NYTT,
-        fagområdekode = Fagområdekode.EFOG,
+        fagområdekode = fagområdekode,
         fagsystemId = "testverdi",
         fagsystemVedtaksdato = LocalDate.now(),
         omgjortVedtakId = BigInteger.ZERO,

--- a/src/test/kotlin/no/nav/familie/tilbake/data/Testdata.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/data/Testdata.kt
@@ -109,6 +109,9 @@ object Testdata {
 
     val behandlingsresultat = Behandlingsresultat(behandlingsvedtak = behandlingsvedtak)
 
+    private val periode = Månedsperiode(LocalDate.now(), LocalDate.now().plusDays(1))
+    private val periode4Mnd = Månedsperiode("2020-04", "2020-08")
+
     fun lagBehandling(
         fagsakId: UUID = fagsak.id,
         ansvarligSaksbehandler: String = "saksbehandler",
@@ -171,18 +174,9 @@ object Testdata {
             begrunnelse = "testverdi",
         )
 
-    private val foreldelsesperiode =
-        Foreldelsesperiode(
-            periode = Månedsperiode(LocalDate.now(), LocalDate.now().plusDays(1)),
-            foreldelsesvurderingstype = Foreldelsesvurderingstype.IKKE_FORELDET,
-            begrunnelse = "testverdi",
-            foreldelsesfrist = LocalDate.now(),
-            oppdagelsesdato = LocalDate.now(),
-        )
-
     fun lagVurdertForeldelse(
         behandlingId: UUID,
-        månedsperioder: Set<Månedsperiode> = setOf(Månedsperiode(LocalDate.now(), LocalDate.now().plusDays(1))),
+        månedsperioder: Set<Månedsperiode> = setOf(periode),
     ) = VurdertForeldelse(
         behandlingId = behandlingId,
         foreldelsesperioder = månedsperioder.map { lagVurdertForeldelsePeriode(it) }.toSet(),
@@ -328,16 +322,9 @@ object Testdata {
             perioder = setOf(vilkårsperiode),
         )
 
-    private val faktaFeilutbetalingsperiode =
-        FaktaFeilutbetalingsperiode(
-            periode = Månedsperiode(LocalDate.now(), LocalDate.now().plusDays(1)),
-            hendelsestype = Hendelsestype.ANNET,
-            hendelsesundertype = Hendelsesundertype.ANNET_FRITEKST,
-        )
-
     fun lagFaktaFeilutbetaling(
         behandlingId: UUID,
-        månedsperioder: Set<Månedsperiode> = setOf(Månedsperiode("2020-04", "2020-08")),
+        månedsperioder: Set<Månedsperiode> = setOf(periode4Mnd),
     ) = FaktaFeilutbetaling(
         begrunnelse = "testverdi",
         aktiv = true,

--- a/src/test/kotlin/no/nav/familie/tilbake/data/Testdata.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/data/Testdata.kt
@@ -180,11 +180,23 @@ object Testdata {
             oppdagelsesdato = LocalDate.now(),
         )
 
-    fun lagVurdertForeldelse(behandlingId: UUID) =
-        VurdertForeldelse(
-            behandlingId = behandlingId,
-            foreldelsesperioder = setOf(foreldelsesperiode),
-        )
+    fun lagVurdertForeldelse(
+        behandlingId: UUID,
+        månedsperioder: Set<Månedsperiode> = setOf(Månedsperiode(LocalDate.now(), LocalDate.now().plusDays(1))),
+    ) = VurdertForeldelse(
+        behandlingId = behandlingId,
+        foreldelsesperioder = månedsperioder.map { lagVurdertForeldelsePeriode(it) }.toSet(),
+    )
+
+    fun lagVurdertForeldelsePeriode(
+        månedsperiode: Månedsperiode,
+    ) = Foreldelsesperiode(
+        periode = månedsperiode,
+        foreldelsesvurderingstype = Foreldelsesvurderingstype.IKKE_FORELDET,
+        begrunnelse = "begrunnelse foreldelsesperiode",
+        foreldelsesfrist = LocalDate.now(),
+        oppdagelsesdato = LocalDate.now(),
+    )
 
     val feilKravgrunnlagsbeløp433 =
         Kravgrunnlagsbeløp433(
@@ -241,8 +253,8 @@ object Testdata {
                 ),
             beløp =
                 setOf(
-                    feilKravgrunnlagsbeløp433,
-                    ytelKravgrunnlagsbeløp433,
+                    feilKravgrunnlagsbeløp433.copy(id = UUID.randomUUID()),
+                    ytelKravgrunnlagsbeløp433.copy(id = UUID.randomUUID()),
                 ),
             månedligSkattebeløp = BigDecimal("123.11"),
         )
@@ -323,21 +335,23 @@ object Testdata {
             hendelsesundertype = Hendelsesundertype.ANNET_FRITEKST,
         )
 
-    fun lagFaktaFeilutbetaling(behandlingId: UUID) =
-        FaktaFeilutbetaling(
-            begrunnelse = "testverdi",
-            aktiv = true,
-            behandlingId = behandlingId,
-            perioder =
-                setOf(
+    fun lagFaktaFeilutbetaling(
+        behandlingId: UUID,
+        månedsperioder: Set<Månedsperiode> = setOf(Månedsperiode("2020-04", "2020-08")),
+    ) = FaktaFeilutbetaling(
+        begrunnelse = "testverdi",
+        aktiv = true,
+        behandlingId = behandlingId,
+        perioder =
+            månedsperioder
+                .map {
                     FaktaFeilutbetalingsperiode(
-                        periode = Månedsperiode("2020-04" to "2022-08"),
+                        periode = it,
                         hendelsestype = Hendelsestype.ANNET,
                         hendelsesundertype = Hendelsesundertype.ANNET_FRITEKST,
-                    ),
-                    faktaFeilutbetalingsperiode,
-                ),
-        )
+                    )
+                }.toSet(),
+    )
 
     val økonomiXmlMottatt =
         ØkonomiXmlMottatt(

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeServiceTest.kt
@@ -1,0 +1,93 @@
+package no.nav.familie.tilbake.dokumentbestilling.vedtak
+
+import io.kotest.matchers.shouldBe
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.Månedsperiode
+import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
+import no.nav.familie.tilbake.OppslagSpringRunnerTest
+import no.nav.familie.tilbake.behandling.BehandlingRepository
+import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandling.domain.Behandling
+import no.nav.familie.tilbake.data.Testdata
+import no.nav.familie.tilbake.data.Testdata.lagKravgrunnlagsperiode
+import no.nav.familie.tilbake.dokumentbestilling.vedtak.domain.SkalSammenslåPerioder
+import no.nav.familie.tilbake.faktaomfeilutbetaling.FaktaFeilutbetalingRepository
+import no.nav.familie.tilbake.foreldelse.VurdertForeldelseRepository
+import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
+import no.nav.familie.tilbake.vilkårsvurdering.VilkårsvurderingRepository
+import no.nav.familie.tilbake.vilkårsvurdering.domain.Vilkårsvurdering
+import no.nav.familie.tilbake.vilkårsvurdering.domain.Vilkårsvurderingsperiode
+import no.nav.familie.tilbake.vilkårsvurdering.domain.Vilkårsvurderingsresultat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.YearMonth
+
+class PeriodeServiceTest : OppslagSpringRunnerTest() {
+    @Autowired
+    private lateinit var behandlingRepository: BehandlingRepository
+
+    @Autowired
+    private lateinit var fagsakRepository: FagsakRepository
+
+    @Autowired
+    private lateinit var faktaFeilutbetalingRepository: FaktaFeilutbetalingRepository
+
+    @Autowired
+    private lateinit var kravgrunnlagRepository: KravgrunnlagRepository
+
+    @Autowired
+    private lateinit var foreldelseRepository: VurdertForeldelseRepository
+
+    @Autowired
+    private lateinit var periodeService: PeriodeService
+
+    @Autowired
+    private lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
+
+    private lateinit var behandling: Behandling
+    private lateinit var saksnummer: String
+
+    private val førstePeriode: Månedsperiode = Månedsperiode(YearMonth.of(2020, 4), YearMonth.of(2020, 8))
+    private val andrePeriode = Månedsperiode(YearMonth.of(2020, 10), YearMonth.of(2020, 12))
+
+    @BeforeEach
+    fun setup() {
+        behandling =
+            Testdata.lagBehandling().copy(
+                ansvarligSaksbehandler = ANSVARLIG_SAKSBEHANDLER,
+                ansvarligBeslutter = ANSVARLIG_BESLUTTER,
+                behandlendeEnhet = "8020",
+            )
+        fagsakRepository.insert(Testdata.fagsak.copy(fagsystem = Fagsystem.EF, ytelsestype = Ytelsestype.OVERGANGSSTØNAD))
+        behandling = behandlingRepository.insert(behandling)
+        saksnummer = Testdata.fagsak.eksternFagsakId
+    }
+
+    @Test
+    fun `erEnsligForsørgerOgPerioderLike - en periode skal returnere IKKE_AKTUELL`() {
+        faktaFeilutbetalingRepository.insert(Testdata.lagFaktaFeilutbetaling(behandling.id))
+        val kravgrunnlag = lagKravgrunnlagsperiode(førstePeriode.fomDato, førstePeriode.tomDato)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id, setOf(kravgrunnlag)))
+        val erEnsligForsørgerOgPerioderLike = periodeService.erEnsligForsørgerOgPerioderLike(behandling.id)
+        erEnsligForsørgerOgPerioderLike shouldBe SkalSammenslåPerioder.IKKE_AKTUELT
+    }
+
+    @Test
+    fun `erEnsligForsørgerOgPerioderLike - har to perioder i fakta - skal returnere JA`() {
+        faktaFeilutbetalingRepository.insert(Testdata.lagFaktaFeilutbetaling(behandling.id, setOf(førstePeriode, andrePeriode)))
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id, perioder = setOf(lagKravgrunnlagsperiode(førstePeriode.fomDato, førstePeriode.tomDato), lagKravgrunnlagsperiode(andrePeriode.fomDato, andrePeriode.tomDato))))
+        foreldelseRepository.insert(Testdata.lagVurdertForeldelse(behandling.id, setOf(førstePeriode, andrePeriode)))
+
+        val vilkårsvurderingsperiode = Vilkårsvurderingsperiode(periode = Månedsperiode(førstePeriode.fomDato, førstePeriode.tomDato), vilkårsvurderingsresultat = Vilkårsvurderingsresultat.FORSTO_BURDE_FORSTÅTT, begrunnelse = "begrunnelse")
+        val vilkårsvurderingsperiode2 = Vilkårsvurderingsperiode(periode = Månedsperiode(andrePeriode.fomDato, andrePeriode.tomDato), vilkårsvurderingsresultat = Vilkårsvurderingsresultat.FORSTO_BURDE_FORSTÅTT, begrunnelse = "begrunnelse")
+        vilkårsvurderingRepository.insert(Vilkårsvurdering(behandlingId = behandling.id, perioder = setOf(vilkårsvurderingsperiode, vilkårsvurderingsperiode2)))
+        val erEnsligForsørgerOgPerioderLike = periodeService.erEnsligForsørgerOgPerioderLike(behandling.id)
+        erEnsligForsørgerOgPerioderLike shouldBe SkalSammenslåPerioder.JA
+    }
+
+    companion object {
+        private const val ANSVARLIG_SAKSBEHANDLER = "Z13456"
+        private const val ANSVARLIG_BESLUTTER = "Z12456"
+    }
+}

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeServiceTest.kt
@@ -14,6 +14,8 @@ import no.nav.familie.tilbake.dokumentbestilling.vedtak.domain.SkalSammenslåPer
 import no.nav.familie.tilbake.faktaomfeilutbetaling.FaktaFeilutbetalingRepository
 import no.nav.familie.tilbake.foreldelse.VurdertForeldelseRepository
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
+import no.nav.familie.tilbake.kravgrunnlag.domain.Fagområdekode
+import no.nav.familie.tilbake.kravgrunnlag.domain.Klassekode
 import no.nav.familie.tilbake.vilkårsvurdering.VilkårsvurderingRepository
 import no.nav.familie.tilbake.vilkårsvurdering.domain.Vilkårsvurdering
 import no.nav.familie.tilbake.vilkårsvurdering.domain.Vilkårsvurderingsperiode
@@ -90,6 +92,19 @@ class PeriodeServiceTest : OppslagSpringRunnerTest() {
     fun `erEnsligForsørgerOgPerioderLike - har to perioder i fakta - skal returnere JA`() {
         faktaFeilutbetalingRepository.insert(Testdata.lagFaktaFeilutbetaling(behandling.id, setOf(førstePeriode, andrePeriode)))
         kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id, perioder = setOf(lagKravgrunnlagsperiode(førstePeriode.fomDato, førstePeriode.tomDato), lagKravgrunnlagsperiode(andrePeriode.fomDato, andrePeriode.tomDato))))
+        foreldelseRepository.insert(Testdata.lagVurdertForeldelse(behandling.id, setOf(førstePeriode, andrePeriode)))
+
+        val vilkårsvurderingsperiode = Vilkårsvurderingsperiode(periode = Månedsperiode(førstePeriode.fomDato, førstePeriode.tomDato), vilkårsvurderingsresultat = Vilkårsvurderingsresultat.FORSTO_BURDE_FORSTÅTT, begrunnelse = "begrunnelse")
+        val vilkårsvurderingsperiode2 = Vilkårsvurderingsperiode(periode = Månedsperiode(andrePeriode.fomDato, andrePeriode.tomDato), vilkårsvurderingsresultat = Vilkårsvurderingsresultat.FORSTO_BURDE_FORSTÅTT, begrunnelse = "begrunnelse")
+        vilkårsvurderingRepository.insert(Vilkårsvurdering(behandlingId = behandling.id, perioder = setOf(vilkårsvurderingsperiode, vilkårsvurderingsperiode2)))
+        val erEnsligForsørgerOgPerioderLike = periodeService.erEnsligForsørgerOgPerioderLike(behandling.id)
+        erEnsligForsørgerOgPerioderLike shouldBe SkalSammenslåPerioder.JA
+    }
+
+    @Test
+    fun `erEnsligForsørgerOgPerioderLike - har to perioder i fakta for barnetilsyn - skal returnere JA`() {
+        faktaFeilutbetalingRepository.insert(Testdata.lagFaktaFeilutbetaling(behandling.id, setOf(førstePeriode, andrePeriode)))
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id, perioder = setOf(lagKravgrunnlagsperiode(førstePeriode.fomDato, førstePeriode.tomDato, Klassekode.EFBT), lagKravgrunnlagsperiode(andrePeriode.fomDato, andrePeriode.tomDato, Klassekode.EFBT)), fagområdekode = Fagområdekode.EFBT))
         foreldelseRepository.insert(Testdata.lagVurdertForeldelse(behandling.id, setOf(førstePeriode, andrePeriode)))
 
         val vilkårsvurderingsperiode = Vilkårsvurderingsperiode(periode = Månedsperiode(førstePeriode.fomDato, førstePeriode.tomDato), vilkårsvurderingsresultat = Vilkårsvurderingsresultat.FORSTO_BURDE_FORSTÅTT, begrunnelse = "begrunnelse")

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/PeriodeServiceTest.kt
@@ -74,6 +74,19 @@ class PeriodeServiceTest : OppslagSpringRunnerTest() {
     }
 
     @Test
+    fun `erEnsligForsørgerOgPerioderLike - en periode som er splittet skal returnere IKKE_AKTUELL`() {
+        faktaFeilutbetalingRepository.insert(Testdata.lagFaktaFeilutbetaling(behandling.id))
+        val kravgrunnlag = lagKravgrunnlagsperiode(førstePeriode.fomDato, førstePeriode.tomDato)
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id, setOf(kravgrunnlag)))
+
+        val vilkårsvurderingsperiode = Vilkårsvurderingsperiode(periode = Månedsperiode(førstePeriode.fomDato, førstePeriode.tomDato), vilkårsvurderingsresultat = Vilkårsvurderingsresultat.FORSTO_BURDE_FORSTÅTT, begrunnelse = "begrunnelse")
+        vilkårsvurderingRepository.insert(Vilkårsvurdering(behandlingId = behandling.id, perioder = setOf(vilkårsvurderingsperiode)))
+
+        val erEnsligForsørgerOgPerioderLike = periodeService.erEnsligForsørgerOgPerioderLike(behandling.id)
+        erEnsligForsørgerOgPerioderLike shouldBe SkalSammenslåPerioder.IKKE_AKTUELT
+    }
+
+    @Test
     fun `erEnsligForsørgerOgPerioderLike - har to perioder i fakta - skal returnere JA`() {
         faktaFeilutbetalingRepository.insert(Testdata.lagFaktaFeilutbetaling(behandling.id, setOf(førstePeriode, andrePeriode)))
         kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id, perioder = setOf(lagKravgrunnlagsperiode(førstePeriode.fomDato, førstePeriode.tomDato), lagKravgrunnlagsperiode(andrePeriode.fomDato, andrePeriode.tomDato))))


### PR DESCRIPTION
Det er ingen perioder å sammenslå dersom det bare er en periode i behandling. 
Det går an at det finnes flere perioder i vilkårsvurderingen, men bare en i fakta, så det må sjekkes at det bare er en periode i alle steg. 

Dette må settes for at målingen [her](https://metabase.ansatt.nav.no/question/4542-skal-sammensla-perioder) skal bli riktig.

I teorien må det patches for at målingen skal bli helt riktig, men det går kanskje greit å endre spørringen til å gjelde fra når denne endringen ble merget?

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22736)