### PR TITLE
Validering av brevmottakere

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Fattevedtakssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Fattevedtakssteg.kt
@@ -133,7 +133,7 @@ class Fattevedtakssteg(
 
     override fun getBehandlingssteg(): Behandlingssteg = Behandlingssteg.FATTE_VEDTAK
 
-    fun validerManuelleBrevmottakere(
+    private fun validerManuelleBrevmottakere(
         behandlingId: UUID,
         erAlleStegGodkjente: Boolean,
     ) {

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Fattevedtakssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Fattevedtakssteg.kt
@@ -9,7 +9,10 @@ import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
 import no.nav.familie.tilbake.behandlingskontroll.Behandlingsstegsinfo
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
+import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
+import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.BrevmottakerAdresseValidering
+import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerRepository
 import no.nav.familie.tilbake.historikkinnslag.Aktør
 import no.nav.familie.tilbake.historikkinnslag.HistorikkTaskService
 import no.nav.familie.tilbake.historikkinnslag.TilbakekrevingHistorikkinnslagstype
@@ -28,6 +31,7 @@ class Fattevedtakssteg(
     private val oppgaveTaskService: OppgaveTaskService,
     private val historikkTaskService: HistorikkTaskService,
     private val behandlingsvedtakService: BehandlingsvedtakService,
+    private val manuellBrevmottakerRepository: ManuellBrevmottakerRepository,
 ) : IBehandlingssteg {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -40,20 +44,24 @@ class Fattevedtakssteg(
         behandlingId: UUID,
         behandlingsstegDto: BehandlingsstegDto,
     ) {
+        val fatteVedtaksstegDto = behandlingsstegDto as BehandlingsstegFatteVedtaksstegDto
+
+        // Steg 1: Validere behandlingens manuelle brevmottakere
+        validerManuelleBrevmottakere(behandlingId, fatteVedtaksstegDto.totrinnsvurderinger.all { it.godkjent })
+
         logger.info("Behandling $behandlingId er på ${Behandlingssteg.FATTE_VEDTAK} steg")
-        // step1: oppdater ansvarligBeslutter
+        // Steg 2: Oppdater ansvarligBeslutter
         totrinnService.validerAnsvarligBeslutter(behandlingId)
         totrinnService.oppdaterAnsvarligBeslutter(behandlingId)
 
-        // step2: lagre totrinnsvurderinger
-        val fatteVedtaksstegDto = behandlingsstegDto as BehandlingsstegFatteVedtaksstegDto
+        // Steg 3: Lagre totrinnsvurderinger
         totrinnService.lagreTotrinnsvurderinger(behandlingId, fatteVedtaksstegDto.totrinnsvurderinger)
 
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
-        // step3: lukk Godkjenne vedtak oppgaver
+        // Steg 4: Lukk Godkjenne vedtak oppgaver
         oppgaveTaskService.ferdigstilleOppgaveTask(behandlingId = behandlingId, oppgavetype = Oppgavetype.GodkjenneVedtak.name)
 
-        // step4: flytter behandling tilbake til Foreslå Vedtak om beslutter underkjente noen steg
+        // Steg 5: Flytter behandling tilbake til Foreslå Vedtak om beslutter underkjente noen steg
         val finnesUnderkjenteSteg = fatteVedtaksstegDto.totrinnsvurderinger.any { !it.godkjent }
         if (finnesUnderkjenteSteg) {
             behandlingskontrollService.behandleStegPåNytt(behandlingId, Behandlingssteg.FORESLÅ_VEDTAK)
@@ -83,7 +91,7 @@ class Fattevedtakssteg(
                 TilbakekrevingHistorikkinnslagstype.VEDTAK_FATTET,
                 Aktør.BESLUTTER,
             )
-            // step 5: opprett behandlingsvedtak og oppdater behandlingsresultat
+            // Steg 6: Opprett behandlingsvedtak og oppdater behandlingsresultat
             behandlingsvedtakService.opprettBehandlingsvedtak(behandlingId)
         }
         behandlingskontrollService.fortsettBehandling(behandlingId)
@@ -124,4 +132,17 @@ class Fattevedtakssteg(
     }
 
     override fun getBehandlingssteg(): Behandlingssteg = Behandlingssteg.FATTE_VEDTAK
+
+    fun validerManuelleBrevmottakere(
+        behandlingId: UUID,
+        erAlleStegGodkjente: Boolean,
+    ) {
+        val manuelleBrevmottakere = manuellBrevmottakerRepository.findByBehandlingId(behandlingId)
+        if (erAlleStegGodkjente && !BrevmottakerAdresseValidering.erBrevmottakereGyldige(manuelleBrevmottakere)) {
+            throw Feil(
+                message = "Det finnes ugyldige brevmottakere, vi kan ikke beslutte vedtaket",
+                frontendFeilmelding = "Adressen som er lagt til manuelt har ugyldig format, og vedtaksbrevet kan ikke sendes. Behandlingen må underkjennes, og saksbehandler må legge til manuell adresse på nytt.",
+            )
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Fattevedtakssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Fattevedtakssteg.kt
@@ -137,7 +137,7 @@ class Fattevedtakssteg(
         behandlingId: UUID,
         erAlleStegGodkjente: Boolean,
     ) {
-        val manuelleBrevmottakere = manuellBrevmottakerRepository.findByBehandlingId(behandlingId)
+        val manuelleBrevmottakere by lazy { manuellBrevmottakerRepository.findByBehandlingId(behandlingId) }
         if (erAlleStegGodkjente && !BrevmottakerAdresseValidering.erBrevmottakereGyldige(manuelleBrevmottakere)) {
             throw Feil(
                 message = "Det finnes ugyldige brevmottakere, vi kan ikke beslutte vedtaket",

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/BrevmottakerAdresseValidering.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/BrevmottakerAdresseValidering.kt
@@ -1,0 +1,10 @@
+package no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker
+
+import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.domene.ManuellBrevmottaker
+
+object BrevmottakerAdresseValidering {
+    fun erBrevmottakereGyldige(brevmottakere: List<ManuellBrevmottaker>): Boolean =
+        brevmottakere.all {
+            it.harGyldigAdresse()
+        }
+}

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/domene/ManuellBrevmottaker.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/domene/ManuellBrevmottaker.kt
@@ -39,5 +39,19 @@ data class ManuellBrevmottaker(
                 landkode.isNullOrBlank()
         )
 
+    fun harGyldigAdresse(): Boolean =
+        if (landkode == "NO") {
+            navn.isNotEmpty() &&
+                !adresselinje1.isNullOrEmpty()
+            !postnummer.isNullOrEmpty() &&
+                !poststed.isNullOrEmpty()
+        } else {
+            // Utenlandske manuelle brevmottakere skal ha postnummer og poststed satt i adresselinjene
+            navn.isNotEmpty() &&
+                !adresselinje1.isNullOrEmpty() &&
+                postnummer.isNullOrEmpty() &&
+                poststed.isNullOrEmpty()
+        }
+
     val erTilleggsmottaker get() = type == MottakerType.VERGE || type == MottakerType.FULLMEKTIG
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/domene/ManuellBrevmottaker.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/dokumentbestilling/manuell/brevmottaker/domene/ManuellBrevmottaker.kt
@@ -42,8 +42,8 @@ data class ManuellBrevmottaker(
     fun harGyldigAdresse(): Boolean =
         if (landkode == "NO") {
             navn.isNotEmpty() &&
-                !adresselinje1.isNullOrEmpty()
-            !postnummer.isNullOrEmpty() &&
+                !adresselinje1.isNullOrEmpty() &&
+                !postnummer.isNullOrEmpty() &&
                 !poststed.isNullOrEmpty()
         } else {
             // Utenlandske manuelle brevmottakere skal ha postnummer og poststed satt i adresselinjene

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/steg/FattevedtaksstegEnhetstest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/steg/FattevedtaksstegEnhetstest.kt
@@ -66,13 +66,12 @@ class FattevedtaksstegEnhetstest {
                 ),
             )
 
-        // Act
+        // Act & assert
         val exception =
             assertThrows<Feil> {
                 fattevedtakssteg.utførSteg(behandlingsId, fatteVedtaksstegDto)
             }
 
-        // Assert
         assertThat(exception.message, `is`("Det finnes ugyldige brevmottakere, vi kan ikke beslutte vedtaket"))
     }
 }

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/steg/FattevedtaksstegEnhetstest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/steg/FattevedtaksstegEnhetstest.kt
@@ -1,0 +1,78 @@
+package no.nav.familie.tilbake.behandling.steg
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.kontrakter.felles.tilbakekreving.MottakerType
+import no.nav.familie.tilbake.api.dto.BehandlingsstegFatteVedtaksstegDto
+import no.nav.familie.tilbake.api.dto.VurdertTotrinnDto
+import no.nav.familie.tilbake.behandling.BehandlingRepository
+import no.nav.familie.tilbake.behandling.BehandlingsvedtakService
+import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
+import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
+import no.nav.familie.tilbake.common.exceptionhandler.Feil
+import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerRepository
+import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.domene.ManuellBrevmottaker
+import no.nav.familie.tilbake.historikkinnslag.HistorikkTaskService
+import no.nav.familie.tilbake.oppgave.OppgaveTaskService
+import no.nav.familie.tilbake.totrinn.TotrinnService
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+class FattevedtaksstegEnhetstest {
+    private val mockBehandlingskontrollService: BehandlingskontrollService = mockk()
+    private val mockBehandlingRepository: BehandlingRepository = mockk()
+    private val mockTotrinnService: TotrinnService = mockk()
+    private val mockOppgaveTaskService: OppgaveTaskService = mockk()
+    private val mockHistorikkTaskService: HistorikkTaskService = mockk()
+    private val mockBehandlingsvedtakService: BehandlingsvedtakService = mockk()
+    private val mockManuellBrevmottakerRepository: ManuellBrevmottakerRepository = mockk()
+
+    private val fattevedtakssteg =
+        Fattevedtakssteg(
+            behandlingskontrollService = mockBehandlingskontrollService,
+            behandlingRepository = mockBehandlingRepository,
+            totrinnService = mockTotrinnService,
+            oppgaveTaskService = mockOppgaveTaskService,
+            historikkTaskService = mockHistorikkTaskService,
+            behandlingsvedtakService = mockBehandlingsvedtakService,
+            manuellBrevmottakerRepository = mockManuellBrevmottakerRepository,
+        )
+
+    @Test
+    fun `skal kaste feil hvis manuelle brevmottakere ikke er gyldige`() {
+        // Arrange
+        val behandlingsId = UUID.randomUUID()
+        val totrinnsvurderinger: List<VurdertTotrinnDto> =
+            listOf(
+                VurdertTotrinnDto(behandlingssteg = Behandlingssteg.FAKTA, godkjent = true),
+                VurdertTotrinnDto(behandlingssteg = Behandlingssteg.VILKÅRSVURDERING, godkjent = true),
+                VurdertTotrinnDto(behandlingssteg = Behandlingssteg.FORESLÅ_VEDTAK, godkjent = true),
+            )
+        val fatteVedtaksstegDto = BehandlingsstegFatteVedtaksstegDto(totrinnsvurderinger)
+
+        every { mockManuellBrevmottakerRepository.findByBehandlingId(any()) } returns
+            listOf(
+                ManuellBrevmottaker(
+                    id = UUID.randomUUID(),
+                    behandlingId = behandlingsId,
+                    navn = "Test testesen",
+                    type = MottakerType.BRUKER_MED_UTENLANDSK_ADRESSE,
+                    adresselinje1 = "Testadresse med ugyldig postnummer og poststed (fordi det er i utlandet)",
+                    postnummer = "0661",
+                    poststed = "Oslo",
+                ),
+            )
+
+        // Act
+        val exception =
+            assertThrows<Feil> {
+                fattevedtakssteg.utførSteg(behandlingsId, fatteVedtaksstegDto)
+            }
+
+        // Assert
+        assertThat(exception.message, `is`("Det finnes ugyldige brevmottakere, vi kan ikke beslutte vedtaket"))
+    }
+}

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DokumentBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DokumentBehandlingServiceTest.kt
@@ -17,6 +17,7 @@ import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.dokumentbestilling.brevmaler.Dokumentmalstype
 import no.nav.familie.tilbake.dokumentbestilling.innhentdokumentasjon.InnhentDokumentasjonbrevService
 import no.nav.familie.tilbake.dokumentbestilling.innhentdokumentasjon.InnhentDokumentasjonbrevTask
+import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerRepository
 import no.nav.familie.tilbake.dokumentbestilling.varsel.manuelt.ManueltVarselbrevService
 import no.nav.familie.tilbake.dokumentbestilling.varsel.manuelt.SendManueltVarselbrevTask
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
@@ -62,6 +63,7 @@ class DokumentBehandlingServiceTest : OppslagSpringRunnerTest() {
 
     private val mockManueltVarselBrevService: ManueltVarselbrevService = mockk()
     private val mockInnhentDokumentasjonbrevService: InnhentDokumentasjonbrevService = mockk()
+    private val mockManuellBrevmottakerRepository: ManuellBrevmottakerRepository = mockk()
 
     private lateinit var dokumentBehandlingService: DokumentbehandlingService
 
@@ -79,6 +81,7 @@ class DokumentBehandlingServiceTest : OppslagSpringRunnerTest() {
                 taskService,
                 mockManueltVarselBrevService,
                 mockInnhentDokumentasjonbrevService,
+                mockManuellBrevmottakerRepository,
             )
     }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DokumentBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DokumentBehandlingServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.tilbake.dokumentbestilling
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import no.nav.familie.prosessering.domene.Status
@@ -83,6 +84,8 @@ class DokumentBehandlingServiceTest : OppslagSpringRunnerTest() {
                 mockInnhentDokumentasjonbrevService,
                 mockManuellBrevmottakerRepository,
             )
+
+        every { mockManuellBrevmottakerRepository.findByBehandlingId(behandling.id) } returns emptyList()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DokumentbehandlingServiceEnhetstest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DokumentbehandlingServiceEnhetstest.kt
@@ -18,9 +18,8 @@ import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBre
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.domene.ManuellBrevmottaker
 import no.nav.familie.tilbake.dokumentbestilling.varsel.manuelt.ManueltVarselbrevService
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import java.util.*
+import java.util.UUID
 
 class DokumentbehandlingServiceEnhetstest {
     private val mockBehandlingRepository: BehandlingRepository = mockk()

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DokumentbehandlingServiceEnhetstest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/DokumentbehandlingServiceEnhetstest.kt
@@ -1,0 +1,60 @@
+package no.nav.familie.tilbake.dokumentbestilling
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.kontrakter.felles.tilbakekreving.MottakerType
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.familie.tilbake.behandling.BehandlingRepository
+import no.nav.familie.tilbake.behandling.FagsakRepository
+import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
+import no.nav.familie.tilbake.common.exceptionhandler.Feil
+import no.nav.familie.tilbake.common.repository.findByIdOrThrow
+import no.nav.familie.tilbake.data.Testdata
+import no.nav.familie.tilbake.dokumentbestilling.brevmaler.Dokumentmalstype
+import no.nav.familie.tilbake.dokumentbestilling.innhentdokumentasjon.InnhentDokumentasjonbrevService
+import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.ManuellBrevmottakerRepository
+import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.domene.ManuellBrevmottaker
+import no.nav.familie.tilbake.dokumentbestilling.varsel.manuelt.ManueltVarselbrevService
+import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class DokumentbehandlingServiceEnhetstest {
+    private val mockBehandlingRepository: BehandlingRepository = mockk()
+    private val mockFagsakRepository: FagsakRepository = mockk()
+    private val mockBehandlingskontrollService: BehandlingskontrollService = mockk()
+    private val mockKravgrunnlagRepository: KravgrunnlagRepository = mockk()
+    private val mockTaskService: TaskService = mockk()
+    private val mockManueltVarselBrevService: ManueltVarselbrevService = mockk()
+    private val mockInnhentDokumentasjonBrevService: InnhentDokumentasjonbrevService = mockk()
+    private val mockManuellBrevmottakerRepository: ManuellBrevmottakerRepository = mockk()
+
+    val dokumentBehandlingService = DokumentbehandlingService(mockBehandlingRepository, mockFagsakRepository, mockBehandlingskontrollService, mockKravgrunnlagRepository, mockTaskService, mockManueltVarselBrevService, mockInnhentDokumentasjonBrevService, mockManuellBrevmottakerRepository)
+
+    @Test
+    fun `bestillBrev skal ikke kunne bestille brev når brevmottakerne er ugyldige`() {
+        // Arrange
+        val behandling = Testdata.lagBehandling()
+        every { mockBehandlingRepository.findByIdOrThrow(behandling.id) } returns behandling
+        every { mockManuellBrevmottakerRepository.findByBehandlingId(any()) } returns
+            listOf(
+                ManuellBrevmottaker(
+                    id = UUID.randomUUID(),
+                    behandlingId = behandling.id,
+                    navn = "Test testesen",
+                    type = MottakerType.BRUKER_MED_UTENLANDSK_ADRESSE,
+                    adresselinje1 = "Testadresse med ugyldig postnummer og poststed (fordi det er i utlandet)",
+                    postnummer = "0661",
+                    poststed = "Oslo",
+                ),
+            )
+
+        // Act & assert
+        shouldThrow<Feil> {
+            dokumentBehandlingService.bestillBrev(behandling.id, Dokumentmalstype.VARSEL, "Bestilt varselbrev")
+        }.message shouldBe "Det finnes ugyldige brevmottakere i utsending av manuelt brev"
+    }
+}


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23182

Brevmottakere skal valideres når brev sendes ut og når beslutter godkjenner et vedtak. Hvis brevmottakerne er ugyldige (postnummer og poststed til stede for utenlandske mottakere), skal kallene feile. Beslutter skal få lov til å sende vedtaket tilbake til saksbehandler hvis dette er tilfelle. :)