### PR TITLE
Fikser opp i tester så datoer henger sammen med vurderinger

### DIFF
--- a/kontrakter-intern/src/main/kotlin/no/nav/tilbakekreving/kontrakter/periode/Månedsperiode.kt
+++ b/kontrakter-intern/src/main/kotlin/no/nav/tilbakekreving/kontrakter/periode/Månedsperiode.kt
@@ -31,4 +31,8 @@ data class Månedsperiode(
     override fun lengdeIHeleMåneder(): Long = (tom.year * 12 + tom.monthValue) - (fom.year * 12 + fom.monthValue) + 1L
 
     fun toDatoperiode() = Datoperiode(fomDato, tomDato)
+
+    companion object {
+        infix fun YearMonth.til(tom: YearMonth) = Månedsperiode(this, tom)
+    }
 }

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingBatchTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingBatchTest.kt
@@ -94,7 +94,7 @@ internal class AutomatiskSaksbehandlingBatchTest : OppslagSpringRunnerTest() {
                     kontrollfelt = "2019-11-22-19.09.31.458065",
                     perioder =
                         setOf(
-                            Testdata.getKravgrunnlagsperiode432().copy(
+                            Testdata.lagKravgrunnlagsperiode().copy(
                                 beløp =
                                     setOf(
                                         feilKravgrunnlagBeløp,
@@ -211,7 +211,7 @@ internal class AutomatiskSaksbehandlingBatchTest : OppslagSpringRunnerTest() {
         kravgrunnlagRepository.update(
             kravgrunnlagRepository
                 .findByBehandlingIdAndAktivIsTrue(behandling.id)
-                .copy(perioder = setOf(Testdata.getKravgrunnlagsperiode432())),
+                .copy(perioder = setOf(Testdata.lagKravgrunnlagsperiode())),
         )
 
         automatiskSaksbehandlingBatch.behandleAutomatisk()

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/batch/AutomatiskSaksbehandlingTaskTest.kt
@@ -118,22 +118,17 @@ internal class AutomatiskSaksbehandlingTaskTest : OppslagSpringRunnerTest() {
                 tilbakekrevesBeløp = BigDecimal("100"),
             )
 
-        val kravgrunnlag =
-            Testdata
-                .lagKravgrunnlag(behandling.id)
-                .copy(
-                    kontrollfelt = "2019-11-22-19.09.31.458065",
-                    perioder =
-                        setOf(
-                            Testdata.getKravgrunnlagsperiode432().copy(
-                                beløp =
-                                    setOf(
-                                        feilKravgrunnlagBeløp,
-                                        ytelKravgrunnlagsbeløp433,
-                                    ),
-                            ),
-                        ),
-                )
+        val kravgrunnlag = Testdata.lagKravgrunnlag(behandling.id).copy(
+            kontrollfelt = "2019-11-22-19.09.31.458065",
+            perioder = setOf(
+                Testdata.lagKravgrunnlagsperiode().copy(
+                    beløp = setOf(
+                        feilKravgrunnlagBeløp,
+                        ytelKravgrunnlagsbeløp433,
+                    ),
+                ),
+            ),
+        )
 
         kravgrunnlagRepository.insert(kravgrunnlag)
         behandlingsstegstilstandRepository.insert(

--- a/src/test/kotlin/no/nav/familie/tilbake/behandling/steg/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/behandling/steg/StegServiceTest.kt
@@ -54,6 +54,8 @@ import no.nav.tilbakekreving.api.v1.dto.GodTroDto
 import no.nav.tilbakekreving.api.v1.dto.PeriodeMedTekstDto
 import no.nav.tilbakekreving.api.v1.dto.VergeDto
 import no.nav.tilbakekreving.api.v1.dto.VilkårsvurderingsperiodeDto
+import no.nav.tilbakekreving.februar
+import no.nav.tilbakekreving.januar
 import no.nav.tilbakekreving.kontrakter.Regelverk
 import no.nav.tilbakekreving.kontrakter.behandling.Behandlingsresultatstype
 import no.nav.tilbakekreving.kontrakter.behandling.Behandlingsstatus
@@ -65,6 +67,7 @@ import no.nav.tilbakekreving.kontrakter.faktaomfeilutbetaling.Hendelsesundertype
 import no.nav.tilbakekreving.kontrakter.foreldelse.Foreldelsesvurderingstype
 import no.nav.tilbakekreving.kontrakter.periode.Datoperiode
 import no.nav.tilbakekreving.kontrakter.periode.Månedsperiode
+import no.nav.tilbakekreving.kontrakter.periode.Månedsperiode.Companion.til
 import no.nav.tilbakekreving.kontrakter.verge.Vergetype
 import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.Vilkårsvurderingsresultat
 import org.junit.jupiter.api.AfterEach
@@ -74,7 +77,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.Pageable
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.time.YearMonth
 import java.util.UUID
 
 internal class StegServiceTest : OppslagSpringRunnerTest() {
@@ -122,8 +124,8 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
     private lateinit var fagsak: Fagsak
     private lateinit var behandling: Behandling
 
-    private val fom = YearMonth.now().minusMonths(1).atDay(1)
-    private val tom = YearMonth.now().atEndOfMonth()
+    private val fom = 1.januar(2023)
+    private val tom = 31.januar(2023)
 
     @BeforeEach
     fun init() {
@@ -399,38 +401,18 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.UTFØRT)
         lagBehandlingsstegstilstand(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.KLAR)
 
-        val førstePeriode =
-            Testdata
-                .getKravgrunnlagsperiode432()
-                .copy(
-                    id = UUID.randomUUID(),
-                    periode =
-                        Månedsperiode(
-                            fom = LocalDate.of(2018, 1, 1),
-                            tom = LocalDate.of(2018, 1, 31),
-                        ),
-                    beløp =
-                        setOf(
-                            Testdata.feilKravgrunnlagsbeløp433.copy(id = UUID.randomUUID()),
-                            Testdata.ytelKravgrunnlagsbeløp433.copy(id = UUID.randomUUID()),
-                        ),
-                )
-        val andrePeriode =
-            Testdata
-                .getKravgrunnlagsperiode432()
-                .copy(
-                    id = UUID.randomUUID(),
-                    periode =
-                        Månedsperiode(
-                            fom = LocalDate.of(2018, 2, 1),
-                            tom = LocalDate.of(2018, 2, 28),
-                        ),
-                    beløp =
-                        setOf(
-                            Testdata.feilKravgrunnlagsbeløp433.copy(id = UUID.randomUUID()),
-                            Testdata.ytelKravgrunnlagsbeløp433.copy(id = UUID.randomUUID()),
-                        ),
-                )
+        val førstePeriode = Testdata.lagKravgrunnlagsperiode(februar() til februar()).copy(
+            beløp = setOf(
+                Testdata.feilKravgrunnlagsbeløp433.copy(id = UUID.randomUUID()),
+                Testdata.ytelKravgrunnlagsbeløp433.copy(id = UUID.randomUUID()),
+            ),
+        )
+        val andrePeriode = Testdata.lagKravgrunnlagsperiode(februar() til februar()).copy(
+            beløp = setOf(
+                Testdata.feilKravgrunnlagsbeløp433.copy(id = UUID.randomUUID()),
+                Testdata.ytelKravgrunnlagsbeløp433.copy(id = UUID.randomUUID()),
+            ),
+        )
 
         val kravgrunnlag431 = Testdata.lagKravgrunnlag(behandling.id).copy(perioder = setOf(førstePeriode, andrePeriode))
         kravgrunnlagRepository.insert(kravgrunnlag431)
@@ -470,7 +452,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
         val tom = LocalDate.of(2010, 1, 31)
 
         lagBehandlingsstegstilstand(Behandlingssteg.FAKTA, Behandlingsstegstatus.KLAR)
-        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id, setOf(lagKravgrunnlagsperiode(fom, tom))))
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id, setOf(lagKravgrunnlagsperiode(januar(2010) til januar(2010)))))
         stegService.håndterSteg(behandling.id, lagBehandlingsstegFaktaDto(fom, tom), SecureLog.Context.tom())
 
         // foreldelsesteg vurderte som IKKE_FORELDET med første omgang

--- a/src/test/kotlin/no/nav/familie/tilbake/beregning/TilbakekrevingsberegningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/beregning/TilbakekrevingsberegningServiceTest.kt
@@ -25,10 +25,13 @@ import no.nav.familie.tilbake.vilkårsvurdering.domain.VilkårsvurderingAktsomhe
 import no.nav.familie.tilbake.vilkårsvurdering.domain.Vilkårsvurderingsperiode
 import no.nav.tilbakekreving.beregning.modell.Beregningsresultat
 import no.nav.tilbakekreving.beregning.modell.Beregningsresultatsperiode
+import no.nav.tilbakekreving.februar
+import no.nav.tilbakekreving.januar
 import no.nav.tilbakekreving.kontrakter.beregning.Vedtaksresultat
 import no.nav.tilbakekreving.kontrakter.foreldelse.Foreldelsesvurderingstype
 import no.nav.tilbakekreving.kontrakter.periode.Datoperiode
 import no.nav.tilbakekreving.kontrakter.periode.Månedsperiode
+import no.nav.tilbakekreving.kontrakter.periode.Månedsperiode.Companion.til
 import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.Aktsomhet
 import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.AnnenVurdering
 import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.Vilkårsvurderingsresultat
@@ -37,7 +40,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.time.YearMonth
 import java.util.UUID
 
 class TilbakekrevingsberegningServiceTest : OppslagSpringRunnerTest() {
@@ -303,29 +305,18 @@ class TilbakekrevingsberegningServiceTest : OppslagSpringRunnerTest() {
         val kravgrunnlag431 = Testdata.lagKravgrunnlag(behandling.id)
         val feilkravgrunnlagsbeløp = Testdata.feilKravgrunnlagsbeløp433
         val yteseskravgrunnlagsbeløp = Testdata.ytelKravgrunnlagsbeløp433
-        val førsteKravgrunnlagsperiode =
-            Testdata
-                .getKravgrunnlagsperiode432()
-                .copy(
-                    periode = Månedsperiode(YearMonth.of(2017, 1), YearMonth.of(2017, 1)),
-                    beløp =
-                        setOf(
-                            feilkravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
-                            yteseskravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
-                        ),
-                )
-        val andreKravgrunnlagsperiode =
-            Testdata
-                .getKravgrunnlagsperiode432()
-                .copy(
-                    id = UUID.randomUUID(),
-                    periode = Månedsperiode(YearMonth.of(2017, 2), YearMonth.of(2017, 2)),
-                    beløp =
-                        setOf(
-                            feilkravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
-                            yteseskravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
-                        ),
-                )
+        val førsteKravgrunnlagsperiode = Testdata.lagKravgrunnlagsperiode(januar(2017) til januar(2017)).copy(
+            beløp = setOf(
+                feilkravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
+                yteseskravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
+            ),
+        )
+        val andreKravgrunnlagsperiode = Testdata.lagKravgrunnlagsperiode(februar(2017) til februar(2017)).copy(
+            beløp = setOf(
+                feilkravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
+                yteseskravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
+            ),
+        )
         kravgrunnlagRepository.insert(
             kravgrunnlag431.copy(
                 perioder =
@@ -490,14 +481,11 @@ class TilbakekrevingsberegningServiceTest : OppslagSpringRunnerTest() {
         skattProsent: BigDecimal,
     ) {
         val p =
-            Testdata.getKravgrunnlagsperiode432().copy(
-                id = UUID.randomUUID(),
-                periode = periode,
-                beløp =
-                    setOf(
-                        lagFeilBeløp(BigDecimal.valueOf(10000)),
-                        lagYtelBeløp(BigDecimal.valueOf(10000), skattProsent),
-                    ),
+            Testdata.lagKravgrunnlagsperiode(periode).copy(
+                beløp = setOf(
+                    lagFeilBeløp(BigDecimal.valueOf(10000)),
+                    lagYtelBeløp(BigDecimal.valueOf(10000), skattProsent),
+                ),
             )
         val grunnlag: Kravgrunnlag431 = Testdata.lagKravgrunnlag(behandling.id).copy(perioder = setOf(p))
         kravgrunnlagRepository.insert(grunnlag)

--- a/src/test/kotlin/no/nav/familie/tilbake/data/Testdata.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/data/Testdata.kt
@@ -42,6 +42,7 @@ import no.nav.familie.tilbake.vilkårsvurdering.domain.VilkårsvurderingAktsomhe
 import no.nav.familie.tilbake.vilkårsvurdering.domain.VilkårsvurderingGodTro
 import no.nav.familie.tilbake.vilkårsvurdering.domain.VilkårsvurderingSærligGrunn
 import no.nav.familie.tilbake.vilkårsvurdering.domain.Vilkårsvurderingsperiode
+import no.nav.tilbakekreving.januar
 import no.nav.tilbakekreving.kontrakter.Tilbakekrevingsvalg
 import no.nav.tilbakekreving.kontrakter.behandling.Behandlingsstatus
 import no.nav.tilbakekreving.kontrakter.behandling.Behandlingstype
@@ -52,6 +53,7 @@ import no.nav.tilbakekreving.kontrakter.faktaomfeilutbetaling.Hendelsestype
 import no.nav.tilbakekreving.kontrakter.faktaomfeilutbetaling.Hendelsesundertype
 import no.nav.tilbakekreving.kontrakter.foreldelse.Foreldelsesvurderingstype
 import no.nav.tilbakekreving.kontrakter.periode.Månedsperiode
+import no.nav.tilbakekreving.kontrakter.periode.Månedsperiode.Companion.til
 import no.nav.tilbakekreving.kontrakter.verge.Vergetype
 import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.Aktsomhet
 import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.SærligGrunn
@@ -61,7 +63,6 @@ import no.nav.tilbakekreving.kontrakter.ytelse.Ytelsestype
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.time.LocalDate
-import java.time.YearMonth
 import java.util.UUID
 
 object Testdata {
@@ -261,44 +262,22 @@ object Testdata {
             skatteprosent = BigDecimal("35.1100"),
         )
 
-    fun getKravgrunnlagsperiode432() =
-        Kravgrunnlagsperiode432(
-            periode =
-                Månedsperiode(
-                    YearMonth.now().minusMonths(1),
-                    YearMonth.now(),
-                ),
-            beløp =
-                setOf(
-                    lagFeilKravgrunnlagsbeløp(),
-                    lagYtelKravgrunnlagsbeløp(),
-                ),
-            månedligSkattebeløp = BigDecimal("123.11"),
-        )
-
     fun lagKravgrunnlagsperiode(
-        fom: LocalDate,
-        tom: LocalDate,
+        periode: Månedsperiode = januar(2023) til januar(2023),
         klassekode: Klassekode = Klassekode.KL_KODE_FEIL_BA,
         beløp: Int = 10000,
-    ): Kravgrunnlagsperiode432 =
-        Kravgrunnlagsperiode432(
-            periode =
-                Månedsperiode(
-                    fom,
-                    tom,
-                ),
-            beløp =
-                setOf(
-                    lagFeilKravgrunnlagsbeløp(klassekode, beløp.toBigDecimal()),
-                    lagYtelKravgrunnlagsbeløp(klassekode),
-                ),
-            månedligSkattebeløp = BigDecimal("123.11"),
-        )
+    ): Kravgrunnlagsperiode432 = Kravgrunnlagsperiode432(
+        periode = periode,
+        beløp = setOf(
+            lagFeilKravgrunnlagsbeløp(klassekode, beløp.toBigDecimal()),
+            lagYtelKravgrunnlagsbeløp(klassekode),
+        ),
+        månedligSkattebeløp = BigDecimal("123.11"),
+    )
 
     fun lagKravgrunnlag(
         behandlingId: UUID,
-        perioder: Set<Kravgrunnlagsperiode432> = setOf(getKravgrunnlagsperiode432()),
+        perioder: Set<Kravgrunnlagsperiode432> = setOf(lagKravgrunnlagsperiode()),
         fagområdekode: Fagområdekode = Fagområdekode.EFOG,
     ) = Kravgrunnlag431(
         behandlingId = behandlingId,
@@ -351,20 +330,21 @@ object Testdata {
             vilkårsvurderingSærligeGrunner = setOf(vilkårsvurderingSærligGrunn),
         )
 
-    val vilkårsperiode =
-        Vilkårsvurderingsperiode(
-            periode = Månedsperiode(LocalDate.now(), LocalDate.now().plusDays(1)),
-            vilkårsvurderingsresultat = Vilkårsvurderingsresultat.FORSTO_BURDE_FORSTÅTT,
-            begrunnelse = "testverdi",
-            aktsomhet = vilkårsvurderingAktsomhet,
-            godTro = vilkårsvurderingGodTro,
-        )
+    fun vilkårsperiode(
+        periode: Månedsperiode = januar() til januar(),
+        godTro: VilkårsvurderingGodTro? = vilkårsvurderingGodTro,
+    ) = Vilkårsvurderingsperiode(
+        periode = periode,
+        vilkårsvurderingsresultat = Vilkårsvurderingsresultat.FORSTO_BURDE_FORSTÅTT,
+        begrunnelse = "testverdi",
+        aktsomhet = vilkårsvurderingAktsomhet,
+        godTro = godTro,
+    )
 
-    fun lagVilkårsvurdering(behandlingId: UUID) =
-        Vilkårsvurdering(
-            behandlingId = behandlingId,
-            perioder = setOf(vilkårsperiode),
-        )
+    fun lagVilkårsvurdering(
+        behandlingId: UUID,
+        perioder: Set<Vilkårsvurderingsperiode> = setOf(vilkårsperiode()),
+    ) = Vilkårsvurdering(behandlingId = behandlingId, perioder = perioder)
 
     fun lagFaktaFeilutbetaling(
         behandlingId: UUID,

--- a/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/dokumentbestilling/vedtak/VedtaksbrevServiceTest.kt
@@ -51,6 +51,9 @@ import no.nav.familie.tilbake.vilkårsvurdering.domain.Vilkårsvurderingsperiode
 import no.nav.tilbakekreving.api.v1.dto.FritekstavsnittDto
 import no.nav.tilbakekreving.api.v1.dto.HentForhåndvisningVedtaksbrevPdfDto
 import no.nav.tilbakekreving.api.v1.dto.PeriodeMedTekstDto
+import no.nav.tilbakekreving.april
+import no.nav.tilbakekreving.februar
+import no.nav.tilbakekreving.januar
 import no.nav.tilbakekreving.kontrakter.behandling.Behandlingsårsakstype
 import no.nav.tilbakekreving.kontrakter.behandling.Saksbehandlingstype
 import no.nav.tilbakekreving.kontrakter.behandlingskontroll.Behandlingssteg
@@ -60,17 +63,19 @@ import no.nav.tilbakekreving.kontrakter.faktaomfeilutbetaling.Hendelsestype
 import no.nav.tilbakekreving.kontrakter.faktaomfeilutbetaling.Hendelsesundertype
 import no.nav.tilbakekreving.kontrakter.periode.Datoperiode
 import no.nav.tilbakekreving.kontrakter.periode.Månedsperiode
+import no.nav.tilbakekreving.kontrakter.periode.Månedsperiode.Companion.til
+import no.nav.tilbakekreving.kontrakter.periode.til
 import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.Aktsomhet
 import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.SærligGrunn
 import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.Vilkårsvurderingsresultat
 import no.nav.tilbakekreving.kontrakter.ytelse.Fagsystem
 import no.nav.tilbakekreving.kontrakter.ytelse.Ytelsestype
+import no.nav.tilbakekreving.mars
+import no.nav.tilbakekreving.oktober
 import org.apache.commons.lang3.RandomStringUtils
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.LocalDate
-import java.time.YearMonth
 import java.util.UUID
 
 internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
@@ -121,9 +126,6 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
 
     private lateinit var sendBrevService: DistribusjonshåndteringService
 
-    private lateinit var behandling: Behandling
-    private lateinit var fagsak: Fagsak
-
     @Autowired
     private lateinit var brevmetadataUtil: BrevmetadataUtil
 
@@ -139,71 +141,26 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
     fun init() {
         spyPdfBrevService = spyk(pdfBrevService)
         manuellBrevmottakerRepository = mockk(relaxed = true)
-        sendBrevService =
-            DistribusjonshåndteringService(
-                fagsakRepository = fagsakRepository,
-                pdfBrevService = spyPdfBrevService,
-                vedtaksbrevgrunnlagService = vedtaksbrevgrunnlagService,
-                brevmetadataUtil = brevmetadataUtil,
-                manuelleBrevmottakerRepository = manuellBrevmottakerRepository,
-            )
-        vedtaksbrevService =
-            VedtaksbrevService(
-                behandlingRepository,
-                vedtaksbrevgeneratorService,
-                vedtaksbrevgrunnlagService,
-                faktaRepository,
-                vilkårsvurderingRepository,
-                vedtaksbrevsoppsummeringRepository,
-                vedtaksbrevsperiodeRepository,
-                spyPdfBrevService,
-                sendBrevService,
-                periodeService,
-                logService,
-            )
-
-        fagsak = fagsakRepository.insert(Testdata.fagsak())
-        behandling = behandlingRepository.insert(Testdata.lagBehandling(fagsakId = fagsak.id).copy(avsluttetDato = LocalDate.now()))
-        val kravgrunnlagsperiode432 =
-            Testdata
-                .lagKravgrunnlag(behandling.id)
-                .perioder
-                .first()
-                .copy(periode = Månedsperiode(YearMonth.of(2023, 3), YearMonth.of(2023, 4)))
-        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id).copy(perioder = setOf(kravgrunnlagsperiode432)))
-        vilkårsvurderingRepository.insert(
-            Testdata
-                .lagVilkårsvurdering(behandling.id)
-                .copy(perioder = setOf(Testdata.vilkårsperiode.copy(periode = Månedsperiode(YearMonth.of(2023, 3), YearMonth.of(2023, 4)), godTro = null))),
+        sendBrevService = DistribusjonshåndteringService(
+            fagsakRepository = fagsakRepository,
+            pdfBrevService = spyPdfBrevService,
+            vedtaksbrevgrunnlagService = vedtaksbrevgrunnlagService,
+            brevmetadataUtil = brevmetadataUtil,
+            manuelleBrevmottakerRepository = manuellBrevmottakerRepository,
         )
-        faktaRepository.insert(
-            Testdata.lagFaktaFeilutbetaling(behandling.id).copy(
-                perioder =
-                    setOf(
-                        FaktaFeilutbetalingsperiode(
-                            periode = Månedsperiode("2020-04" to "2022-08"),
-                            hendelsestype = Hendelsestype.ANNET,
-                            hendelsesundertype = Hendelsesundertype.ANNET_FRITEKST,
-                        ),
-                        FaktaFeilutbetalingsperiode(
-                            periode = Månedsperiode("2023-03" to "2023-04"),
-                            hendelsestype = Hendelsestype.ANNET,
-                            hendelsesundertype = Hendelsesundertype.ANNET_FRITEKST,
-                        ),
-                    ),
-            ),
+        vedtaksbrevService = VedtaksbrevService(
+            behandlingRepository,
+            vedtaksbrevgeneratorService,
+            vedtaksbrevgrunnlagService,
+            faktaRepository,
+            vilkårsvurderingRepository,
+            vedtaksbrevsoppsummeringRepository,
+            vedtaksbrevsperiodeRepository,
+            spyPdfBrevService,
+            sendBrevService,
+            periodeService,
+            logService,
         )
-
-        val personinfo = Personinfo("28056325874", LocalDate.now(), "Fiona")
-
-        every { eksterneDataForBrevService.hentPerson(fagsak.bruker.ident, any(), any()) }.returns(personinfo)
-        every { eksterneDataForBrevService.hentSaksbehandlernavn(behandling.ansvarligSaksbehandler) }
-            .returns("Ansvarlig O'Saksbehandler")
-        every { eksterneDataForBrevService.hentSaksbehandlernavn(behandling.ansvarligBeslutter!!) }
-            .returns("Ansvarlig O'Beslutter")
-        every {
-            eksterneDataForBrevService.hentAdresse(any(), any(), any<Verge>(), any(), any())
-        }.returns(Adresseinfo("12345678901", "Test"))
     }
 
     @Test
@@ -213,15 +170,16 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
         val brevtypeSlot = slot<Brevtype>()
         val brevdataSlot = slot<Brevdata>()
 
+        val (fagsak, behandling) = nyBehandling()
         val behandlingUtenVerge = behandling.copy(verger = emptySet())
         vedtaksbrevService.sendVedtaksbrev(behandlingUtenVerge)
 
         verify {
             spyPdfBrevService.sendBrev(
-                capture(behandlingSlot),
-                capture(fagsakSlot),
-                capture(brevtypeSlot),
-                capture(brevdataSlot),
+                behandling = capture(behandlingSlot),
+                fagsak = capture(fagsakSlot),
+                brevtype = capture(brevtypeSlot),
+                data = capture(brevdataSlot),
             )
         }
         behandlingSlot.captured shouldBe behandlingUtenVerge
@@ -235,6 +193,7 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
         val behandlingSlot = slot<Behandling>()
         val brevdataSlot = slot<Brevdata>()
 
+        val (fagsak, behandling) = nyBehandling()
         val efFagsak = fagsak.copy(fagsystem = Fagsystem.EF, ytelsestype = Ytelsestype.OVERGANGSSTØNAD)
         fagsakRepository.update(efFagsak)
 
@@ -260,63 +219,51 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
         brevdataSlot.captured.brevtekst shouldContain "{venstrejustert}Bob Burger{høyrejustert}"
     }
 
-    private fun lagBehandlingstegtilstandIverksetter(under4rettsgebyrbehandling: Behandling) =
-        Behandlingsstegstilstand(
-            behandlingId = under4rettsgebyrbehandling.id,
-            behandlingssteg = Behandlingssteg.IVERKSETT_VEDTAK,
-            behandlingsstegsstatus = Behandlingsstegstatus.KLAR,
-        )
+    private fun lagBehandlingstegtilstandIverksetter(under4rettsgebyrbehandling: Behandling) = Behandlingsstegstilstand(
+        behandlingId = under4rettsgebyrbehandling.id,
+        behandlingssteg = Behandlingssteg.IVERKSETT_VEDTAK,
+        behandlingsstegsstatus = Behandlingsstegstatus.KLAR,
+    )
 
     @Test
     fun `sendVedtaksbrev til organisasjon skal sette orgnr som mottakerident i brevdata`() {
         val orgNr = "123456789"
         val brevdataSlot = mutableListOf<Brevdata>()
 
-        every { manuellBrevmottakerRepository.findByBehandlingId(any()) } returns
-            listOf(
-                ManuellBrevmottaker(
-                    type = MottakerType.FULLMEKTIG,
-                    behandlingId = behandling.id,
-                    navn = "Organisasjonen v/ advokatfullmektig",
-                    orgNr = orgNr,
-                ),
-            )
+        val (_, behandling) = nyBehandling()
+
+        every { manuellBrevmottakerRepository.findByBehandlingId(any()) } returns listOf(
+            ManuellBrevmottaker(
+                type = MottakerType.FULLMEKTIG,
+                behandlingId = behandling.id,
+                navn = "Organisasjonen v/ advokatfullmektig",
+                orgNr = orgNr,
+            ),
+        )
         vedtaksbrevService.sendVedtaksbrev(behandling.copy(verger = emptySet()))
 
-        verify {
-            spyPdfBrevService.sendBrev(
-                any(),
-                any(),
-                any(),
-                capture(brevdataSlot),
-            )
-        }
+        verify { spyPdfBrevService.sendBrev(any(), any(), any(), capture(brevdataSlot)) }
         brevdataSlot.last().mottager shouldBe Brevmottager.MANUELL_TILLEGGSMOTTAKER
-        brevdataSlot
-            .last()
-            .metadata.mottageradresse.ident shouldBe orgNr
+        brevdataSlot.last().metadata.mottageradresse.ident shouldBe orgNr
     }
 
     @Test
     fun `hentForhåndsvisningVedtaksbrevMedVedleggSomPdf skal generere en gyldig pdf`() {
-        val dto =
-            HentForhåndvisningVedtaksbrevPdfDto(
-                behandling.id,
-                "Dette er en stor og gild oppsummeringstekst",
-                listOf(
-                    PeriodeMedTekstDto(
-                        Datoperiode(
-                            LocalDate.now().minusDays(1),
-                            LocalDate.now(),
-                        ),
-                        "Friktekst om fakta",
-                        "Friktekst om foreldelse",
-                        "Friktekst om vilkår",
-                        """Friktekst & > < ' "særligeGrunner""",
-                        "Friktekst om særligeGrunnerAnnet",
-                    ),
+        val (_, behandling) = nyBehandling()
+        val dto = HentForhåndvisningVedtaksbrevPdfDto(
+            behandling.id,
+            "Dette er en stor og gild oppsummeringstekst",
+            listOf(
+                PeriodeMedTekstDto(
+                    1.januar(2021) til 31.januar(2021),
+                    "Friktekst om fakta",
+                    "Friktekst om foreldelse",
+                    "Friktekst om vilkår",
+                    """Friktekst & > < ' "særligeGrunner""",
+                    "Friktekst om særligeGrunnerAnnet",
                 ),
-            )
+            ),
+        )
 
         val bytes = vedtaksbrevService.hentForhåndsvisningVedtaksbrevMedVedleggSomPdf(dto)
         //   File("test.pdf").writeBytes(bytes)
@@ -326,6 +273,7 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentForhåndsvisningVedtaksbrevMedVedleggSomPdf skal generere en gyldig pdf med xml-spesialtegn`() {
+        val (_, behandling) = nyBehandling()
         val bytes = vedtaksbrevService.hentForhåndsvisningVedtaksbrevMedVedleggSomPdf(forhåndvisningDto(behandling.id))
 
 //        File("test.pdf").writeBytes(bytes)
@@ -334,6 +282,7 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentForhåndsvisningVedtaksbrevSomTekst genererer avsnitt med tekst for forhåndsvisning av vedtaksbrev`() {
+        val (_, behandling) = nyBehandling()
         val avsnitt = vedtaksbrevService.hentVedtaksbrevSomTekst(behandling.id)
 
         avsnitt.shouldHaveSize(3)
@@ -342,133 +291,175 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `lagreFriteksterFraSaksbehandler skal ikke lagre fritekster når en av de periodene er ugyldig`() {
-        lagFakta()
-        val perioderMedTekst =
-            listOf(
-                PeriodeMedTekstDto(
-                    periode = Datoperiode(YearMonth.of(2021, 1), YearMonth.of(2021, 3)),
-                    faktaAvsnitt = "fakta fritekst",
-                    vilkårAvsnitt = "vilkår fritekst",
-                ),
-                PeriodeMedTekstDto(
-                    periode = Datoperiode(YearMonth.of(2021, 10), YearMonth.of(2021, 10)),
-                    faktaAvsnitt = "ugyldig",
-                    vilkårAvsnitt = "ugyldig",
-                ),
-            )
-        val fritekstAvsnittDto =
-            FritekstavsnittDto(
-                oppsummeringstekst = "oppsummeringstekst",
-                perioderMedTekst = perioderMedTekst,
-            )
+        val (_, behandling) = nyBehandling(
+            lagFaktaVurdering = false,
+            kravgrunnlagPerioder = listOf(
+                januar(2021) til januar(2021),
+                februar(2021) til februar(2021),
+                mars(2021) til mars(2021),
+            ),
+        )
+        lagFakta(behandling.id, januar(2021) til mars(2021))
+        val perioderMedTekst = listOf(
+            PeriodeMedTekstDto(
+                periode = 1.januar(2021) til 31.mars(2021),
+                faktaAvsnitt = "fakta fritekst",
+                vilkårAvsnitt = "vilkår fritekst",
+            ),
+            PeriodeMedTekstDto(
+                periode = 1.oktober(2021) til 31.oktober(2021),
+                faktaAvsnitt = "ugyldig",
+                vilkårAvsnitt = "ugyldig",
+            ),
+        )
+        val fritekstAvsnittDto = FritekstavsnittDto(
+            oppsummeringstekst = "oppsummeringstekst",
+            perioderMedTekst = perioderMedTekst,
+        )
 
-        val exception =
-            shouldThrow<RuntimeException> {
-                vedtaksbrevService.lagreFriteksterFraSaksbehandler(
-                    behandling.id,
-                    fritekstAvsnittDto,
-                    SecureLog.Context.tom(),
-                )
-            }
+        val exception = shouldThrow<RuntimeException> {
+            vedtaksbrevService.lagreFriteksterFraSaksbehandler(
+                behandling.id,
+                fritekstAvsnittDto,
+                SecureLog.Context.tom(),
+            )
+        }
         exception.message shouldBe "Periode 2021-10-01-2021-10-31 er ugyldig for behandling ${behandling.id}"
     }
 
     @Test
     fun `lagreFriteksterFraSaksbehandler skal ikke lagre fritekster når oppsummeringstekst er for lang`() {
-        lagFakta()
-        val exception =
-            shouldThrow<RuntimeException> {
-                vedtaksbrevService.lagreFriteksterFraSaksbehandler(
-                    behandling.id,
-                    lagFritekstAvsnittDto(
-                        "fakta",
-                        RandomStringUtils.random(5000),
-                    ),
-                    SecureLog.Context.tom(),
-                )
-            }
+        val (_, behandling) = nyBehandling(lagFaktaVurdering = false)
+        lagFakta(behandling.id, januar(2021) til januar(2021))
+        val exception = shouldThrow<RuntimeException> {
+            vedtaksbrevService.lagreFriteksterFraSaksbehandler(
+                behandling.id,
+                lagFritekstAvsnittDto(
+                    faktaFritekst = "fakta",
+                    oppsummeringstekst = RandomStringUtils.random(5000),
+                    periode = 1.januar(2021) til 31.januar(2021),
+                ),
+                SecureLog.Context.tom(),
+            )
+        }
         exception.message shouldBe "Oppsummeringstekst er for lang for behandling ${behandling.id}"
     }
 
     @Test
     fun `lagreFriteksterFraSaksbehandler skal ikke lagre når fritekst mangler for ANNET særliggrunner begrunnelse`() {
-        lagFakta()
-        lagVilkårsvurdering()
-        val exception =
-            shouldThrow<RuntimeException> {
-                vedtaksbrevService.lagreFriteksterFraSaksbehandler(
-                    behandling.id,
-                    lagFritekstAvsnittDto("fakta", "fakta data"),
-                    SecureLog.Context.tom(),
-                )
-            }
-        exception.message shouldBe "Mangler ANNET Særliggrunner fritekst for " +
-            "${Månedsperiode(YearMonth.of(2021, 1), YearMonth.of(2021, 3))}"
+        val (_, behandling) = nyBehandling(
+            lagFaktaVurdering = false,
+            lagVilkårsvurdering = false,
+            kravgrunnlagPerioder = listOf(
+                januar(2021) til januar(2021),
+                februar(2021) til februar(2021),
+                mars(2021) til mars(2021),
+            ),
+        )
+        lagFakta(behandling.id, januar(2021) til mars(2021))
+        lagVilkårsvurdering(behandling.id, januar(2021) til mars(2021))
+        val exception = shouldThrow<RuntimeException> {
+            vedtaksbrevService.lagreFriteksterFraSaksbehandler(
+                behandling.id,
+                lagFritekstAvsnittDto(
+                    faktaFritekst = "fakta",
+                    oppsummeringstekst = "fakta data",
+                    periode = 1.januar(2021) til 31.mars(2021),
+                ),
+                SecureLog.Context.tom(),
+            )
+        }
+        exception.message shouldBe "Mangler ANNET Særliggrunner fritekst for ${januar(2021) til mars(2021)}"
     }
 
     @Test
     fun `lagreFriteksterFraSaksbehandler skal ikke lagre når fritekst mangler for alle fakta perioder`() {
-        lagFakta()
-        val exception =
-            shouldThrow<RuntimeException> {
-                vedtaksbrevService.lagreFriteksterFraSaksbehandler(
-                    behandling.id,
-                    lagFritekstAvsnittDto(),
-                    SecureLog.Context.tom(),
-                )
-            }
+        val (_, behandling) = nyBehandling(
+            lagFaktaVurdering = false,
+            lagVilkårsvurdering = false,
+            kravgrunnlagPerioder = listOf(
+                januar(2021) til januar(2021),
+                februar(2021) til februar(2021),
+            ),
+        )
+        lagFakta(
+            behandling.id,
+            januar(2021) til januar(2021),
+            februar(2021) til februar(2021),
+        )
+        val exception = shouldThrow<RuntimeException> {
+            vedtaksbrevService.lagreFriteksterFraSaksbehandler(
+                behandling.id,
+                lagFritekstAvsnittDto(periode = 1.januar(2021) til 31.januar(2021)),
+                SecureLog.Context.tom(),
+            )
+        }
         exception.message shouldBe "Mangler fakta fritekst for alle fakta perioder"
     }
 
     @Test
     fun `lagreFriteksterFraSaksbehandler skal ikke lagre når fritekst mangler for en av fakta perioder`() {
-        lagFakta()
-        val perioderMedTekst =
-            listOf(
-                PeriodeMedTekstDto(
-                    periode = Datoperiode(YearMonth.of(2021, 1), YearMonth.of(2021, 1)),
-                    faktaAvsnitt = "fakta fritekst",
-                    vilkårAvsnitt = "vilkår fritekst",
-                ),
-                PeriodeMedTekstDto(
-                    periode = Datoperiode(YearMonth.of(2021, 2), YearMonth.of(2021, 2)),
-                    faktaAvsnitt = "fakta fritekst",
-                    vilkårAvsnitt = "vilkår fritekst",
-                ),
-                PeriodeMedTekstDto(
-                    periode = Datoperiode(YearMonth.of(2021, 3), YearMonth.of(2021, 3)),
-                    vilkårAvsnitt = "vilkår fritekst",
-                ),
-            )
+        val (_, behandling) = nyBehandling(
+            lagFaktaVurdering = false,
+            kravgrunnlagPerioder = listOf(
+                januar(2021) til januar(2021),
+                februar(2021) til februar(2021),
+                mars(2021) til mars(2021),
+            ),
+        )
+        lagFakta(behandling.id, januar(2021) til mars(2021))
+        val perioderMedTekst = listOf(
+            PeriodeMedTekstDto(
+                periode = 1.januar(2021) til 31.januar(2021),
+                faktaAvsnitt = "fakta fritekst",
+                vilkårAvsnitt = "vilkår fritekst",
+            ),
+            PeriodeMedTekstDto(
+                periode = 1.februar(2021) til 28.februar(2021),
+                faktaAvsnitt = "fakta fritekst",
+                vilkårAvsnitt = "vilkår fritekst",
+            ),
+            PeriodeMedTekstDto(
+                periode = 1.mars(2021) til 31.mars(2021),
+                vilkårAvsnitt = "vilkår fritekst",
+            ),
+        )
         val fritekstAvsnittDto =
             FritekstavsnittDto(
                 oppsummeringstekst = "oppsummeringstekst",
                 perioderMedTekst = perioderMedTekst,
             )
 
-        val exception =
-            shouldThrow<RuntimeException> {
-                vedtaksbrevService.lagreFriteksterFraSaksbehandler(
-                    behandlingId = behandling.id,
-                    fritekstavsnittDto = fritekstAvsnittDto,
-                    logContext = SecureLog.Context.tom(),
-                )
-            }
-        exception.message shouldBe "Mangler fakta fritekst for ${LocalDate.of(2021, 3, 1)}-" +
-            "${LocalDate.of(2021, 3, 31)}"
+        val exception = shouldThrow<RuntimeException> {
+            vedtaksbrevService.lagreFriteksterFraSaksbehandler(
+                behandlingId = behandling.id,
+                fritekstavsnittDto = fritekstAvsnittDto,
+                logContext = SecureLog.Context.tom(),
+            )
+        }
+        exception.message shouldBe "Mangler fakta fritekst for ${1.mars(2021)}-${31.mars(2021)}"
     }
 
     @Test
     fun `lagreFriteksterFraSaksbehandler skal lagre fritekst`() {
-        lagFakta()
-        lagVilkårsvurdering()
+        val (_, behandling) = nyBehandling(
+            kravgrunnlagPerioder = listOf(
+                januar(2021) til januar(2021),
+                februar(2021) til februar(2021),
+                mars(2021) til mars(2021),
+            ),
+            lagFaktaVurdering = false,
+            lagVilkårsvurdering = false,
+        )
+        lagFakta(behandling.id, januar(2021) til mars(2021))
+        lagVilkårsvurdering(behandling.id, januar(2021) til mars(2021))
 
-        val fritekstAvsnittDto =
-            lagFritekstAvsnittDto(
-                faktaFritekst = "fakta fritekst",
-                oppsummeringstekst = "oppsummering fritekst",
-                særligGrunnerAnnetFritekst = "særliggrunner annet fritekst",
-            )
+        val fritekstAvsnittDto = lagFritekstAvsnittDto(
+            faktaFritekst = "fakta fritekst",
+            oppsummeringstekst = "oppsummering fritekst",
+            særligGrunnerAnnetFritekst = "særliggrunner annet fritekst",
+            periode = 1.januar(2021) til 31.mars(2021),
+        )
 
         vedtaksbrevService.lagreFriteksterFraSaksbehandler(
             behandlingId = behandling.id,
@@ -482,15 +473,22 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
 
         val oppsummeringsavsnitt = avsnittene.firstOrNull { Avsnittstype.OPPSUMMERING == it.avsnittstype }
         oppsummeringsavsnitt.shouldNotBeNull()
-        oppsummeringsavsnitt.underavsnittsliste.size shouldBe 2
-        val oppsummeringsunderavsnitt1 = oppsummeringsavsnitt.underavsnittsliste[0]
+        oppsummeringsavsnitt.underavsnittsliste.size shouldBe 3
+        val oppsummeringsunderavsnitt0 = oppsummeringsavsnitt.underavsnittsliste[0]
+        assertUnderavsnitt(
+            underavsnitt = oppsummeringsunderavsnitt0,
+            fritekst = "",
+            fritekstTillatt = false,
+            fritekstPåkrevet = false,
+        )
+        val oppsummeringsunderavsnitt1 = oppsummeringsavsnitt.underavsnittsliste[1]
         assertUnderavsnitt(
             underavsnitt = oppsummeringsunderavsnitt1,
             fritekst = "",
             fritekstTillatt = false,
             fritekstPåkrevet = false,
         )
-        val oppsummeringsunderavsnitt2 = oppsummeringsavsnitt.underavsnittsliste[1]
+        val oppsummeringsunderavsnitt2 = oppsummeringsavsnitt.underavsnittsliste[2]
         assertUnderavsnitt(
             underavsnitt = oppsummeringsunderavsnitt2,
             fritekst = "oppsummering fritekst",
@@ -500,13 +498,12 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
 
         val periodeAvsnitter = avsnittene.firstOrNull { Avsnittstype.PERIODE == it.avsnittstype }
         periodeAvsnitter.shouldNotBeNull()
-        periodeAvsnitter.fom shouldBe LocalDate.of(2021, 1, 1)
-        periodeAvsnitter.tom shouldBe LocalDate.of(2021, 3, 31)
+        periodeAvsnitter.fom shouldBe 1.januar(2021)
+        periodeAvsnitter.tom shouldBe 31.mars(2021)
 
         periodeAvsnitter.underavsnittsliste.size shouldBe 7
-        val faktaUnderavsnitt =
-            periodeAvsnitter.underavsnittsliste
-                .firstOrNull { Underavsnittstype.FAKTA == it.underavsnittstype }
+        val faktaUnderavsnitt = periodeAvsnitter.underavsnittsliste
+            .firstOrNull { Underavsnittstype.FAKTA == it.underavsnittstype }
         faktaUnderavsnitt.shouldNotBeNull()
         assertUnderavsnitt(
             underavsnitt = faktaUnderavsnitt,
@@ -515,9 +512,8 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
             fritekstPåkrevet = true,
         )
 
-        val foreldelseUnderavsnitt =
-            periodeAvsnitter.underavsnittsliste
-                .firstOrNull { Underavsnittstype.FORELDELSE == it.underavsnittstype }
+        val foreldelseUnderavsnitt = periodeAvsnitter.underavsnittsliste
+            .firstOrNull { Underavsnittstype.FORELDELSE == it.underavsnittstype }
         foreldelseUnderavsnitt.shouldBeNull() // periodene er ikke foreldet
 
         val vilkårUnderavsnitter = periodeAvsnitter.underavsnittsliste.filter { Underavsnittstype.VILKÅR == it.underavsnittstype }
@@ -537,9 +533,8 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
             fritekstPåkrevet = false,
         )
 
-        val særligGrunnerUnderavsnitt =
-            periodeAvsnitter.underavsnittsliste
-                .firstOrNull { Underavsnittstype.SÆRLIGEGRUNNER == it.underavsnittstype }
+        val særligGrunnerUnderavsnitt = periodeAvsnitter.underavsnittsliste
+            .firstOrNull { Underavsnittstype.SÆRLIGEGRUNNER == it.underavsnittstype }
         særligGrunnerUnderavsnitt.shouldNotBeNull()
         assertUnderavsnitt(
             underavsnitt = særligGrunnerUnderavsnitt,
@@ -548,9 +543,8 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
             fritekstPåkrevet = false,
         )
 
-        val særligGrunnerAnnetUnderavsnitt =
-            periodeAvsnitter.underavsnittsliste
-                .firstOrNull { Underavsnittstype.SÆRLIGEGRUNNER_ANNET == it.underavsnittstype }
+        val særligGrunnerAnnetUnderavsnitt = periodeAvsnitter.underavsnittsliste
+            .firstOrNull { Underavsnittstype.SÆRLIGEGRUNNER_ANNET == it.underavsnittstype }
         særligGrunnerAnnetUnderavsnitt.shouldNotBeNull()
         assertUnderavsnitt(
             underavsnitt = særligGrunnerAnnetUnderavsnitt,
@@ -565,14 +559,15 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `lagreUtkastAvFriteksterFraSaksbehandler skal lagre selv når påkrevet fritekst mangler for alle fakta perioder`() {
-        lagFakta()
-        lagVilkårsvurdering()
+        val (_, behandling) = nyBehandling(lagFaktaVurdering = false, lagVilkårsvurdering = false)
+        lagFakta(behandling.id, januar(2021) til januar(2021))
+        lagVilkårsvurdering(behandling.id, januar(2021) til januar(2021))
 
-        val fritekstAvsnittDto =
-            lagFritekstAvsnittDto(
-                oppsummeringstekst = "oppsummering fritekst",
-                særligGrunnerAnnetFritekst = "særliggrunner annet fritekst",
-            )
+        val fritekstAvsnittDto = lagFritekstAvsnittDto(
+            oppsummeringstekst = "oppsummering fritekst",
+            særligGrunnerAnnetFritekst = "særliggrunner annet fritekst",
+            periode = 1.januar(2021) til 31.januar(2021),
+        )
         vedtaksbrevService.lagreUtkastAvFritekster(
             behandling.id,
             fritekstAvsnittDto,
@@ -586,14 +581,15 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `lagreUtkastAvFriteksterFraSaksbehandler skal lagre selv når påkrevet fritekst mangler for ANNET særliggrunner begrunnelse`() {
-        lagFakta()
-        lagVilkårsvurdering()
+        val (_, behandling) = nyBehandling(lagFaktaVurdering = false, lagVilkårsvurdering = false)
+        lagFakta(behandling.id, januar(2021) til januar(2021))
+        lagVilkårsvurdering(behandling.id, januar(2021) til januar(2021))
 
-        val fritekstAvsnittDto =
-            lagFritekstAvsnittDto(
-                faktaFritekst = "fakta fritekst",
-                oppsummeringstekst = "oppsummering fritekst",
-            )
+        val fritekstAvsnittDto = lagFritekstAvsnittDto(
+            faktaFritekst = "fakta fritekst",
+            oppsummeringstekst = "oppsummering fritekst",
+            periode = 1.januar(2021) til 31.januar(2021),
+        )
 
         vedtaksbrevService.lagreUtkastAvFritekster(
             behandlingId = behandling.id,
@@ -608,7 +604,8 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `lagreUtkastAvFriteksterFraSaksbehandler skal lagre selv når påkrevet fritekst mangler for oppsummering`() {
-        var lokalBehandling =
+        val (fagsak, behandling) = nyBehandling()
+        val revurdering = behandlingRepository.insert(
             Testdata.lagRevurdering(behandling.id, fagsak.id).copy(
                 id = UUID.randomUUID(),
                 eksternBrukId = UUID.randomUUID(),
@@ -620,35 +617,36 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
                             type = Behandlingsårsakstype.REVURDERING_OPPLYSNINGER_OM_VILKÅR,
                         ),
                     ),
-            )
-        lokalBehandling = behandlingRepository.insert(lokalBehandling)
+            ),
+        )
 
         // Er nødt til å opprette kravgrunnlag for revurderingen
-        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id).copy(id = UUID.randomUUID(), behandlingId = lokalBehandling.id, perioder = emptySet()))
+        kravgrunnlagRepository.insert(Testdata.lagKravgrunnlag(behandling.id).copy(id = UUID.randomUUID(), behandlingId = revurdering.id, perioder = emptySet()))
 
-        lagFakta(lokalBehandling.id)
-        lagVilkårsvurdering(lokalBehandling.id)
+        lagFakta(revurdering.id, januar(2021) til januar(2021))
+        lagVilkårsvurdering(revurdering.id, januar(2021) til januar(2021))
 
-        val fritekstAvsnittDto =
-            lagFritekstAvsnittDto(
-                faktaFritekst = "fakta fritekst",
-                særligGrunnerAnnetFritekst = "særliggrunner annet fritekst",
-            )
+        val fritekstAvsnittDto = lagFritekstAvsnittDto(
+            faktaFritekst = "fakta fritekst",
+            særligGrunnerAnnetFritekst = "særliggrunner annet fritekst",
+            periode = 1.januar(2021) til 31.januar(2021),
+        )
 
         vedtaksbrevService.lagreUtkastAvFritekster(
-            behandlingId = lokalBehandling.id,
+            behandlingId = revurdering.id,
             fritekstavsnittDto = fritekstAvsnittDto,
             logContext = SecureLog.Context.tom(),
         )
 
-        val avsnittene = vedtaksbrevService.hentVedtaksbrevSomTekst(lokalBehandling.id)
+        val avsnittene = vedtaksbrevService.hentVedtaksbrevSomTekst(revurdering.id)
         avsnittene.shouldNotBeEmpty()
         avsnittene.size shouldBe 3
     }
 
     @Test
     fun `lagreFriteksterFraSaksbehandler skal ikke lagre fritekster når påkrevet oppsummeringstekst mangler`() {
-        var lokalBehandling =
+        val (fagsak, behandling) = nyBehandling()
+        val revurdering = behandlingRepository.insert(
             Testdata.lagRevurdering(behandling.id, fagsak.id).copy(
                 id = UUID.randomUUID(),
                 eksternBrukId = UUID.randomUUID(),
@@ -659,95 +657,141 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
                             type = Behandlingsårsakstype.REVURDERING_OPPLYSNINGER_OM_VILKÅR,
                         ),
                     ),
-            )
-        lokalBehandling = behandlingRepository.insert(lokalBehandling)
-        lagFakta(lokalBehandling.id)
-        lagVilkårsvurdering(lokalBehandling.id)
+            ),
+        )
+        lagFakta(revurdering.id, januar(2021) til januar(2021))
+        lagVilkårsvurdering(revurdering.id, januar(2021) til januar(2021))
 
-        val exception =
-            shouldThrow<RuntimeException> {
-                vedtaksbrevService.lagreFriteksterFraSaksbehandler(
-                    lokalBehandling.id,
-                    lagFritekstAvsnittDto(
-                        faktaFritekst = "fakta",
-                        særligGrunnerAnnetFritekst = "test",
-                    ),
-                    SecureLog.Context.tom(),
-                )
-            }
-        exception.message shouldBe "oppsummering fritekst påkrevet for revurdering ${lokalBehandling.id}"
+        val exception = shouldThrow<RuntimeException> {
+            vedtaksbrevService.lagreFriteksterFraSaksbehandler(
+                revurdering.id,
+                lagFritekstAvsnittDto(
+                    faktaFritekst = "fakta",
+                    særligGrunnerAnnetFritekst = "test",
+                    periode = 1.januar(2021) til 31.januar(2021),
+                ),
+                SecureLog.Context.tom(),
+            )
+        }
+        exception.message shouldBe "oppsummering fritekst påkrevet for revurdering ${revurdering.id}"
     }
 
     private fun lagFritekstAvsnittDto(
         faktaFritekst: String? = null,
         oppsummeringstekst: String? = null,
         særligGrunnerAnnetFritekst: String? = null,
+        periode: Datoperiode,
     ): FritekstavsnittDto {
-        val perioderMedTekst =
-            listOf(
+        return FritekstavsnittDto(
+            oppsummeringstekst = oppsummeringstekst,
+            perioderMedTekst = listOf(
                 PeriodeMedTekstDto(
-                    periode = Datoperiode(YearMonth.of(2021, 1), YearMonth.of(2021, 3)),
+                    periode = periode,
                     faktaAvsnitt = faktaFritekst,
                     vilkårAvsnitt = "vilkår fritekst",
                     foreldelseAvsnitt = "foreldelse fritekst",
                     særligeGrunnerAvsnitt = "særliggrunner fritekst",
                     særligeGrunnerAnnetAvsnitt = særligGrunnerAnnetFritekst,
                 ),
-            )
-        return FritekstavsnittDto(
-            oppsummeringstekst = oppsummeringstekst,
-            perioderMedTekst = perioderMedTekst,
+            ),
         )
     }
 
-    private fun lagFakta(behandlingId: UUID = behandling.id) {
-        val faktaFeilutbetaltePerioder =
-            setOf(
-                FaktaFeilutbetalingsperiode(
-                    periode = Månedsperiode(YearMonth.of(2021, 1), YearMonth.of(2021, 3)),
-                    hendelsestype = Hendelsestype.ANNET,
-                    hendelsesundertype = Hendelsesundertype.ANNET_FRITEKST,
-                ),
-            )
-        faktaFeilutbetalingService.deaktiverEksisterendeFaktaOmFeilutbetaling(behandlingId)
+    private fun lagFakta(
+        behandlingId: UUID,
+        vararg perioder: Månedsperiode,
+    ) {
         faktaRepository.insert(
             FaktaFeilutbetaling(
                 behandlingId = behandlingId,
                 begrunnelse = "fakta begrrunnelse",
-                perioder = faktaFeilutbetaltePerioder,
+                perioder = perioder.map {
+                    FaktaFeilutbetalingsperiode(
+                        periode = it,
+                        hendelsestype = Hendelsestype.ANNET,
+                        hendelsesundertype = Hendelsesundertype.ANNET_FRITEKST,
+                    )
+                }.toSet(),
             ),
         )
     }
 
-    private fun lagVilkårsvurdering(behandlingId: UUID = behandling.id) {
-        val aktsomhet =
-            VilkårsvurderingAktsomhet(
-                aktsomhet = Aktsomhet.GROV_UAKTSOMHET,
-                særligeGrunnerBegrunnelse = "Særlig grunner begrunnelse",
-                særligeGrunnerTilReduksjon = false,
-                vilkårsvurderingSærligeGrunner =
-                    setOf(
-                        VilkårsvurderingSærligGrunn(
-                            særligGrunn = SærligGrunn.ANNET,
-                            begrunnelse = "Annet begrunnelse",
-                        ),
-                    ),
-                begrunnelse = "aktsomhet begrunnelse",
-            )
-        val vilkårsvurderingPeriode =
-            Vilkårsvurderingsperiode(
-                periode = Månedsperiode(YearMonth.of(2021, 1), YearMonth.of(2021, 3)),
-                vilkårsvurderingsresultat = Vilkårsvurderingsresultat.FEIL_OPPLYSNINGER_FRA_BRUKER,
-                begrunnelse = "Vilkårsvurdering begrunnelse",
-                aktsomhet = aktsomhet,
-            )
-        vilkårsvurderingService.deaktiverEksisterendeVilkårsvurdering(behandlingId)
+    private fun lagVilkårsvurdering(
+        behandlingId: UUID,
+        periode: Månedsperiode,
+    ) {
         vilkårsvurderingRepository.insert(
             Vilkårsvurdering(
                 behandlingId = behandlingId,
-                perioder = setOf(vilkårsvurderingPeriode),
+                perioder = setOf(
+                    Vilkårsvurderingsperiode(
+                        periode = periode,
+                        vilkårsvurderingsresultat = Vilkårsvurderingsresultat.FEIL_OPPLYSNINGER_FRA_BRUKER,
+                        begrunnelse = "Vilkårsvurdering begrunnelse",
+                        aktsomhet = VilkårsvurderingAktsomhet(
+                            aktsomhet = Aktsomhet.GROV_UAKTSOMHET,
+                            særligeGrunnerBegrunnelse = "Særlig grunner begrunnelse",
+                            særligeGrunnerTilReduksjon = false,
+                            vilkårsvurderingSærligeGrunner = setOf(
+                                VilkårsvurderingSærligGrunn(
+                                    særligGrunn = SærligGrunn.ANNET,
+                                    begrunnelse = "Annet begrunnelse",
+                                ),
+                            ),
+                            begrunnelse = "aktsomhet begrunnelse",
+                        ),
+                    ),
+                ),
             ),
         )
+    }
+
+    fun nyBehandling(
+        lagFaktaVurdering: Boolean = true,
+        lagVilkårsvurdering: Boolean = true,
+        kravgrunnlagPerioder: List<Månedsperiode> = listOf(mars(2021) til mars(2021)),
+    ): Pair<Fagsak, Behandling> {
+        val fagsak = fagsakRepository.insert(Testdata.fagsak())
+        val behandling = behandlingRepository.insert(Testdata.lagBehandling(fagsakId = fagsak.id).copy(avsluttetDato = 20.april(2024)))
+        kravgrunnlagRepository.insert(
+            Testdata.lagKravgrunnlag(
+                behandlingId = behandling.id,
+                perioder = kravgrunnlagPerioder.map { Testdata.lagKravgrunnlagsperiode(it) }.toSet(),
+            ),
+        )
+        if (lagVilkårsvurdering) {
+            vilkårsvurderingRepository.insert(
+                Testdata.lagVilkårsvurdering(
+                    behandlingId = behandling.id,
+                    perioder = setOf(Testdata.vilkårsperiode(mars(2021) til april(2021), godTro = null)),
+                ),
+            )
+        }
+        if (lagFaktaVurdering) {
+            faktaRepository.insert(
+                Testdata.lagFaktaFeilutbetaling(behandling.id).copy(
+                    perioder = setOf(
+                        FaktaFeilutbetalingsperiode(
+                            periode = mars(2021) til april(2021),
+                            hendelsestype = Hendelsestype.ANNET,
+                            hendelsesundertype = Hendelsesundertype.ANNET_FRITEKST,
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        val personinfo = Personinfo("28056325874", 1.januar(2024), "Fiona")
+
+        every { eksterneDataForBrevService.hentPerson(fagsak.bruker.ident, any(), any()) }.returns(personinfo)
+        every { eksterneDataForBrevService.hentSaksbehandlernavn(behandling.ansvarligSaksbehandler) }
+            .returns("Ansvarlig O'Saksbehandler")
+        every { eksterneDataForBrevService.hentSaksbehandlernavn(behandling.ansvarligBeslutter!!) }
+            .returns("Ansvarlig O'Beslutter")
+        every { eksterneDataForBrevService.hentAdresse(any(), any(), any<Verge>(), any(), any()) }
+            .returns(Adresseinfo("12345678901", "Test"))
+
+        return fagsak to behandling
     }
 
     private fun assertUnderavsnitt(
@@ -761,20 +805,16 @@ internal class VedtaksbrevServiceTest : OppslagSpringRunnerTest() {
         underavsnitt.fritekstPåkrevet shouldBe fritekstPåkrevet
     }
 
-    fun forhåndvisningDto(behandlingId: UUID) =
-        HentForhåndvisningVedtaksbrevPdfDto(
-            behandlingId,
-            "Dette er en stor og gild oppsummeringstekst",
-            listOf(
-                PeriodeMedTekstDto(
-                    Datoperiode(
-                        LocalDate.now().minusDays(1),
-                        LocalDate.now(),
-                    ),
-                    faktaAvsnitt = "&bob",
-                    vilkårAvsnitt = "<bob>",
-                    særligeGrunnerAnnetAvsnitt = "'bob' \"bob\"",
-                ),
+    fun forhåndvisningDto(behandlingId: UUID) = HentForhåndvisningVedtaksbrevPdfDto(
+        behandlingId,
+        "Dette er en stor og gild oppsummeringstekst",
+        listOf(
+            PeriodeMedTekstDto(
+                1.januar(2024) til 31.januar(2024),
+                faktaAvsnitt = "&bob",
+                vilkårAvsnitt = "<bob>",
+                særligeGrunnerAnnetAvsnitt = "'bob' \"bob\"",
             ),
-        )
+        ),
+    )
 }

--- a/src/test/kotlin/no/nav/familie/tilbake/foreldelse/ForeldelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/foreldelse/ForeldelseServiceTest.kt
@@ -15,9 +15,12 @@ import no.nav.familie.tilbake.log.SecureLog
 import no.nav.familie.tilbake.vilkårsvurdering.VilkårsvurderingRepository
 import no.nav.tilbakekreving.api.v1.dto.BehandlingsstegForeldelseDto
 import no.nav.tilbakekreving.api.v1.dto.ForeldelsesperiodeDto
+import no.nav.tilbakekreving.februar
+import no.nav.tilbakekreving.januar
 import no.nav.tilbakekreving.kontrakter.foreldelse.Foreldelsesvurderingstype
 import no.nav.tilbakekreving.kontrakter.periode.Datoperiode
 import no.nav.tilbakekreving.kontrakter.periode.Månedsperiode
+import no.nav.tilbakekreving.kontrakter.periode.Månedsperiode.Companion.til
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -53,39 +56,29 @@ internal class ForeldelseServiceTest : OppslagSpringRunnerTest() {
         fagsak = fagsakRepository.insert(Testdata.fagsak())
         behandling = behandlingRepository.insert(Testdata.lagBehandling(fagsakId = fagsak.id))
 
-        val kravgrunnlag431 = Testdata.lagKravgrunnlag(behandling.id)
         val feilkravgrunnlagsbeløp = Testdata.feilKravgrunnlagsbeløp433
         val yteseskravgrunnlagsbeløp = Testdata.ytelKravgrunnlagsbeløp433
         val førsteKravgrunnlagsperiode =
-            Testdata
-                .getKravgrunnlagsperiode432()
-                .copy(
-                    periode = Månedsperiode(YearMonth.of(2017, 1), YearMonth.of(2017, 1)),
-                    beløp =
-                        setOf(
-                            feilkravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
-                            yteseskravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
-                        ),
-                )
+            Testdata.lagKravgrunnlagsperiode(januar(2017) til januar(2017)).copy(
+                beløp = setOf(
+                    feilkravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
+                    yteseskravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
+                ),
+            )
         val andreKravgrunnlagsperiode =
-            Testdata
-                .getKravgrunnlagsperiode432()
-                .copy(
-                    id = UUID.randomUUID(),
-                    periode = Månedsperiode(YearMonth.of(2017, 2), YearMonth.of(2017, 2)),
-                    beløp =
-                        setOf(
-                            feilkravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
-                            yteseskravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
-                        ),
-                )
+            Testdata.lagKravgrunnlagsperiode(februar(2017) til februar(2017)).copy(
+                beløp = setOf(
+                    feilkravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
+                    yteseskravgrunnlagsbeløp.copy(id = UUID.randomUUID()),
+                ),
+            )
         kravgrunnlagRepository.insert(
-            kravgrunnlag431.copy(
-                perioder =
-                    setOf(
-                        førsteKravgrunnlagsperiode,
-                        andreKravgrunnlagsperiode,
-                    ),
+            Testdata.lagKravgrunnlag(
+                behandlingId = behandling.id,
+                perioder = setOf(
+                    førsteKravgrunnlagsperiode,
+                    andreKravgrunnlagsperiode,
+                ),
             ),
         )
     }

--- a/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppgavePrioritetServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/oppgave/OppgavePrioritetServiceTest.kt
@@ -9,11 +9,11 @@ import no.nav.familie.tilbake.kontrakter.oppgave.Oppgave
 import no.nav.familie.tilbake.kontrakter.oppgave.OppgavePrioritet
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
 import no.nav.familie.tilbake.kravgrunnlag.domain.Kravgrunnlag431
-import no.nav.tilbakekreving.kontrakter.periode.Månedsperiode
+import no.nav.tilbakekreving.januar
+import no.nav.tilbakekreving.kontrakter.periode.Månedsperiode.Companion.til
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
-import java.time.YearMonth
 import java.util.UUID
 
 internal class OppgavePrioritetServiceTest {
@@ -76,16 +76,12 @@ internal class OppgavePrioritetServiceTest {
     }
 
     private fun lagKravgrunnlagMedFeilutbetaling(feilutbetaling: Int): Kravgrunnlag431 {
-        val periode =
-            Testdata.getKravgrunnlagsperiode432().copy(
-                id = UUID.randomUUID(),
-                periode = Månedsperiode(YearMonth.of(2020, 1), YearMonth.of(2023, 1)),
-                beløp =
-                    setOf(
-                        lagFeilBeløp(BigDecimal(feilutbetaling)),
-                        lagYtelBeløp(BigDecimal(feilutbetaling), BigDecimal(10)),
-                    ),
-            )
+        val periode = Testdata.lagKravgrunnlagsperiode(januar(2020) til januar(2023)).copy(
+            beløp = setOf(
+                lagFeilBeløp(BigDecimal(feilutbetaling)),
+                lagYtelBeløp(BigDecimal(feilutbetaling), BigDecimal(10)),
+            ),
+        )
 
         return Testdata.lagKravgrunnlag(Testdata.lagBehandling(Testdata.fagsak().id).id).copy(perioder = setOf(periode))
     }

--- a/src/test/kotlin/no/nav/tilbakekreving/Dato.kt
+++ b/src/test/kotlin/no/nav/tilbakekreving/Dato.kt
@@ -1,16 +1,53 @@
 package no.nav.tilbakekreving
 
 import java.time.LocalDate
+import java.time.Month
+import java.time.YearMonth
 
-val Int.januar: LocalDate get() = LocalDate.of(2018, 1, this)
-val Int.februar: LocalDate get() = LocalDate.of(2018, 2, this)
-val Int.mars: LocalDate get() = LocalDate.of(2018, 3, this)
-val Int.april: LocalDate get() = LocalDate.of(2018, 4, this)
-val Int.mai: LocalDate get() = LocalDate.of(2018, 5, this)
-val Int.juni: LocalDate get() = LocalDate.of(2018, 6, this)
-val Int.juli: LocalDate get() = LocalDate.of(2018, 7, this)
-val Int.august: LocalDate get() = LocalDate.of(2018, 8, this)
-val Int.september: LocalDate get() = LocalDate.of(2018, 9, this)
-val Int.oktober: LocalDate get() = LocalDate.of(2018, 10, this)
-val Int.november: LocalDate get() = LocalDate.of(2018, 11, this)
-val Int.desember: LocalDate get() = LocalDate.of(2018, 12, this)
+fun Int.januar(år: Int = 2018): LocalDate = LocalDate.of(år, 1, this)
+
+fun Int.februar(år: Int = 2018): LocalDate = LocalDate.of(år, 2, this)
+
+fun Int.mars(år: Int = 2018): LocalDate = LocalDate.of(år, 3, this)
+
+fun Int.april(år: Int = 2018): LocalDate = LocalDate.of(år, 4, this)
+
+fun Int.mai(år: Int = 2018): LocalDate = LocalDate.of(år, 5, this)
+
+fun Int.juni(år: Int = 2018): LocalDate = LocalDate.of(år, 6, this)
+
+fun Int.juli(år: Int = 2018): LocalDate = LocalDate.of(år, 7, this)
+
+fun Int.august(år: Int = 2018): LocalDate = LocalDate.of(år, 8, this)
+
+fun Int.september(år: Int = 2018): LocalDate = LocalDate.of(år, 9, this)
+
+fun Int.oktober(år: Int = 2018): LocalDate = LocalDate.of(år, 10, this)
+
+fun Int.november(år: Int = 2018): LocalDate = LocalDate.of(år, 11, this)
+
+fun Int.desember(år: Int = 2018): LocalDate = LocalDate.of(år, 12, this)
+
+fun januar(år: Int = 2018) = YearMonth.of(år, Month.JANUARY)
+
+fun februar(år: Int = 2018) = YearMonth.of(år, Month.FEBRUARY)
+
+fun mars(år: Int = 2018) = YearMonth.of(år, Month.MARCH)
+
+fun april(år: Int = 2018) = YearMonth.of(år, Month.APRIL)
+
+fun mai(år: Int = 2018) = YearMonth.of(år, Month.MAY)
+
+fun juni(år: Int = 2018) = YearMonth.of(år, Month.JUNE)
+
+fun juli(år: Int = 2018) = YearMonth.of(år, Month.JULY)
+
+fun august(år: Int = 2018) = YearMonth.of(år, Month.AUGUST)
+
+fun september(år: Int = 2018) = YearMonth.of(år, Month.SEPTEMBER)
+
+fun oktober(år: Int = 2018) = YearMonth.of(år, Month.OCTOBER)
+
+fun november(år: Int = 2018) = YearMonth.of(år, Month.NOVEMBER)
+
+fun desember(år: Int = 2018) = YearMonth.of(år, Month.DECEMBER)

--- a/src/test/kotlin/no/nav/tilbakekreving/kravgrunnlag/KravgrunnlagValidatorTest.kt
+++ b/src/test/kotlin/no/nav/tilbakekreving/kravgrunnlag/KravgrunnlagValidatorTest.kt
@@ -26,8 +26,8 @@ class KravgrunnlagValidatorTest {
         KravgrunnlagValidator.valider(
             kravgrunnlag = kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 31.januar).medStandardFeilutbetaling(),
-                    periode(1.februar til 28.februar).medStandardFeilutbetaling(),
+                    periode(1.januar() til 31.januar()).medStandardFeilutbetaling(),
+                    periode(1.februar() til 28.februar()).medStandardFeilutbetaling(),
                 ),
             ),
             periodeValidator = PeriodeValidator.MånedsperiodeValidator,
@@ -52,14 +52,14 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag = kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(periode = 1.januar til 28.februar).medStandardFeilutbetaling(),
-                    periode(periode = 1.mars til 30.april).medStandardFeilutbetaling(),
+                    periode(periode = 1.januar() til 28.februar()).medStandardFeilutbetaling(),
+                    periode(periode = 1.mars() til 30.april()).medStandardFeilutbetaling(),
                 ),
             ),
             periodeValidator = PeriodeValidator.MånedsperiodeValidator,
             forventetFeil = listOf(
-                "Perioden ${1.januar} til ${28.februar} er ikke innenfor samme kalendermåned",
-                "Perioden ${1.mars} til ${30.april} er ikke innenfor samme kalendermåned",
+                "Perioden ${1.januar()} til ${28.februar()} er ikke innenfor samme kalendermåned",
+                "Perioden ${1.mars()} til ${30.april()} er ikke innenfor samme kalendermåned",
             ),
         )
     }
@@ -69,13 +69,13 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag = kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 28.februar).medStandardFeilutbetaling(),
-                    periode(1.mars til 31.mars).medStandardFeilutbetaling(),
+                    periode(1.januar() til 28.februar()).medStandardFeilutbetaling(),
+                    periode(1.mars() til 31.mars()).medStandardFeilutbetaling(),
                 ),
             ),
             periodeValidator = PeriodeValidator.MånedsperiodeValidator,
             forventetFeil = listOf(
-                "Perioden ${1.januar} til ${28.februar} er ikke innenfor samme kalendermåned",
+                "Perioden ${1.januar()} til ${28.februar()} er ikke innenfor samme kalendermåned",
             ),
         )
     }
@@ -85,13 +85,13 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag = kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 27.februar).medStandardFeilutbetaling(),
+                    periode(1.januar() til 27.februar()).medStandardFeilutbetaling(),
                 ),
             ),
             periodeValidator = PeriodeValidator.MånedsperiodeValidator,
             forventetFeil = listOf(
-                "Perioden ${1.januar} til ${27.februar} er ikke innenfor samme kalendermåned",
-                "Perioden ${1.januar} til ${27.februar} slutter ikke siste dag i måned",
+                "Perioden ${1.januar()} til ${27.februar()} er ikke innenfor samme kalendermåned",
+                "Perioden ${1.januar()} til ${27.februar()} slutter ikke siste dag i måned",
             ),
         )
     }
@@ -101,13 +101,13 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 31.januar).medStandardFeilutbetaling(),
-                    periode(1.januar til 31.januar).medStandardFeilutbetaling(),
+                    periode(1.januar() til 31.januar()).medStandardFeilutbetaling(),
+                    periode(1.januar() til 31.januar()).medStandardFeilutbetaling(),
                 ),
             ),
             periodeValidator = PeriodeValidator.MånedsperiodeValidator,
             forventetFeil = listOf(
-                "Perioden ${1.januar} til ${31.januar} overlapper med perioden ${1.januar} til ${31.januar}",
+                "Perioden ${1.januar()} til ${31.januar()} overlapper med perioden ${1.januar()} til ${31.januar()}",
             ),
         )
     }
@@ -117,15 +117,15 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 31.januar).medStandardFeilutbetaling(),
-                    periode(30.januar til 28.februar).medStandardFeilutbetaling(),
+                    periode(1.januar() til 31.januar()).medStandardFeilutbetaling(),
+                    periode(30.januar() til 28.februar()).medStandardFeilutbetaling(),
                 ),
             ),
             periodeValidator = PeriodeValidator.MånedsperiodeValidator,
             forventetFeil = listOf(
-                "Perioden ${1.januar} til ${31.januar} overlapper med perioden ${30.januar} til ${28.februar}",
-                "Perioden ${30.januar} til ${28.februar} er ikke innenfor samme kalendermåned",
-                "Perioden ${30.januar} til ${28.februar} starter ikke første dag i måned",
+                "Perioden ${1.januar()} til ${31.januar()} overlapper med perioden ${30.januar()} til ${28.februar()}",
+                "Perioden ${30.januar()} til ${28.februar()} er ikke innenfor samme kalendermåned",
+                "Perioden ${30.januar()} til ${28.februar()} starter ikke første dag i måned",
             ),
         )
     }
@@ -135,14 +135,14 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 31.januar).medStandardFeilutbetaling(),
-                    periode(1.februar til 28.februar).medStandardFeilutbetaling(),
-                    periode(1.januar til 31.januar).medStandardFeilutbetaling(),
+                    periode(1.januar() til 31.januar()).medStandardFeilutbetaling(),
+                    periode(1.februar() til 28.februar()).medStandardFeilutbetaling(),
+                    periode(1.januar() til 31.januar()).medStandardFeilutbetaling(),
                 ),
             ),
             periodeValidator = PeriodeValidator.MånedsperiodeValidator,
             forventetFeil = listOf(
-                "Perioden ${1.januar} til ${31.januar} overlapper med perioden ${1.januar} til ${31.januar}",
+                "Perioden ${1.januar()} til ${31.januar()} overlapper med perioden ${1.januar()} til ${31.januar()}",
             ),
         )
     }
@@ -152,7 +152,7 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 31.januar, beløpSkattMåned = 299)
+                    periode(1.januar() til 31.januar(), beløpSkattMåned = 299)
                         .medStandardFeilutbetaling(
                             tilbakekreves = 3000,
                             skatteprosent = 10,
@@ -171,14 +171,14 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag = kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 31.januar)
+                    periode(1.januar() til 31.januar())
                         .medYtelsesutbetaling(),
                 ),
             ),
             periodeValidator = PeriodeValidator.MånedsperiodeValidator,
             forventetFeil = listOf(
-                "Perioden ${1.januar} til ${31.januar} mangler postering med klassetype=FEIL",
-                "Perioden ${1.januar} til ${31.januar} har ulikt summert tilbakekrevingsbeløp i YTEL postering(3000.00) i forhold til summert beløpNy i FEIL postering(0.00)",
+                "Perioden ${1.januar()} til ${31.januar()} mangler postering med klassetype=FEIL",
+                "Perioden ${1.januar()} til ${31.januar()} har ulikt summert tilbakekrevingsbeløp i YTEL postering(3000.00) i forhold til summert beløpNy i FEIL postering(0.00)",
             ),
         )
     }
@@ -188,7 +188,7 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag = kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 31.januar)
+                    periode(1.januar() til 31.januar())
                         .medFeilutbetaling(
                             skatteprosent = 10,
                             beløpTilbakekreves = 3000,
@@ -197,8 +197,8 @@ class KravgrunnlagValidatorTest {
             ),
             periodeValidator = PeriodeValidator.MånedsperiodeValidator,
             forventetFeil = listOf(
-                "Perioden ${1.januar} til ${31.januar} mangler postering med klassetype=YTEL",
-                "Perioden ${1.januar} til ${31.januar} har ulikt summert tilbakekrevingsbeløp i YTEL postering(0.00) i forhold til summert beløpNy i FEIL postering(3000.00)",
+                "Perioden ${1.januar()} til ${31.januar()} mangler postering med klassetype=YTEL",
+                "Perioden ${1.januar()} til ${31.januar()} har ulikt summert tilbakekrevingsbeløp i YTEL postering(0.00) i forhold til summert beløpNy i FEIL postering(3000.00)",
             ),
         )
     }
@@ -208,15 +208,15 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag = kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 31.januar)
+                    periode(1.januar() til 31.januar())
                         .medFeilutbetaling(beløpNy = -1)
                         .medYtelsesutbetaling(beløpNy = 27000, originaltBeløp = 30000, beløpTilbakekreves = 3000),
                 ),
             ),
             periodeValidator = PeriodeValidator.MånedsperiodeValidator,
             forventetFeil = listOf(
-                "Perioden ${1.januar} til ${31.januar} har feilpostering med negativt beløp",
-                "Perioden ${1.januar} til ${31.januar} har ulikt summert tilbakekrevingsbeløp i YTEL postering(3000.00) i forhold til summert beløpNy i FEIL postering(-1.00)",
+                "Perioden ${1.januar()} til ${31.januar()} har feilpostering med negativt beløp",
+                "Perioden ${1.januar()} til ${31.januar()} har ulikt summert tilbakekrevingsbeløp i YTEL postering(3000.00) i forhold til summert beløpNy i FEIL postering(-1.00)",
             ),
         )
     }
@@ -226,14 +226,14 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag = kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 31.januar)
+                    periode(1.januar() til 31.januar())
                         .medFeilutbetaling(beløpNy = 1400)
                         .medYtelsesutbetaling(
                             originaltBeløp = 30000,
                             beløpNy = 28500,
                             beløpTilbakekreves = 1500,
                         ),
-                    periode(1.februar til 28.februar)
+                    periode(1.februar() til 28.februar())
                         .medFeilutbetaling(beløpNy = 1300)
                         .medYtelsesutbetaling(
                             originaltBeløp = 30000,
@@ -244,8 +244,8 @@ class KravgrunnlagValidatorTest {
             ),
             periodeValidator = PeriodeValidator.MånedsperiodeValidator,
             forventetFeil = listOf(
-                "Perioden ${1.januar} til ${31.januar} har ulikt summert tilbakekrevingsbeløp i YTEL postering(1500.00) i forhold til summert beløpNy i FEIL postering(1400.00)",
-                "Perioden ${1.februar} til ${28.februar} har ulikt summert tilbakekrevingsbeløp i YTEL postering(1400.00) i forhold til summert beløpNy i FEIL postering(1300.00)",
+                "Perioden ${1.januar()} til ${31.januar()} har ulikt summert tilbakekrevingsbeløp i YTEL postering(1500.00) i forhold til summert beløpNy i FEIL postering(1400.00)",
+                "Perioden ${1.februar()} til ${28.februar()} har ulikt summert tilbakekrevingsbeløp i YTEL postering(1400.00) i forhold til summert beløpNy i FEIL postering(1300.00)",
             ),
         )
     }
@@ -255,7 +255,7 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag = kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 31.januar)
+                    periode(1.januar() til 31.januar())
                         .medFeilutbetaling(
                             beløpNy = 3000,
                         )
@@ -266,7 +266,7 @@ class KravgrunnlagValidatorTest {
             ),
             periodeValidator = PeriodeValidator.MånedsperiodeValidator,
             forventetFeil = listOf(
-                "Perioden ${1.januar} til ${31.januar} har ulikt summert tilbakekrevingsbeløp i YTEL postering(2900.00) " +
+                "Perioden ${1.januar()} til ${31.januar()} har ulikt summert tilbakekrevingsbeløp i YTEL postering(2900.00) " +
                     "i forhold til summert beløpNy i FEIL postering(3000.00)",
             ),
         )
@@ -277,7 +277,7 @@ class KravgrunnlagValidatorTest {
         assertFeil(
             kravgrunnlag = kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 31.januar)
+                    periode(1.januar() til 31.januar())
                         .medFeilutbetaling(beløpNy = 3100)
                         .medYtelsesutbetaling(beløpTilbakekreves = 3100),
                 ),
@@ -294,13 +294,13 @@ class KravgrunnlagValidatorTest {
         KravgrunnlagValidator.valider(
             kravgrunnlag = kravgrunnlag(
                 tilbakekrevingsperioder = listOf(
-                    periode(1.januar til 31.januar)
+                    periode(1.januar() til 31.januar())
                         .medFeilutbetaling(beløpNy = 3100)
                         .medYtelsesutbetaling(beløpTilbakekreves = 3100),
-                    periode(1.februar til 28.februar)
+                    periode(1.februar() til 28.februar())
                         .medFeilutbetaling(beløpNy = 3100)
                         .medYtelsesutbetaling(beløpTilbakekreves = 3100),
-                    periode(1.mars til 31.mars)
+                    periode(1.mars() til 31.mars())
                         .medFeilutbetaling(beløpNy = 2900)
                         .medYtelsesutbetaling(beløpTilbakekreves = 2900),
                 ),
@@ -329,7 +329,7 @@ class KravgrunnlagValidatorTest {
     private fun kravgrunnlag(
         referanse: String? = UUID.randomUUID().toString(),
         tilbakekrevingsperioder: List<DetaljertKravgrunnlagPeriodeDto> = listOf(
-            periode(1.januar til 31.januar).medStandardFeilutbetaling(),
+            periode(1.januar() til 31.januar()).medStandardFeilutbetaling(),
         ),
     ) = DetaljertKravgrunnlagDto().apply {
         this.kravgrunnlagId = BigInteger.ZERO

--- a/src/test/kotlin/no/nav/tilbakekreving/kravgrunnlag/MånedsperiodeValidatorTest.kt
+++ b/src/test/kotlin/no/nav/tilbakekreving/kravgrunnlag/MånedsperiodeValidatorTest.kt
@@ -13,9 +13,9 @@ class MånedsperiodeValidatorTest {
     @Test
     fun `månedsvalidator, flere ulike måneder`() {
         assertFeil(
-            periode = 1.januar til 28.februar,
+            periode = 1.januar() til 28.februar(),
             forventetFeilmeldinger = listOf(
-                "Perioden ${1.januar} til ${28.februar} er ikke innenfor samme kalendermåned",
+                "Perioden ${1.januar()} til ${28.februar()} er ikke innenfor samme kalendermåned",
             ),
         )
     }
@@ -23,16 +23,16 @@ class MånedsperiodeValidatorTest {
     @Test
     fun `starter ikke første dag i måned`() {
         assertFeil(
-            periode = 2.januar til 31.januar,
-            forventetFeilmeldinger = listOf("Perioden ${2.januar} til ${31.januar} starter ikke første dag i måned"),
+            periode = 2.januar() til 31.januar(),
+            forventetFeilmeldinger = listOf("Perioden ${2.januar()} til ${31.januar()} starter ikke første dag i måned"),
         )
     }
 
     @Test
     fun `slutter ikke siste dag i måned`() {
         assertFeil(
-            periode = 1.januar til 30.januar,
-            forventetFeilmeldinger = listOf("Perioden ${1.januar} til ${30.januar} slutter ikke siste dag i måned"),
+            periode = 1.januar() til 30.januar(),
+            forventetFeilmeldinger = listOf("Perioden ${1.januar()} til ${30.januar()} slutter ikke siste dag i måned"),
         )
     }
 


### PR DESCRIPTION
Tidligere har tester i VedtaksbrevServiceTest hatt ulike datoer for vurdering og kravgrunnlag. Det gir lite mening og fører til vedtaksbrev som ikke matcher reelle tillfeller