### PR TITLE
filtrer oppgavetyper ved sjekk på flere oppgaver

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
@@ -18,16 +18,11 @@ import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
 import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.behandling.domain.Fagsak
-import no.nav.familie.tilbake.behandlingskontroll.BehandlingsstegstilstandRepository
-import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg.FATTE_VEDTAK
-import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg.FORESLÅ_VEDTAK
-import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.common.exceptionhandler.ManglerOppgaveFeil
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.integration.familie.IntegrasjonerClient
 import no.nav.familie.tilbake.person.PersonService
-import no.nav.familie.tilbake.totrinn.TotrinnService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.core.env.Environment
@@ -46,8 +41,6 @@ class OppgaveService(
     private val personService: PersonService,
     private val taskService: TaskService,
     private val environment: Environment,
-    private val behandlingsstegstilstandRepository: BehandlingsstegstilstandRepository,
-    private val totrinnService: TotrinnService,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
     private val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
@@ -250,27 +243,6 @@ class OppgaveService(
                     Oppgavetype.BehandleUnderkjentVedtak.value,
                 )
         }
-
-    fun utledOppgavetypeForGjenoppretting(behandlingId: UUID): Oppgavetype {
-        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
-        val behandlingsstegstilstand =
-            behandlingsstegstilstandRepository
-                .findByBehandlingIdAndBehandlingsstegsstatusIn(behandling.id, Behandlingsstegstatus.aktiveStegStatuser)
-                ?: throw Feil("Prøvde å gjenopprette oppgave på en inaktiv behandling (id=${behandling.id})")
-
-        return when (behandlingsstegstilstand.behandlingssteg) {
-            FORESLÅ_VEDTAK -> {
-                if (totrinnService.finnesUnderkjenteStegITotrinnsvurdering(behandlingId)) {
-                    Oppgavetype.BehandleUnderkjentVedtak
-                } else {
-                    Oppgavetype.BehandleSak
-                }
-            }
-
-            FATTE_VEDTAK -> Oppgavetype.GodkjenneVedtak
-            else -> Oppgavetype.BehandleSak
-        }
-    }
 
     fun finnOppgave(
         behandling: Behandling,

--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
@@ -216,7 +216,7 @@ class OppgaveService(
         val fagsak = fagsakRepository.findByIdOrThrow(behandling.fagsakId)
         val (finnOppgaveRequest, finnOppgaveResponse) = finnOppgave(behandling, oppgavetype, fagsak)
 
-        val tilbakekrevingsOppgaver = finnOppgaveResponse.oppgaver.filtrerTilbakekrevringsOppgave()
+        val tilbakekrevingsOppgaver = finnOppgaveResponse.oppgaver.filtrerTilbakekrevingsOppgave()
 
         when {
             tilbakekrevingsOppgaver.size > 1 -> {
@@ -241,13 +241,13 @@ class OppgaveService(
         }
     }
 
-    private fun List<Oppgave>.filtrerTilbakekrevringsOppgave(): List<Oppgave> =
+    private fun List<Oppgave>.filtrerTilbakekrevingsOppgave(): List<Oppgave> =
         this.filter {
             it.oppgavetype in
                 listOf(
-                    Oppgavetype.BehandleSak.name,
-                    Oppgavetype.GodkjenneVedtak.name,
-                    Oppgavetype.BehandleUnderkjentVedtak.name,
+                    Oppgavetype.BehandleSak.value,
+                    Oppgavetype.GodkjenneVedtak.value,
+                    Oppgavetype.BehandleUnderkjentVedtak.value,
                 )
         }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppgaveServiceTest.kt
@@ -69,8 +69,6 @@ class OppgaveServiceTest {
                 personService,
                 taskService,
                 environment,
-                behandlingsstegstilstandRepository,
-                totrinnService,
             )
         every { fagsakRepository.findByIdOrThrow(fagsak.id) } returns fagsak
         every { behandlingRepository.findByIdOrThrow(behandling.id) } returns behandling

--- a/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppgaveServiceTest.kt
@@ -18,14 +18,12 @@ import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.tilbake.behandling.BehandlingRepository
 import no.nav.familie.tilbake.behandling.FagsakRepository
 import no.nav.familie.tilbake.behandling.domain.Behandling
-import no.nav.familie.tilbake.behandlingskontroll.BehandlingsstegstilstandRepository
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.data.Testdata
 import no.nav.familie.tilbake.data.Testdata.fagsak
 import no.nav.familie.tilbake.integration.familie.IntegrasjonerClient
 import no.nav.familie.tilbake.person.PersonService
-import no.nav.familie.tilbake.totrinn.TotrinnService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -41,8 +39,8 @@ class OppgaveServiceTest {
     private val personService: PersonService = mockk(relaxed = true)
     private val environment: Environment = mockk(relaxed = true)
     private val taskService: TaskService = mockk(relaxed = true)
-    private val behandlingsstegstilstandRepository: BehandlingsstegstilstandRepository = mockk(relaxed = true)
-    private val totrinnService: TotrinnService = mockk(relaxed = true)
+    // private val behandlingsstegstilstandRepository: BehandlingsstegstilstandRepository = mockk(relaxed = true)
+    // private val totrinnService: TotrinnService = mockk(relaxed = true)
 
     private val mappeIdGodkjenneVedtak = 100
     private val mappeIdBehandleSak = 200
@@ -248,40 +246,43 @@ class OppgaveServiceTest {
         }
     }
 
-    @Test
-    fun `ferdigstillOppgave skal ikke ferdigstille hvis det er mer enn én oppgave`() {
-        // Arrange
-        every { behandlingRepository.findByIdOrThrow(any()) } returns behandling
-        every { fagsakRepository.findByIdOrThrow(any()) } returns fagsak
-        every { integrasjonerClient.finnOppgaver(any()) } returns
-            FinnOppgaveResponseDto(
-                2L,
-                listOf(
-                    Oppgave(oppgavetype = Oppgavetype.GodkjenneVedtak.name),
-                    Oppgave(oppgavetype = Oppgavetype.BehandleUnderkjentVedtak.name),
-                ),
-            )
-        // Act & Assert
-        assertThrows<Feil> { oppgaveService.ferdigstillOppgave(behandling.id, Oppgavetype.GodkjenneVedtak) }
-    }
+    @Nested
+    inner class FerdigstillOppgave {
+        @Test
+        fun `ferdigstillOppgave skal ikke ferdigstille hvis det er mer enn én oppgave`() {
+            // Arrange
+            every { behandlingRepository.findByIdOrThrow(any()) } returns behandling
+            every { fagsakRepository.findByIdOrThrow(any()) } returns fagsak
+            every { integrasjonerClient.finnOppgaver(any()) } returns
+                FinnOppgaveResponseDto(
+                    2L,
+                    listOf(
+                        Oppgave(oppgavetype = Oppgavetype.GodkjenneVedtak.value),
+                        Oppgave(oppgavetype = Oppgavetype.BehandleUnderkjentVedtak.value),
+                    ),
+                )
+            // Act & Assert
+            assertThrows<Feil> { oppgaveService.ferdigstillOppgave(behandling.id, Oppgavetype.GodkjenneVedtak) }
+        }
 
-    @Test
-    fun `ferdigstillOppgave skal ferdigstille hvis det ikke er mer enn én oppgave av familie tilbake sine oppgavetyper`() {
-        // Arrange
-        every { behandlingRepository.findByIdOrThrow(any()) } returns behandling
-        every { fagsakRepository.findByIdOrThrow(any()) } returns fagsak
-        every { integrasjonerClient.finnOppgaver(any()) } returns
-            FinnOppgaveResponseDto(
-                2L,
-                listOf(
-                    Oppgave(oppgavetype = Oppgavetype.GodkjenneVedtak.name, id = 1L),
-                    Oppgave(oppgavetype = "randomUkjentOppgavetype", id = 2L),
-                ),
-            )
-        // Act
-        oppgaveService.ferdigstillOppgave(behandling.id, Oppgavetype.GodkjenneVedtak)
+        @Test
+        fun `ferdigstillOppgave skal ferdigstille hvis det ikke er mer enn én oppgave av familie tilbake sine oppgavetyper`() {
+            // Arrange
+            every { behandlingRepository.findByIdOrThrow(any()) } returns behandling
+            every { fagsakRepository.findByIdOrThrow(any()) } returns fagsak
+            every { integrasjonerClient.finnOppgaver(any()) } returns
+                FinnOppgaveResponseDto(
+                    2L,
+                    listOf(
+                        Oppgave(oppgavetype = Oppgavetype.GodkjenneVedtak.value, id = 1L),
+                        Oppgave(oppgavetype = "randomUkjentOppgavetype", id = 2L),
+                    ),
+                )
+            // Act
+            oppgaveService.ferdigstillOppgave(behandling.id, Oppgavetype.GodkjenneVedtak)
 
-        // Assert
-        verify(exactly = 1) { integrasjonerClient.ferdigstillOppgave(any()) }
+            // Assert
+            verify(exactly = 1) { integrasjonerClient.ferdigstillOppgave(any()) }
+        }
     }
 }


### PR DESCRIPTION
Kun sjekk på oppgaver fra familie-tilbake når vi sjekker om det er flere oppgaver i ferdigstillOppgaveTask

Vi har tasker som feiler i familie-prosessering fordi vi har flere oppgaver åpne samtidig. Trenger kun å filtrere når oppgaven er en av BehandleSak, GodkjenneVedtak eller BehandleUnderkjentVedtak. 

Task som feiler: https://familie-prosessering.intern.nav.no/service/familie-tilbake/task/2381379

Legger til filtrering på dette