### PR TITLE
Deploy application to new namespace

### DIFF
--- a/.deploy/nais/app-dev-gcp.yaml
+++ b/.deploy/nais/app-dev-gcp.yaml
@@ -62,7 +62,7 @@ spec:
       enabled: true
       tenant: trygdeetaten.no
       replyURLs:
-        - "https://tilbakekreving.intern.dev.nav.no/swagger-ui/oauth2-redirect.html"
+        - "https://tilbakekreving-backend.intern.dev.nav.no/swagger-ui/oauth2-redirect.html"
       singlePageApplication: true
   accessPolicy:
     inbound:
@@ -115,7 +115,7 @@ spec:
       memory: 1024Mi
       cpu: 25m
   ingresses:
-    - https://tilbakekreving.intern.dev.nav.no
+    - https://tilbakekreving-backend.intern.dev.nav.no
   secureLogs:
     enabled: true
   env:

--- a/.deploy/nais/app-dev-gcp.yaml
+++ b/.deploy/nais/app-dev-gcp.yaml
@@ -88,8 +88,8 @@ spec:
         - application: ida
           namespace: traktor
           cluster: prod-fss
-        - application: familie-prosessering
-          namespace: teamfamilie
+        - application: tilbakekreving-prosessering
+          namespace: tilbake
           cluster: dev-gcp
         - application: familie-prosessering-lokal
           namespace: teamfamilie

--- a/.deploy/nais/app-dev-gcp.yaml
+++ b/.deploy/nais/app-dev-gcp.yaml
@@ -1,18 +1,18 @@
 apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
-  name: familie-tilbake
+  name: tilbakekreving-backend
   namespace: teamfamilie
   annotations:
     nais.io/run-as-group: "65532" # nonroot https://github.com/GoogleContainerTools/distroless/issues/443
     nais.io/run-as-user: "65532" # nonroot https://github.com/GoogleContainerTools/distroless/issues/443
   labels:
-    team: teamfamilie
+    team: tilbake
 
 spec:
   envFrom:
-    - secret: familie-tilbake
-    - secret: familie-tilbake-unleash-api-token
+    - secret: tilbakekreving-backend
+    - secret: tilbakekreving-backend-unleash-api-token
   image: {{ image }}
   port: 8030
   leaderElection: true
@@ -37,10 +37,10 @@ spec:
     sqlInstances:
       - type: POSTGRES_14
         tier: db-custom-1-3840
-        name: familie-tilbake
+        name: tilbakekreving
         autoBackupHour: 3
         databases:
-          - name: familie-tilbake
+          - name: tilbakekreving
             envVarPrefix: DB
   azure:
     application:
@@ -62,7 +62,7 @@ spec:
       enabled: true
       tenant: trygdeetaten.no
       replyURLs:
-        - "https://familie-tilbake.intern.dev.nav.no/swagger-ui/oauth2-redirect.html"
+        - "https://tilbakekreving.intern.dev.nav.no/swagger-ui/oauth2-redirect.html"
       singlePageApplication: true
   accessPolicy:
     inbound:
@@ -99,7 +99,7 @@ spec:
           cluster: dev-gcp
     outbound:
       external:
-        - host: teamfamilie-unleash-api.nav.cloud.nais.io
+        - host: tilbake-unleash-api.nav.cloud.nais.io
         - host: familie-integrasjoner.dev-fss-pub.nais.io
         - host: pdl-api.dev-fss-pub.nais.io
         - host: b27apvl220.preprod.local
@@ -115,7 +115,7 @@ spec:
       memory: 1024Mi
       cpu: 25m
   ingresses:
-    - https://familie-tilbake.intern.dev.nav.no
+    - https://tilbakekreving.intern.dev.nav.no
   secureLogs:
     enabled: true
   env:

--- a/.deploy/nais/app-dev-gcp.yaml
+++ b/.deploy/nais/app-dev-gcp.yaml
@@ -35,7 +35,7 @@ spec:
     enabled: false
   gcp: # Database
     sqlInstances:
-      - type: POSTGRES_14
+      - type: POSTGRES_17
         tier: db-custom-1-3840
         name: tilbakekreving
         autoBackupHour: 3

--- a/.deploy/nais/app-dev-gcp.yaml
+++ b/.deploy/nais/app-dev-gcp.yaml
@@ -2,7 +2,7 @@ apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
   name: tilbakekreving-backend
-  namespace: teamfamilie
+  namespace: tilbake
   annotations:
     nais.io/run-as-group: "65532" # nonroot https://github.com/GoogleContainerTools/distroless/issues/443
     nais.io/run-as-user: "65532" # nonroot https://github.com/GoogleContainerTools/distroless/issues/443

--- a/.deploy/nais/kafka/hentfagsystemsbehandling_request_topic.yaml
+++ b/.deploy/nais/kafka/hentfagsystemsbehandling_request_topic.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.nais.io/v1
 kind: Topic
 metadata:
-  name: privat-tbk-hentfagsystemsbehandling-request
+  name: privat-tbk-hentfagsystemsbehandling
   namespace: tilbake
   labels:
     team: tilbake

--- a/.deploy/nais/kafka/hentfagsystemsbehandling_request_topic.yaml
+++ b/.deploy/nais/kafka/hentfagsystemsbehandling_request_topic.yaml
@@ -15,8 +15,8 @@ spec:
     retentionBytes: -1  # -1 means unlimited
     retentionHours: 72  # -1 means unlimited
   acl:
-    - team: teamfamilie
-      application: familie-tilbake #owner
+    - team: tilbake
+      application: tilbakekreving-backend #owner
       access: readwrite   # readwrite
     - team: teamfamilie
       application: familie-ba-sak #owner

--- a/.deploy/nais/kafka/hentfagsystemsbehandling_request_topic.yaml
+++ b/.deploy/nais/kafka/hentfagsystemsbehandling_request_topic.yaml
@@ -1,10 +1,10 @@
 apiVersion: kafka.nais.io/v1
 kind: Topic
 metadata:
-  name: privat-tbk-hentfagsystemsbehandling-request-topic
-  namespace: teamfamilie
+  name: privat-tbk-hentfagsystemsbehandling-request
+  namespace: tilbake
   labels:
-    team: teamfamilie
+    team: tilbake
 spec:
   pool: nav-dev
   config: # optional; all fields are optional too; defaults shown

--- a/.deploy/nais/kafka/hentfagsystemsbehandling_respons_topic.yaml
+++ b/.deploy/nais/kafka/hentfagsystemsbehandling_respons_topic.yaml
@@ -1,10 +1,10 @@
 apiVersion: kafka.nais.io/v1
 kind: Topic
 metadata:
-  name: privat-tbk-hentfagsystemsbehandling-respons-topic
-  namespace: teamfamilie
+  name: privat-tbk-hentfagsystemsbehandling-respons
+  namespace: tilbake
   labels:
-    team: teamfamilie
+    team: tilbake
 spec:
   pool: nav-dev
   config: # optional; all fields are optional too; defaults shown

--- a/.deploy/nais/kafka/hentfagsystemsbehandling_respons_topic.yaml
+++ b/.deploy/nais/kafka/hentfagsystemsbehandling_respons_topic.yaml
@@ -15,8 +15,8 @@ spec:
     retentionBytes: -1  # -1 means unlimited
     retentionHours: 72  # -1 means unlimited
   acl:
-    - team: teamfamilie
-      application: familie-tilbake #owner
+    - team: tilbake
+      application: tilbakekreving-backend #owner
       access: readwrite   # readwrite
     - team: teamfamilie
       application: familie-ba-sak #owner

--- a/.deploy/nais/kafka/hentfagsystemsbehandling_respons_topic.yaml
+++ b/.deploy/nais/kafka/hentfagsystemsbehandling_respons_topic.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.nais.io/v1
 kind: Topic
 metadata:
-  name: privat-tbk-hentfagsystemsbehandling-respons
+  name: privat-tbk-hentfagsystemsbehandling-svar
   namespace: tilbake
   labels:
     team: tilbake

--- a/.deploy/nais/unleash/unleash-apitoken-preprod.yaml
+++ b/.deploy/nais/unleash/unleash-apitoken-preprod.yaml
@@ -1,16 +1,16 @@
 apiVersion: unleash.nais.io/v1
 kind: ApiToken
 metadata:
-  name: familie-klage
-  namespace: teamfamilie
+  name: tilbakekreving-backend
+  namespace: tilbake
   labels:
-    team: teamfamilie
+    team: tilbake
 spec:
   unleashInstance:
     apiVersion: unleash.nais.io/v1
     kind: RemoteUnleash
-    name: teamfamilie
-  secretName: familie-tilbake-unleash-api-token
+    name: tilbake
+  secretName: tilbakekreving-backend-unleash-api-token
 
   # Specify which environment the API token should be created for.
   # Can be one of: development, or production.

--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: nais/docker-build-push@v0
         id: docker-push
         with:
-          team: teamfamilie
+          team: tilbake
           push_image: true
           tag: ${{ github.sha }}
           dockerfile: Dockerfile
@@ -72,7 +72,7 @@ jobs:
         with:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          team: teamfamilie
+          team: tilbake
       - name: Checkout e2e tests
         if: "!contains(github.event.head_commit.message, 'e2e skip')"
         uses: actions/checkout@v4
@@ -81,12 +81,9 @@ jobs:
           repository: navikt/familie-tilbake-e2e
           token: ${{ secrets.READER_TOKEN }}
           path: tilbake-e2e
-      - name: Setter riktig familie-tilbake versjon i e2e tester hvis e2e bruker ghcr.io(deprecated)
-        if: "!contains(github.event.head_commit.message, 'e2e skip')"
-        run: sed -i 's/ghcr.io\/navikt\/familie-tilbake:latest/europe-north1-docker.pkg.dev\/nais-management-233d\/teamfamilie\/familie-tilbake:${{ github.sha }}/g' tilbake-e2e/e2e/docker-compose.yml
       - name: Setter riktig familie-tilbake versjon i e2e tester
         if: "!contains(github.event.head_commit.message, 'e2e skip')"
-        run: sed -i 's/europe-north1-docker.pkg.dev\/nais-management-233d\/teamfamilie\/familie-tilbake:latest/europe-north1-docker.pkg.dev\/nais-management-233d\/teamfamilie\/familie-tilbake:${{ github.sha }}/g' tilbake-e2e/e2e/docker-compose.yml
+        run: sed -i 's/europe-north1-docker.pkg.dev\/nais-management-233d\/teamfamilie\/familie-tilbake:latest/europe-north1-docker.pkg.dev\/nais-management-233d\/tilbake\/familie-tilbake:${{ github.sha }}/g' tilbake-e2e/e2e/docker-compose.yml
       - name: Set up Java 21
         uses: actions/setup-java@v4
         with:
@@ -135,6 +132,9 @@ jobs:
 
   deploy-to-dev:
     name: Deploy til dev-gcp
+    permissions:
+      contents: "read"
+      id-token: "write"
     runs-on: ubuntu-latest
     needs: [ build-jar-docker, run-junit ]
     steps:
@@ -144,8 +144,8 @@ jobs:
       - name: Deploy til dev-gcp
         uses: nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/app-dev-gcp.yaml
           VAR: image=${{ needs.build-jar-docker.outputs.image }}
+          ENVIRONMENT: dev-gcp:tilbake
 

--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -91,27 +91,12 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Start alle apper (e2e)
-        env:
-          INTEGRASJONER_CLIENT_ID: ${{ secrets.INTEGRASJONER_CLIENT_ID }}
-          INTEGRASJONER_CLIENT_SECRET: ${{ secrets.INTEGRASJONER_CLIENT_SECRET }}
-          INTEGRASJONER_INFOTRYGD_KS_SCOPE: ${{ secrets.INTEGRASJONER_INFOTRYGD_KS_SCOPE }}
-          INTEGRASJONER_AAD_GRAPH_SCOPE: ${{ secrets.INTEGRASJONER_AAD_GRAPH_SCOPE }}
-          TILBAKE_CLIENT_ID: ${{ secrets.TILBAKE_CLIENT_ID }}
-          TILBAKE_CLIENT_SECRET: ${{ secrets.TILBAKE_CLIENT_SECRET }}
-          TILBAKE_FRONTEND_CLIENT_ID: ${{ secrets.TILBAKE_FRONTEND_CLIENT_ID }}
-          INTEGRASJONER_SCOPE: ${{ secrets.INTEGRASJONER_SCOPE }}
-          HISTORIKK_CLIENT_ID: ${{ secrets.HISTORIKK_CLIENT_ID }}
-          HISTORIKK_CLIENT_SECRET: ${{ secrets.HISTORIKK_CLIENT_SECRET }}
         if: "!contains(github.event.head_commit.message, 'e2e skip')"
         run: cd tilbake-e2e/e2e; ./e2e.sh
       - name: Kjør tester (e2e)
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TILBAKE_CLIENT_ID: ${{ secrets.TILBAKE_CLIENT_ID }}
-          TILBAKE_CLIENT_SECRET: ${{ secrets.TILBAKE_CLIENT_SECRET }}
-          HISTORIKK_CLIENT_ID: ${{ secrets.HISTORIKK_CLIENT_ID }}
-          HISTORIKK_CLIENT_SECRET: ${{ secrets.HISTORIKK_CLIENT_SECRET }}
         if: "!contains(github.event.head_commit.message, 'e2e skip')"
         run: cd tilbake-e2e/autotest; mvn -B --no-transfer-progress --settings .m2/maven-settings.xml -Dtest="**" test
       - name: Samle Docker-logs ved feil

--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   build-jar-docker:
-    if: github.event.pull_request.draft == false
+#    if: github.event.pull_request.draft == false
     name: Bygg app/image, push til github
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         id: docker-push
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         with:
-          team: teamfamilie
+          team: tilbake
           push_image: true
           tag: ${{ github.sha }}
           dockerfile: Dockerfile
@@ -99,7 +99,7 @@ jobs:
         with:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          team: teamfamilie
+          team: tilbake
       - name: Checkout e2e tests
         if: "!contains(github.event.head_commit.message, 'e2e skip')"
         uses: actions/checkout@v4
@@ -110,10 +110,10 @@ jobs:
           path: tilbake-e2e
       - name: Setter riktig familie-tilbake versjon i e2e tester hvis e2e bruker ghcr.io(deprecated)
         if: "!contains(github.event.head_commit.message, 'e2e skip')"
-        run: sed -i 's/ghcr.io\/navikt\/familie-tilbake:latest/europe-north1-docker.pkg.dev\/nais-management-233d\/teamfamilie\/familie-tilbake:${{ github.sha }}/g' tilbake-e2e/e2e/docker-compose.yml
+        run: sed -i 's/ghcr.io\/navikt\/familie-tilbake:latest/europe-north1-docker.pkg.dev\/nais-management-233d\/tilbake\/familie-tilbake:${{ github.sha }}/g' tilbake-e2e/e2e/docker-compose.yml
       - name: Setter riktig familie-tilbake versjon i e2e tester
         if: "!contains(github.event.head_commit.message, 'e2e skip')"
-        run: sed -i 's/europe-north1-docker.pkg.dev\/nais-management-233d\/teamfamilie\/familie-tilbake:latest/europe-north1-docker.pkg.dev\/nais-management-233d\/teamfamilie\/familie-tilbake:${{ github.sha }}/g' tilbake-e2e/e2e/docker-compose.yml
+        run: sed -i 's/europe-north1-docker.pkg.dev\/nais-management-233d\/tilbake\/familie-tilbake:latest/europe-north1-docker.pkg.dev\/nais-management-233d\/tilbake\/familie-tilbake:${{ github.sha }}/g' tilbake-e2e/e2e/docker-compose.yml
       - name: Set up Java 21
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,27 +121,12 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Start alle apper (e2e)
-        env:
-          INTEGRASJONER_CLIENT_ID: ${{ secrets.INTEGRASJONER_CLIENT_ID }}
-          INTEGRASJONER_CLIENT_SECRET: ${{ secrets.INTEGRASJONER_CLIENT_SECRET }}
-          INTEGRASJONER_INFOTRYGD_KS_SCOPE: ${{ secrets.INTEGRASJONER_INFOTRYGD_KS_SCOPE }}
-          INTEGRASJONER_AAD_GRAPH_SCOPE: ${{ secrets.INTEGRASJONER_AAD_GRAPH_SCOPE }}
-          TILBAKE_CLIENT_ID: ${{ secrets.TILBAKE_CLIENT_ID }}
-          TILBAKE_CLIENT_SECRET: ${{ secrets.TILBAKE_CLIENT_SECRET }}
-          TILBAKE_FRONTEND_CLIENT_ID: ${{ secrets.TILBAKE_FRONTEND_CLIENT_ID }}
-          INTEGRASJONER_SCOPE: ${{ secrets.INTEGRASJONER_SCOPE }}
-          HISTORIKK_CLIENT_ID: ${{ secrets.HISTORIKK_CLIENT_ID }}
-          HISTORIKK_CLIENT_SECRET: ${{ secrets.HISTORIKK_CLIENT_SECRET }}
         if: "!contains(github.event.head_commit.message, 'e2e skip')"
         run: cd tilbake-e2e/e2e; ./e2e.sh
       - name: Kjør tester (e2e)
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TILBAKE_CLIENT_ID: ${{ secrets.TILBAKE_CLIENT_ID }}
-          TILBAKE_CLIENT_SECRET: ${{ secrets.TILBAKE_CLIENT_SECRET }}
-          HISTORIKK_CLIENT_ID: ${{ secrets.HISTORIKK_CLIENT_ID }}
-          HISTORIKK_CLIENT_SECRET: ${{ secrets.HISTORIKK_CLIENT_SECRET }}
         if: "!contains(github.event.head_commit.message, 'e2e skip')"
         run: cd tilbake-e2e/autotest; mvn -B --no-transfer-progress --settings .m2/maven-settings.xml -Dtest="**" test
       - name: Samle Docker-logs ved feil

--- a/.github/workflows/deploy-kafka-manager.yml
+++ b/.github/workflows/deploy-kafka-manager.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,15 +39,15 @@ jobs:
       - name: Deploy hentfagsystemsbehandling_request_topic
         uses: nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/kafka/hentfagsystemsbehandling_request_topic.yaml
+          ENVIRONMENT: dev-gcp:tilbake
       - name: Deploy hentfagsystemsbehandling_respons_topic
         uses: nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/kafka/hentfagsystemsbehandling_respons_topic.yaml
+          ENVIRONMENT: dev-gcp:tilbake
       - name: Deploy dvh_sak_topic
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -60,12 +63,12 @@ jobs:
       - name: Deploy hentfagsystemsbehandling_request_topic
         uses: nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .deploy/nais/kafka/prod/hentfagsystemsbehandling_request_topic_prod.yaml
+          ENVIRONMENT: prod-gcp:tilbake
       - name: Deploy hentfagsystemsbehandling_respons_topic
         uses: nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .deploy/nais/kafka/prod/hentfagsystemsbehandling_respons_topic_prod.yaml
+          ENVIRONMENT: prod-gcp:tilbake

--- a/.github/workflows/deploy-unleash-api-token.yaml
+++ b/.github/workflows/deploy-unleash-api-token.yaml
@@ -6,15 +6,18 @@ on:
 jobs:
   deploy-dev:
     runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: deploy unleash api-token to dev
         uses: nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/unleash/unleash-apitoken-preprod.yaml
+          ENVIRONMENT: dev-gcp:tilbake
   deploy-prod:
     runs-on: ubuntu-latest
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,7 @@
             </activation>
             <build>
                 <plugins>
-                    <plugin>
+                    <!--<plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <executions>
@@ -437,7 +437,8 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
+
+                    </plugin>-->
                 </plugins>
             </build>
         </profile>
@@ -455,7 +456,7 @@
                     <artifactId>sonar-maven-plugin</artifactId>
                     <version>5.0.0.4389</version>
                 </plugin>
-                <plugin>
+                <!--<plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.12</version>
@@ -465,7 +466,7 @@
                             <exclude>**/config/OppdragMQConfig.kt</exclude>
                         </excludes>
                     </configuration>
-                </plugin>
+                </plugin>-->
             </plugins>
         </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,7 @@
             </activation>
             <build>
                 <plugins>
-                    <!--<plugin>
+                    <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <executions>
@@ -437,8 +437,7 @@
                                 </goals>
                             </execution>
                         </executions>
-
-                    </plugin>-->
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -456,7 +455,7 @@
                     <artifactId>sonar-maven-plugin</artifactId>
                     <version>5.0.0.4389</version>
                 </plugin>
-                <!--<plugin>
+                <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.12</version>
@@ -466,7 +465,7 @@
                             <exclude>**/config/OppdragMQConfig.kt</exclude>
                         </excludes>
                     </configuration>
-                </plugin>-->
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/src/main/kotlin/no/nav/familie/tilbake/config/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/KafkaConfig.kt
@@ -88,9 +88,8 @@ class KafkaConfig(
         )
 
     companion object {
-        const val HISTORIKK_TOPIC = "teamfamilie.privat-historikk-topic"
-        const val HENT_FAGSYSTEMSBEHANDLING_REQUEST_TOPIC = "teamfamilie.privat-tbk-hentfagsystemsbehandling-request-topic"
-        const val HENT_FAGSYSTEMSBEHANDLING_RESPONS_TOPIC = "teamfamilie.privat-tbk-hentfagsystemsbehandling-respons-topic"
+        const val HENT_FAGSYSTEMSBEHANDLING_REQUEST_TOPIC = "teamfamilie.privat-tbk-hentfagsystemsbehandling-request"
+        const val HENT_FAGSYSTEMSBEHANDLING_RESPONS_TOPIC = "teamfamilie.privat-tbk-hentfagsystemsbehandling-respons"
         const val SAK_TOPIC = "teamfamilie.aapen-tbk-datavarehus-sak-topic"
         const val VEDTAK_TOPIC = "teamfamilie.aapen-tbk-datavarehus-vedtak-topic"
     }

--- a/src/main/kotlin/no/nav/familie/tilbake/config/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/KafkaConfig.kt
@@ -88,8 +88,8 @@ class KafkaConfig(
         )
 
     companion object {
-        const val HENT_FAGSYSTEMSBEHANDLING_REQUEST_TOPIC = "teamfamilie.privat-tbk-hentfagsystemsbehandling-request"
-        const val HENT_FAGSYSTEMSBEHANDLING_RESPONS_TOPIC = "teamfamilie.privat-tbk-hentfagsystemsbehandling-respons"
+        const val HENT_FAGSYSTEMSBEHANDLING_REQUEST_TOPIC = "tilbake.privat-tbk-hentfagsystemsbehandling"
+        const val HENT_FAGSYSTEMSBEHANDLING_RESPONS_TOPIC = "tilbake.privat-tbk-hentfagsystemsbehandling-svar"
         const val SAK_TOPIC = "teamfamilie.aapen-tbk-datavarehus-sak-topic"
         const val VEDTAK_TOPIC = "teamfamilie.aapen-tbk-datavarehus-vedtak-topic"
     }

--- a/src/main/kotlin/no/nav/familie/tilbake/config/OppdragMQConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/OppdragMQConfig.kt
@@ -10,6 +10,7 @@ import org.messaginghub.pooled.jms.JmsPoolConnectionFactory
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.jms.DefaultJmsListenerContainerFactoryConfigurer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -24,6 +25,11 @@ private const val UTF_8_WITH_PUA = 1208
 
 @Configuration
 @Profile("!integrasjonstest & !e2e")
+@ConditionalOnProperty(
+    value = ["oppdrag.mq.enabled"],
+    havingValue = "true",
+    matchIfMissing = true
+)
 class OppdragMQConfig(
     @Value("\${oppdrag.mq.hostname}") val hostname: String,
     @Value("\${oppdrag.mq.queuemanager}") val queuemanager: String,

--- a/src/main/kotlin/no/nav/familie/tilbake/config/OppdragMQConfig.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/config/OppdragMQConfig.kt
@@ -28,7 +28,7 @@ private const val UTF_8_WITH_PUA = 1208
 @ConditionalOnProperty(
     value = ["oppdrag.mq.enabled"],
     havingValue = "true",
-    matchIfMissing = true
+    matchIfMissing = true,
 )
 class OppdragMQConfig(
     @Value("\${oppdrag.mq.hostname}") val hostname: String,

--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagMottaker.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagMottaker.kt
@@ -7,6 +7,7 @@ import no.nav.familie.tilbake.config.Constants
 import no.nav.familie.tilbake.kravgrunnlag.task.BehandleKravgrunnlagTask
 import no.nav.familie.tilbake.kravgrunnlag.task.BehandleStatusmeldingTask
 import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Profile
 import org.springframework.jms.annotation.JmsListener
 import org.springframework.stereotype.Service
@@ -16,6 +17,11 @@ import java.util.UUID
 
 @Service
 @Profile("!e2e & !integrasjonstest")
+@ConditionalOnProperty(
+    value = ["oppdrag.mq.enabled"],
+    havingValue = "true",
+    matchIfMissing = true
+)
 class KravgrunnlagMottaker(
     private val taskService: TaskService,
 ) {

--- a/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagMottaker.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/kravgrunnlag/KravgrunnlagMottaker.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 @ConditionalOnProperty(
     value = ["oppdrag.mq.enabled"],
     havingValue = "true",
-    matchIfMissing = true
+    matchIfMissing = true,
 )
 class KravgrunnlagMottaker(
     private val taskService: TaskService,

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -34,6 +34,7 @@ rolle:
 FAMILIE_INTEGRASJONER_URL: https://familie-integrasjoner.dev-fss-pub.nais.io
 FAMILIE_INTEGRASJONER_SCOPE: api://dev-fss.teamfamilie.familie-integrasjoner/.default
 FAMILIE_OPPDRAG_URL: https://familie-oppdrag.dev-fss-pub.nais.io
+FAMILIE_OPPDRAG_SCOPE: api://dev-fss.teamfamilie.familie-oppdrag/.default
 SECURITYTOKENSERVICE_URL: https://api-gw-q1.oera.no/security-token-service/SecurityTokenServiceProvider/
 
 PDL_URL: https://pdl-api.dev-fss-pub.nais.io

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,9 +1,7 @@
 
 spring:
   datasource:
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/familie-tilbake
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: ${DB_JDBC_URL}
 
 
 oppdrag.mq:

--- a/src/main/resources/application-e2e.yaml
+++ b/src/main/resources/application-e2e.yaml
@@ -5,10 +5,10 @@ no.nav.security.jwt:
   client:
     registration:
       familie-integrasjoner:
-        resource-url: ${FAMILIE_INTEGRASJONER_URL}
+        resource-url: ${FAMILIE_INTEGRASJONER_URL}n
         token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${FAMILIE_INTEGRASJONER_SCOPE}
+        scope: api://dev-fss.teamfamilie.familie-integrasjoner/.default
         authentication:
           client-id: ${TILBAKE_CLIENT_ID}
           client-secret: ${TILBAKE_CLIENT_SECRET}
@@ -17,7 +17,7 @@ no.nav.security.jwt:
         resource-url: ${FAMILIE_INTEGRASJONER_URL}
         token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
         grant-type: client_credentials
-        scope: ${FAMILIE_INTEGRASJONER_SCOPE}
+        scope: api://dev-fss.teamfamilie.familie-integrasjoner/.default
         authentication:
           client-id: ${TILBAKE_CLIENT_ID}
           client-secret: ${TILBAKE_CLIENT_SECRET}
@@ -44,7 +44,7 @@ no.nav.security.jwt:
         resource-url: ${FAMILIE_OPPDRAG_URL}
         token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${FAMILIE_OPPDRAG_SCOPE}
+        scope: api://dev-fss.teamfamilie.familie-oppdrag/.default
         authentication:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
@@ -53,7 +53,7 @@ no.nav.security.jwt:
         resource-url: ${FAMILIE_OPPDRAG_URL}
         token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
         grant-type: client_credentials
-        scope: ${FAMILIE_OPPDRAG_SCOPE}
+        scope: api://dev-fss.teamfamilie.familie-oppdrag/.default
         authentication:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}

--- a/src/main/resources/application-fagsak_e2e.yaml
+++ b/src/main/resources/application-fagsak_e2e.yaml
@@ -9,7 +9,7 @@ no.nav.security.jwt:
         resource-url: ${FAMILIE_INTEGRASJONER_URL}
         token-endpoint-url: http://mock-oauth2-server:1111/v2.0/token
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${FAMILIE_INTEGRASJONER_SCOPE}
+        scope: api://dev-fss.teamfamilie.familie-integrasjoner/.default
         authentication:
           client-id: ${TILBAKE_CLIENT_ID}
           client-secret: ${TILBAKE_CLIENT_SECRET}
@@ -18,7 +18,7 @@ no.nav.security.jwt:
         resource-url: ${FAMILIE_INTEGRASJONER_URL}
         token-endpoint-url: http://mock-oauth2-server:1111/v2.0/token
         grant-type: client_credentials
-        scope: ${FAMILIE_INTEGRASJONER_SCOPE}
+        scope: api://dev-fss.teamfamilie.familie-integrasjoner/.default
         authentication:
           client-id: ${TILBAKE_CLIENT_ID}
           client-secret: ${TILBAKE_CLIENT_SECRET}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -11,7 +11,7 @@ oppdrag.mq:
   channel: P_FAMILIE_TILBAKE
   hostname: mpls02.adeo.no
   port: 1414
-  enabled: false
+  enabled: ${OPPDRAG_MQ_ENABLED:true}
 
 rolle:
   barnetrygd:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -39,7 +39,9 @@ PDL_URL: https://pdl-api.prod-fss-pub.nais.io
 PDL_SCOPE: api://prod-fss.pdl.pdl-api/.default
 
 FAMILIE_INTEGRASJONER_URL: https://familie-integrasjoner.prod-fss-pub.nais.io
+FAMILIE_INTEGRASJONER_SCOPE: api://prod-fss.teamfamilie.familie-integrasjoner/.default
 FAMILIE_OPPDRAG_URL: https://familie-oppdrag.prod-fss-pub.nais.io
+FAMILIE_OPPDRAG_SCOPE: api://prod-fss.teamfamilie.familie-oppdrag/.default
 CRON_HÅNDTER_GAMMEL_KRAVGRUNNLAG: 0 0 7 ? * MON-FRI
 AUTHORIZATION_URL: https://login.microsoftonline.com/navno.onmicrosoft.com/oauth2/v2.0/authorize
 TOKEN_URL: https://login.microsoftonline.com/navno.onmicrosoft.com/oauth2/v2.0/token

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,8 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/familie-tilbake
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: ${DB_JDBC_URL}
   flyway:
     placeholders:
       ignoreIfProd: --

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/RyddBehandlingUtenKravgrunnlagTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/RyddBehandlingUtenKravgrunnlagTaskTest.kt
@@ -3,6 +3,9 @@ package no.nav.familie.tilbake.behandling.batch
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockkObject
 import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
@@ -11,12 +14,18 @@ import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.BehandlingService
 import no.nav.familie.tilbake.behandling.FagsakRepository
 import no.nav.familie.tilbake.behandling.domain.Behandlingsstatus
+import no.nav.familie.tilbake.common.ContextService
 import no.nav.familie.tilbake.common.fagsystem
 import no.nav.familie.tilbake.config.PropertyName
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.dokumentbestilling.felles.BrevsporingRepository
 import no.nav.familie.tilbake.oppgave.LagOppgaveTask
+import no.nav.familie.tilbake.sikkerhet.Behandlerrolle
+import no.nav.familie.tilbake.sikkerhet.InnloggetBrukertilgang
+import no.nav.familie.tilbake.sikkerhet.Tilgangskontrollsfagsystem
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.util.Properties
@@ -40,6 +49,18 @@ internal class RyddBehandlingUtenKravgrunnlagTaskTest : OppslagSpringRunnerTest(
 
     @Autowired
     private lateinit var taskService: TaskService
+
+    @BeforeEach
+    fun init() {
+        mockkObject(ContextService)
+        every { ContextService.hentSaksbehandler() }.returns("Z0000")
+        every { ContextService.hentHøyesteRolletilgangOgYtelsestypeForInnloggetBruker(any(), any()) }.returns(InnloggetBrukertilgang(mapOf(Tilgangskontrollsfagsystem.SYSTEM_TILGANG to Behandlerrolle.SYSTEM)))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearMocks(ContextService)
+    }
 
     @Test
     fun `skal hennlegge behandling uten kravgrunnlag som har sendt brev`() {


### PR DESCRIPTION
* [x] Lage nye topics for å hente ny info fra fagsystem
    * Ved å bruke nye topics kan vi kjøre opp applikasjonen før vi gjør en eventuelt switchover. Det gjør at vi ikke ender opp med samme staten i ny og gammel instanse.
* [x] Flytte over toggles fra unleash
* [x] Bytte til ny unleash
    * Vi burde kunne bytte unleash instanse før vi deployer til nytt namespace
* [x] Endre tilgangskontroll i familie-oppdrag så vi kan kalle APIene
    * La tilgangen gjelde begge namespaces til vi vet at vi kan flytte over all trafikk
* [x] Endre tilgangskontroll i integrasjoner så vi kan kalle APIene
    * La tilgangen gjelde begge namespaces til vi vet at vi kan flytte over all trafikk
* [x] Endre tilgangskontroll i PDL så vi kan kalle APIene
* [x] Gjøre det mulig å kjøre applikasjonen uten MQ i produksjon
    * Ved å innføre en ny profil i spring appen kan vi slå av MQ integrasjonen før vi deployer til produksjon i nytt namespace. Det gjør at vi unngår at den nye instansen tar over kravgrunnlag som skulle bli lest av instansen i familie-namespacet.
* [ ] Endre namespace i prod Kubernetes manifester
* [x] Endre namespace i dev Kubernetes manifester
* [x] Flytt over secrets for prod
* [ ] Bytte til midlertidig ingress i produksjon
    * Gir oss muligheten til å kjøre opp applikasjonen i produksjon uten å ta over trafikken fra saksbehandlerne
* [ ] Opprette ny database(endre navn i nais kubernetes manifest)
  * [x] Dev
  * [ ] Prod
* [ ] Oppdatere bygg pipelines til å peke mot nytt NAIS team
  * [x] Dev
  * [ ] Prod
* [ ] Migrere data til ny postgres instanse
    * Dobbelsjekk at vi ikke kommer til å ha noen problemer med automatiske genererte primary keys
