### PR TITLE
Skrur ned loggnivå på ting som logges til INFO i vanlig logg, siden man har begynt å få alarm på ERROR i securelogs

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/common/exceptionhandler/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/common/exceptionhandler/ApiExceptionHandler.kt
@@ -32,7 +32,7 @@ class ApiExceptionHandler {
 
     @ExceptionHandler(Feil::class)
     fun handleThrowable(feil: Feil): ResponseEntity<Ressurs<Nothing>> {
-        secureLogger.error("En håndtert feil har oppstått(${feil.httpStatus}): ${feil.message}", feil)
+        secureLogger.warn("En håndtert feil har oppstått(${feil.httpStatus}): ${feil.message}", feil)
         logger.info("En håndtert feil har oppstått(${feil.httpStatus}) exception=${rootCause(feil)}: ${feil.message} ")
         return ResponseEntity.status(feil.httpStatus).body(
             Ressurs.failure(
@@ -40,13 +40,6 @@ class ApiExceptionHandler {
                 frontendFeilmelding = feil.frontendFeilmelding,
             ),
         )
-    }
-
-    @ExceptionHandler(ManglerTilgang::class)
-    fun handleThrowable(manglerTilgang: ManglerTilgang): ResponseEntity<Ressurs<Nothing>> {
-        secureLogger.error("En håndtert tilgangsfeil har oppstått - ${manglerTilgang.melding}", manglerTilgang)
-        logger.info("En håndtert tilgangsfeil har oppstått")
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Ressurs.ikkeTilgang(melding = manglerTilgang.melding))
     }
 
     @ExceptionHandler(IntegrasjonException::class)

--- a/src/main/kotlin/no/nav/familie/tilbake/common/exceptionhandler/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/common/exceptionhandler/Feil.kt
@@ -37,10 +37,6 @@ class ManglerOppgaveFeil(
     val melding: String,
 ) : RuntimeException(melding)
 
-class ManglerTilgang(
-    val melding: String,
-) : RuntimeException(melding)
-
 class UgyldigKravgrunnlagFeil(
     val melding: String,
 ) : RuntimeException(melding)


### PR DESCRIPTION
I det siste har man begynt å få alarmer på ERRORs i securelogger for familie-tilbake. Skrur ned nivå i ApiExceptionHandler til WARN for feil av typen Feil. Disse logges til vanlig logg som INFO

Slettet også forvirrende exception ManglerTilgang, som kun er i bruk i ApiExceptionHandler