### PR TITLE
ikke prøv å avslutte behandling som allerede er avsluttet

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/iverksettvedtak/task/AvsluttBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/iverksettvedtak/task/AvsluttBehandlingTask.kt
@@ -39,6 +39,11 @@ class AvsluttBehandlingTask(
         val behandlingId = UUID.fromString(task.payload)
 
         var behandling = behandlingRepository.findByIdOrThrow(behandlingId)
+        if (behandling.status == Behandlingsstatus.AVSLUTTET) {
+            log.info("Behandling er allerede avsluttet")
+            return
+        }
+
         if (!behandling.erUnderIverksettelse) {
             throw Feil(message = "Behandling med id=$behandlingId kan ikke avsluttes")
         }

--- a/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/AvsluttBehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/iverksettvedtak/AvsluttBehandlingTaskTest.kt
@@ -1,9 +1,6 @@
 package no.nav.familie.tilbake.iverksettvedtak
 
-import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.core.read.ListAppender
 import io.kotest.matchers.shouldBe
-import io.kotest.mpp.log
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
@@ -26,7 +23,6 @@ import no.nav.familie.tilbake.iverksettvedtak.task.AvsluttBehandlingTask
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import java.util.UUID
 
@@ -96,7 +92,7 @@ internal class AvsluttBehandlingTaskTest : OppslagSpringRunnerTest() {
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         behandlingRepository.update(behandling.copy(status = Behandlingsstatus.AVSLUTTET))
 
-        //Act and assert
+        // Act and assert
         assertDoesNotThrow { avsluttBehandlingTask.doTask(Task(type = AvsluttBehandlingTask.TYPE, payload = behandlingId.toString())) }
     }
 }


### PR DESCRIPTION
Får feil i [denne](https://familie-prosessering.intern.nav.no/service/familie-tilbake/task/2300661) tasken som prøver å avslutte en behandling som allerede er avsluttet. Legger til en sjekk slik at vi ikke prøver å avslutte behandlinger som allerede er avsluttet.