### PR TITLE
Hopp over ansvarlig saksbehandler sjekk hvis man er forvalter

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/api/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/BehandlingController.kt
@@ -22,6 +22,7 @@ import no.nav.familie.tilbake.sikkerhet.AuditLoggerEvent
 import no.nav.familie.tilbake.sikkerhet.Behandlerrolle
 import no.nav.familie.tilbake.sikkerhet.HenteParam
 import no.nav.familie.tilbake.sikkerhet.Rolletilgangssjekk
+import no.nav.familie.tilbake.sikkerhet.TilgangService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -44,6 +45,7 @@ class BehandlingController(
     private val stegService: StegService,
     private val forvaltningService: ForvaltningService,
     private val behandlingskontrollService: BehandlingskontrollService,
+    private val tilgangService: TilgangService,
 ) {
     @Operation(summary = "Opprett tilbakekrevingsbehandling automatisk, kan kalles av fagsystem, batch")
     @PostMapping(
@@ -248,7 +250,7 @@ class BehandlingController(
     }
 
     private fun validerKanSetteBehandlingTilbakeTilFakta(behandlingId: UUID) {
-        feilHvis(!erAnsvarligSaksbehandler(behandlingId), HttpStatus.FORBIDDEN) {
+        feilHvis(!erAnsvarligSaksbehandler(behandlingId) || tilgangService.harInnloggetBrukerForvalterRolle(), HttpStatus.FORBIDDEN) {
             "Kun ansvarlig saksbehandler kan flytte behandling tilbake til fakta"
         }
         feilHvis(behandlingskontrollService.erBehandlingPåVent(behandlingId), HttpStatus.FORBIDDEN) {


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23344

Når flagget kanSetteBehandlingTilbakeTilFakta settes, så hopper man over ansvarlig saksbehandler sjekken dersom man er forvalter. Men når man faktisk forsøker å sette behandling tilbake til fakta, så tas det ikke hensyn til forvalter rollen.

Tar derfor hensyn til forvalter rollen på samme måte som når kanSetteBehandlingTilbakeTilFakta settes.