### PR TITLE
Nav 23517 validere saksbehandler opp mot enhet

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
@@ -30,7 +30,6 @@ class OppdaterAnsvarligSaksbehandlerTask(
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         val oppgave = oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandlingId)
         val prioritet = oppgavePrioritetService.utledOppgaveprioritet(behandlingId, oppgave)
-        oppgave.tildeltEnhetsnr
 
         try {
             oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
@@ -34,9 +34,9 @@ class OppdaterAnsvarligSaksbehandlerTask(
         log.info("=====>>>> behandling.ansvarligSaksbehandler:  {}", behandling.ansvarligSaksbehandler)
         log.info("=====>>>> oppgave.prioritet:   {}", oppgave.prioritet)
         log.info("=====>>>> prioritet:           {}", prioritet)
-        if (oppgave.tilordnetRessurs != behandling.ansvarligSaksbehandler || oppgave.prioritet != prioritet) {
+      /*  if (oppgave.tilordnetRessurs != behandling.ansvarligSaksbehandler || oppgave.prioritet != prioritet) {
             oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
-        }
+        }*/
         try{
             oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
         }catch (e:Exception) {

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
@@ -37,6 +37,12 @@ class OppdaterAnsvarligSaksbehandlerTask(
         if (oppgave.tilordnetRessurs != behandling.ansvarligSaksbehandler || oppgave.prioritet != prioritet) {
             oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
         }
+        try{
+            oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
+        }catch (e:Exception) {
+            log.info("Eneht på oppgaven og enhet hos saksbehandleren er IKKE det samme!")
+            oppgaveService.patchOppgave(oppgave.copy(prioritet = prioritet))
+        }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
@@ -5,6 +5,7 @@ import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
+import no.nav.familie.tilbake.integration.pdl.internal.secureLogger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -36,7 +37,7 @@ class OppdaterAnsvarligSaksbehandlerTask(
                 oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
             } catch (e: Exception) {
                 oppgaveService.patchOppgave(oppgave.copy(prioritet = prioritet))
-                log.info("Kunne ikke oppdatere tilordnetRessurs. Mulig årsak kan være at eneht på oppgaven og enhet hos saksbehandleren er IKKE det samme!")
+                secureLogger.warn("Kunne ikke oppdatere tilordnetRessurs, ${behandling.ansvarligSaksbehandler}" )
             }
         }
     }

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
@@ -30,19 +30,14 @@ class OppdaterAnsvarligSaksbehandlerTask(
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         val oppgave = oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandlingId)
         val prioritet = oppgavePrioritetService.utledOppgaveprioritet(behandlingId, oppgave)
-        log.info("=====>>>> oppgave.tilordnetRessurs:           {}", oppgave.tilordnetRessurs)
-        log.info("=====>>>> behandling.ansvarligSaksbehandler:  {}", behandling.ansvarligSaksbehandler)
-        log.info("=====>>>> oppgave.prioritet:   {}", oppgave.prioritet)
-        log.info("=====>>>> prioritet:           {}", prioritet)
-      /*  if (oppgave.tilordnetRessurs != behandling.ansvarligSaksbehandler || oppgave.prioritet != prioritet) {
-            oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
-        }*/
-        try{
-            oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
-        }catch (e:Exception) {
-            log.info("Eneht på oppgaven og enhet hos saksbehandleren er IKKE det samme!")
-            oppgaveService.patchOppgave(oppgave.copy(prioritet = prioritet))
-        }
+        oppgave.tildeltEnhetsnr
+
+          try{
+              oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
+          }catch (e:Exception) {
+              oppgaveService.patchOppgave(oppgave.copy(prioritet = prioritet))
+              log.info("Eneht på oppgaven og enhet hos saksbehandleren er IKKE det samme!")
+          }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
@@ -36,7 +36,7 @@ class OppdaterAnsvarligSaksbehandlerTask(
             oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
         } catch (e: Exception) {
             oppgaveService.patchOppgave(oppgave.copy(prioritet = prioritet))
-            log.info("Eneht på oppgaven og enhet hos saksbehandleren er IKKE det samme!")
+            log.info("Kunne ikke oppdatere tilordnetRessurs. Mulig årsak kan være at eneht på oppgaven og enhet hos saksbehandleren er IKKE det samme!")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
@@ -32,12 +32,12 @@ class OppdaterAnsvarligSaksbehandlerTask(
         val prioritet = oppgavePrioritetService.utledOppgaveprioritet(behandlingId, oppgave)
         oppgave.tildeltEnhetsnr
 
-          try{
-              oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
-          }catch (e:Exception) {
-              oppgaveService.patchOppgave(oppgave.copy(prioritet = prioritet))
-              log.info("Eneht på oppgaven og enhet hos saksbehandleren er IKKE det samme!")
-          }
+        try {
+            oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
+        } catch (e: Exception) {
+            oppgaveService.patchOppgave(oppgave.copy(prioritet = prioritet))
+            log.info("Eneht på oppgaven og enhet hos saksbehandleren er IKKE det samme!")
+        }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
@@ -37,7 +37,7 @@ class OppdaterAnsvarligSaksbehandlerTask(
                 oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
             } catch (e: Exception) {
                 oppgaveService.patchOppgave(oppgave.copy(prioritet = prioritet))
-                secureLogger.warn("Kunne ikke oppdatere tilordnetRessurs, ${behandling.ansvarligSaksbehandler}" )
+                secureLogger.warn("Kunne ikke oppdatere tilordnetRessurs, ${behandling.ansvarligSaksbehandler}")
             }
         }
     }

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
@@ -30,7 +30,10 @@ class OppdaterAnsvarligSaksbehandlerTask(
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         val oppgave = oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandlingId)
         val prioritet = oppgavePrioritetService.utledOppgaveprioritet(behandlingId, oppgave)
-
+        log.info("=====>>>> oppgave.tilordnetRessurs:           {}", oppgave.tilordnetRessurs)
+        log.info("=====>>>> behandling.ansvarligSaksbehandler:  {}", behandling.ansvarligSaksbehandler)
+        log.info("=====>>>> oppgave.prioritet:   {}", oppgave.prioritet)
+        log.info("=====>>>> prioritet:           {}", prioritet)
         if (oppgave.tilordnetRessurs != behandling.ansvarligSaksbehandler || oppgave.prioritet != prioritet) {
             oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
         }

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTask.kt
@@ -31,11 +31,13 @@ class OppdaterAnsvarligSaksbehandlerTask(
         val oppgave = oppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandlingId)
         val prioritet = oppgavePrioritetService.utledOppgaveprioritet(behandlingId, oppgave)
 
-        try {
-            oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
-        } catch (e: Exception) {
-            oppgaveService.patchOppgave(oppgave.copy(prioritet = prioritet))
-            log.info("Kunne ikke oppdatere tilordnetRessurs. Mulig årsak kan være at eneht på oppgaven og enhet hos saksbehandleren er IKKE det samme!")
+        if (oppgave.tilordnetRessurs != behandling.ansvarligSaksbehandler || oppgave.prioritet != prioritet) {
+            try {
+                oppgaveService.patchOppgave(oppgave.copy(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = prioritet))
+            } catch (e: Exception) {
+                oppgaveService.patchOppgave(oppgave.copy(prioritet = prioritet))
+                log.info("Kunne ikke oppdatere tilordnetRessurs. Mulig årsak kan være at eneht på oppgaven og enhet hos saksbehandleren er IKKE det samme!")
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterOppgaveTask.kt
@@ -60,7 +60,7 @@ class OppdaterOppgaveTask(
                 beskrivelse + System.lineSeparator() + (oppgave?.beskrivelse ?: "")
 
         val prioritet = oppgavePrioritetService.utledOppgaveprioritet(behandlingId, oppgave)
-     
+
         var patchetOppgave =
             oppgave.copy(
                 fristFerdigstillelse = frist,

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterOppgaveTask.kt
@@ -60,11 +60,7 @@ class OppdaterOppgaveTask(
                 beskrivelse + System.lineSeparator() + (oppgave?.beskrivelse ?: "")
 
         val prioritet = oppgavePrioritetService.utledOppgaveprioritet(behandlingId, oppgave)
-        log.info("=====>>>>> TEST saksbehandler <<<====== {}", saksbehandler)
-        log.info("=====>>>>> TEST oppgave.tildeltEnhetsnr <<<====== {}", oppgave.tildeltEnhetsnr)
-        log.info("=====>>>>> TEST oppgave.tilordnetRessurs <<<====== {}", oppgave.tilordnetRessurs)
-
-
+     
         var patchetOppgave =
             oppgave.copy(
                 fristFerdigstillelse = frist,

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppdaterOppgaveTask.kt
@@ -60,6 +60,10 @@ class OppdaterOppgaveTask(
                 beskrivelse + System.lineSeparator() + (oppgave?.beskrivelse ?: "")
 
         val prioritet = oppgavePrioritetService.utledOppgaveprioritet(behandlingId, oppgave)
+        log.info("=====>>>>> TEST saksbehandler <<<====== {}", saksbehandler)
+        log.info("=====>>>>> TEST oppgave.tildeltEnhetsnr <<<====== {}", oppgave.tildeltEnhetsnr)
+        log.info("=====>>>>> TEST oppgave.tilordnetRessurs <<<====== {}", oppgave.tilordnetRessurs)
+
 
         var patchetOppgave =
             oppgave.copy(

--- a/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTaskTest.kt
@@ -1,6 +1,9 @@
 package no.nav.familie.tilbake.oppgave
 
-import io.mockk.*
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
@@ -75,7 +78,6 @@ internal class OppdaterAnsvarligSaksbehandlerTaskTest {
         }
     }
 
-
     @Test
     fun `Skal kalle patchOppgave med oppdatert prioritet når unntak kastes`() {
         val oppgave = Oppgave(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = OppgavePrioritet.NORM)
@@ -91,11 +93,12 @@ internal class OppdaterAnsvarligSaksbehandlerTaskTest {
 
         verify(exactly = 2) { mockOppgaveService.patchOppgave(any()) }
         verify {
-            mockOppgaveService.patchOppgave(match {
-                it.prioritet == OppgavePrioritet.NORM
-            })
+            mockOppgaveService.patchOppgave(
+                match {
+                    it.prioritet == OppgavePrioritet.NORM
+                },
+            )
         }
-
     }
 
     private fun lagTask(opprettetAv: String? = null): Task =
@@ -111,9 +114,4 @@ internal class OppdaterAnsvarligSaksbehandlerTaskTest {
                     }
                 },
         )
-
-
-
 }
-
-

--- a/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTaskTest.kt
@@ -58,8 +58,20 @@ internal class OppdaterAnsvarligSaksbehandlerTaskTest {
     }
 
     @Test
-    fun `doTask skal oppdatere oppgave når saksbehandler endret`() {
+    fun `Skal ikke oppdatere oppgave når ingenting er endret`() {
         val oppgave = Oppgave(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = OppgavePrioritet.NORM)
+
+        every { oppgavePrioritetService.utledOppgaveprioritet(any(), any()) } returns OppgavePrioritet.NORM
+        every { mockOppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandling.id) } returns oppgave
+
+        oppdaterAnsvarligSaksbehandlerTask.doTask(lagTask())
+
+        verify(exactly = 0) { mockOppgaveService.patchOppgave(any()) }
+    }
+
+    @Test
+    fun `doTask skal oppdatere oppgave når saksbehandler endret`() {
+        val oppgave = Oppgave(tilordnetRessurs = "Saksbehandler", prioritet = OppgavePrioritet.NORM)
 
         every { oppgavePrioritetService.utledOppgaveprioritet(any(), any()) } returns OppgavePrioritet.NORM
         every { mockOppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandling.id) } returns oppgave

--- a/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppdaterAnsvarligSaksbehandlerTaskTest.kt
@@ -1,11 +1,9 @@
 package no.nav.familie.tilbake.oppgave
 
-import io.mockk.clearMocks
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import io.mockk.*
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
+import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.tilbake.behandling.BehandlingRepository
@@ -58,9 +56,12 @@ internal class OppdaterAnsvarligSaksbehandlerTaskTest {
 
     @Test
     fun `doTask skal oppdatere oppgave når saksbehandler endret`() {
-        val oppgave = Oppgave(tilordnetRessurs = "TIDLIGERE saksbehandler", prioritet = OppgavePrioritet.NORM)
+        val oppgave = Oppgave(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = OppgavePrioritet.NORM)
+
         every { oppgavePrioritetService.utledOppgaveprioritet(any(), any()) } returns OppgavePrioritet.NORM
         every { mockOppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandling.id) } returns oppgave
+
+        every { mockOppgaveService.patchOppgave(match { it.tilordnetRessurs == behandling.ansvarligSaksbehandler && it.prioritet == OppgavePrioritet.NORM }) } returns OppgaveResponse(oppgave.id ?: 1)
 
         oppdaterAnsvarligSaksbehandlerTask.doTask(lagTask())
 
@@ -74,16 +75,27 @@ internal class OppdaterAnsvarligSaksbehandlerTaskTest {
         }
     }
 
+
     @Test
-    fun `Skal ikke oppdatere oppgave når ingenting er endret`() {
+    fun `Skal kalle patchOppgave med oppdatert prioritet når unntak kastes`() {
         val oppgave = Oppgave(tilordnetRessurs = behandling.ansvarligSaksbehandler, prioritet = OppgavePrioritet.NORM)
+        val oppgaveSomFeiler = Oppgave(prioritet = OppgavePrioritet.NORM)
 
         every { oppgavePrioritetService.utledOppgaveprioritet(any(), any()) } returns OppgavePrioritet.NORM
-        every { mockOppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandling.id) } returns oppgave
+        every { mockOppgaveService.finnOppgaveForBehandlingUtenOppgaveType(behandling.id) } returns oppgaveSomFeiler
+
+        every { mockOppgaveService.patchOppgave(match { it.tilordnetRessurs == behandling.ansvarligSaksbehandler && it.prioritet == OppgavePrioritet.NORM }) } throws RuntimeException("Mock exception")
+        every { mockOppgaveService.patchOppgave(match { it.prioritet == OppgavePrioritet.NORM && it.tilordnetRessurs == null }) } returns OppgaveResponse(oppgave.id ?: 1)
 
         oppdaterAnsvarligSaksbehandlerTask.doTask(lagTask())
 
-        verify(exactly = 0) { mockOppgaveService.patchOppgave(any()) }
+        verify(exactly = 2) { mockOppgaveService.patchOppgave(any()) }
+        verify {
+            mockOppgaveService.patchOppgave(match {
+                it.prioritet == OppgavePrioritet.NORM
+            })
+        }
+
     }
 
     private fun lagTask(opprettetAv: String? = null): Task =
@@ -99,4 +111,9 @@ internal class OppdaterAnsvarligSaksbehandlerTaskTest {
                     }
                 },
         )
+
+
+
 }
+
+


### PR DESCRIPTION
Erstattet if-statement med en try-catch slik at oppgaven oppdateres uten feil selv om enhet på oppgaven og enhet på den nye saksbehandleren ikke samsvarer. 