### PR TITLE
Sørger for at vi bruker korrekt klassekode for utvidet ved iverksettelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/iverksettvedtak/IverksettelseService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/iverksettvedtak/IverksettelseService.kt
@@ -168,7 +168,7 @@ class IverksettelseService(
         ) {
             throw Feil(
                 message =
-                "Det gikk noe feil i beregning under iverksettelse for behandlingId=$behandlingId." +
+                    "Det gikk noe feil i beregning under iverksettelse for behandlingId=$behandlingId." +
                         "Beregnet beløp i vedtaksbrev er " +
                         "totalTilbakekrevingsbeløpUtenRenter=$totalTilbakekrevingsbeløpUtenRenter," +
                         "totalRenteBeløp=$totalRenteBeløp, totalSkatteBeløp=$totalSkatteBeløp mens " +

--- a/src/main/kotlin/no/nav/familie/tilbake/iverksettvedtak/IverksettelseService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/iverksettvedtak/IverksettelseService.kt
@@ -110,7 +110,7 @@ class IverksettelseService(
         beregnetBeløper.map {
             val tilbakekrevingsbeløp = TilbakekrevingsbelopDto()
             tilbakekrevingsbeløp.apply {
-                kodeKlasse = it.klassekode.name
+                kodeKlasse = it.klassekode.tilKlassekodeNavn()
                 belopNy = it.nyttBeløp
                 belopOpprUtbet = it.utbetaltBeløp
                 belopTilbakekreves = it.tilbakekrevesBeløp
@@ -168,7 +168,7 @@ class IverksettelseService(
         ) {
             throw Feil(
                 message =
-                    "Det gikk noe feil i beregning under iverksettelse for behandlingId=$behandlingId." +
+                "Det gikk noe feil i beregning under iverksettelse for behandlingId=$behandlingId." +
                         "Beregnet beløp i vedtaksbrev er " +
                         "totalTilbakekrevingsbeløpUtenRenter=$totalTilbakekrevingsbeløpUtenRenter," +
                         "totalRenteBeløp=$totalRenteBeløp, totalSkatteBeløp=$totalSkatteBeløp mens " +

--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/domain/Kravgrunnlag431.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/domain/Kravgrunnlag431.kt
@@ -163,6 +163,9 @@ enum class Klassekode(
     TREK_KODER(""), // Felles klassekode for alle TREK klassetyper
     ;
 
+    fun tilKlassekodeNavn(): String =
+        this.overstyrtKlassekode.ifEmpty { this.name }
+
     companion object {
         fun fraKode(
             kode: String,

--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/domain/Kravgrunnlag431.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/domain/Kravgrunnlag431.kt
@@ -163,8 +163,7 @@ enum class Klassekode(
     TREK_KODER(""), // Felles klassekode for alle TREK klassetyper
     ;
 
-    fun tilKlassekodeNavn(): String =
-        this.overstyrtKlassekode.ifEmpty { this.name }
+    fun tilKlassekodeNavn(): String = this.overstyrtKlassekode.ifEmpty { this.name }
 
     companion object {
         fun fraKode(

--- a/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/domain/KlassekodeTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/kravgrunnlag/domain/KlassekodeTest.kt
@@ -16,4 +16,25 @@ class KlassekodeTest {
             assertThat(klassekode).isEqualTo(Klassekode.BAUTV_OP)
         }
     }
+
+    @Nested
+    inner class TilKlassekodeNavn {
+        @Test
+        fun `skal bruke overstyrtKlassekode dersom den finnes ellers enum navn`() {
+            // Act
+            val klassekodeNavn = Klassekode.BAUTV_OP.tilKlassekodeNavn()
+
+            // Assert
+            assertThat(klassekodeNavn).isEqualTo("BAUTV-OP")
+        }
+
+        @Test
+        fun `skal bruke enum navn dersom overstyrtKlassekode ikke er satt`() {
+            // Act
+            val klassekodeNavn = Klassekode.BATR.tilKlassekodeNavn()
+
+            // Assert
+            assertThat(klassekodeNavn).isEqualTo("BATR")
+        }
+    }
 }


### PR DESCRIPTION
Ved iverksettelse ble `Klassekode.name` brukt for feltet `kodeKlasse`. Dette har fungert helt frem til vi nå har introdusert klassekoden `BAUTV-OP` og enum-verdien `BAUTV_OP`. Fordi vi bruker `name` så er det `BATUV_OP` som vi forsøker å sende ved iverksettelse, men denne koden er ikke gyldig, da vi skulle ha brukt `BAUTV-OP` med bindestrek (-).

Legger her til extension-function for å sette feltet `kodeKlasse`, slik at vi bruker enum-feltet `overstyrtKlassekode` dersom det finnes og ellers bare `Klassekode.name` slik som før.