### PR TITLE
Del 1 av Forslag til løsning på problem lagHistorikkInnslag

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Fattevedtakssteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Fattevedtakssteg.kt
@@ -9,6 +9,7 @@ import no.nav.familie.tilbake.behandlingskontroll.BehandlingskontrollService
 import no.nav.familie.tilbake.behandlingskontroll.Behandlingsstegsinfo
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingssteg
 import no.nav.familie.tilbake.behandlingskontroll.domain.Behandlingsstegstatus
+import no.nav.familie.tilbake.common.ContextService
 import no.nav.familie.tilbake.common.exceptionhandler.Feil
 import no.nav.familie.tilbake.common.repository.findByIdOrThrow
 import no.nav.familie.tilbake.dokumentbestilling.manuell.brevmottaker.BrevmottakerAdresseValidering
@@ -83,7 +84,7 @@ class Fattevedtakssteg(
                 behandlingId,
                 TilbakekrevingHistorikkinnslagstype.BEHANDLING_SENDT_TILBAKE_TIL_SAKSBEHANDLER,
                 Aktør.BESLUTTER,
-                beslutter = behandling.ansvarligBeslutter,
+                beslutter = ContextService.hentPåloggetSaksbehandler(null, logContext),
             )
             totrinnService.fjernAnsvarligBeslutter(behandlingId)
             oppgaveTaskService.opprettOppgaveTask(

--- a/src/main/kotlin/no/nav/familie/tilbake/historikkinnslag/HistorikkService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/historikkinnslag/HistorikkService.kt
@@ -99,9 +99,9 @@ class HistorikkService(
             Aktør.VEDTAKSLØSNING -> Constants.BRUKER_ID_VEDTAKSLØSNINGEN
             Aktør.SAKSBEHANDLER -> behandling.ansvarligSaksbehandler
             Aktør.BESLUTTER ->
-                behandling.ansvarligBeslutter
-                    ?: beslutter
-                    ?: error("Beslutter mangler ident for behandling: ${behandling.id}")
+                beslutter
+                    ?: behandling.ansvarligBeslutter
+                    ?: error("Behandling: ${behandling.id} mangler ansvarlig beslutter")
         }
 
     private fun hentBrevdata(


### PR DESCRIPTION
Del 1 av Forslag til løsning på problem lagHistorikkInnslag
Del 2 bør fjerne bruk av  behandling.ansvarligBeslutter i hentAktørIdent (HistorikkService) da dette kan sette feil beslutter på gammelt historikkinnslag