### PR TITLE
Unngå unødvendig splitting av perioder med vurdert foreldelse

### DIFF
--- a/modell/src/main/kotlin/no/nav/tilbakekreving/beregning/Beregning.kt
+++ b/modell/src/main/kotlin/no/nav/tilbakekreving/beregning/Beregning.kt
@@ -34,7 +34,7 @@ class Beregning(
     private val foreldet = foreldetPerioder.flatMap { foreldetPeriode ->
         kravgrunnlag.perioder()
             .filter { it.periode() in foreldetPeriode }
-            .map { Foreldet.opprett(it.periode(), it) }
+            .map { Foreldet.opprett(foreldetPeriode, it) }
     }
     private val vilkårsvurdert = vilkårsvurdering.perioder().flatMap { vurdering ->
         val kgPerioder = kravgrunnlag.perioder()

--- a/modell/src/main/kotlin/no/nav/tilbakekreving/beregning/delperiode/Foreldet.kt
+++ b/modell/src/main/kotlin/no/nav/tilbakekreving/beregning/delperiode/Foreldet.kt
@@ -38,13 +38,13 @@ class Foreldet(
 
     companion object {
         fun opprett(
-            periode: Datoperiode,
+            vurdertPeriode: Datoperiode,
             kravgrunnlagPeriode: KravgrunnlagPeriodeAdapter,
         ): Foreldet {
-            val delperiode = requireNotNull(kravgrunnlagPeriode.periode().snitt(periode)) {
-                "Finner ingen kravgrunnlagsperiode som er dekket av foreldelsesperioden $periode, kravgrunnlagsperiode=${kravgrunnlagPeriode.periode()}"
+            val delperiode = requireNotNull(kravgrunnlagPeriode.periode().snitt(vurdertPeriode)) {
+                "Finner ingen kravgrunnlagsperiode som er dekket av foreldelsesperioden $vurdertPeriode, kravgrunnlagsperiode=${kravgrunnlagPeriode.periode()}"
             }
-            return Foreldet(delperiode, periode, Andel(kravgrunnlagPeriode, delperiode))
+            return Foreldet(delperiode, vurdertPeriode, Andel(kravgrunnlagPeriode, delperiode))
         }
     }
 }

--- a/modell/src/test/kotlin/no/nav/tilbakekreving/beregning/BeregningTest.kt
+++ b/modell/src/test/kotlin/no/nav/tilbakekreving/beregning/BeregningTest.kt
@@ -490,6 +490,64 @@ class BeregningTest {
         )
     }
 
+    @Test
+    fun `sammenslåing av perioder som er foreldet`() {
+        val beregning = Beregning(
+            beregnRenter = true,
+            tilbakekrevLavtBeløp = false,
+            vilkårsvurdering = vurdering(),
+            foreldetPerioder = listOf(
+                1.januar til 28.februar,
+            ),
+            kravgrunnlag = perioder(
+                1.januar til 31.januar medTilbakekrevesBeløp 2000.kroner,
+                1.februar til 28.februar medTilbakekrevesBeløp 2000.kroner,
+            ),
+        )
+
+        val delperioder = beregning.beregn()
+        delperioder.size shouldBe 2
+        delperioder[0].shouldMatch(
+            periode = 1.januar til 31.januar,
+            renter = 0.kroner,
+            tilbakekrevesBrutto = 0.kroner,
+            tilbakekrevesBruttoMedRenter = 0.kroner,
+            skatt = 0.kroner,
+            utbetaltYtelsesbeløp = 20000.kroner,
+            feilutbetaltBeløp = 2000.kroner,
+        )
+        delperioder[1].shouldMatch(
+            periode = 1.februar til 28.februar,
+            renter = 0.kroner,
+            tilbakekrevesBrutto = 0.kroner,
+            tilbakekrevesBruttoMedRenter = 0.kroner,
+            skatt = 0.kroner,
+            utbetaltYtelsesbeløp = 20000.kroner,
+            feilutbetaltBeløp = 2000.kroner,
+        )
+
+        beregning.oppsummer() shouldBe Beregningsresultat(
+            beregningsresultatsperioder = listOf(
+                Beregningsresultatsperiode(
+                    periode = 1.januar til 28.februar,
+                    vurdering = AnnenVurdering.FORELDET,
+                    feilutbetaltBeløp = 4000.kroner,
+                    andelAvBeløp = 0.prosent,
+                    renteprosent = null,
+                    manueltSattTilbakekrevingsbeløp = null,
+                    tilbakekrevingsbeløpUtenRenter = 0.kroner,
+                    rentebeløp = 0.kroner,
+                    tilbakekrevingsbeløp = 0.kroner,
+                    skattebeløp = 0.kroner,
+                    tilbakekrevingsbeløpEtterSkatt = 0.kroner,
+                    utbetaltYtelsesbeløp = 40000.kroner,
+                    riktigYtelsesbeløp = 36000.kroner,
+                ),
+            ),
+            vedtaksresultat = Vedtaksresultat.INGEN_TILBAKEBETALING,
+        )
+    }
+
     fun perioder(
         vararg perioder: TestKravgrunnlagPeriode,
     ) = object : KravgrunnlagAdapter {

--- a/modell/src/test/kotlin/no/nav/tilbakekreving/beregning/delperiode/DelperiodeTest.kt
+++ b/modell/src/test/kotlin/no/nav/tilbakekreving/beregning/delperiode/DelperiodeTest.kt
@@ -1,0 +1,66 @@
+package no.nav.tilbakekreving.beregning.delperiode
+
+import io.kotest.matchers.shouldBe
+import no.nav.tilbakekreving.beregning.BeregningTest.TestKravgrunnlagPeriode.Companion.kroner
+import no.nav.tilbakekreving.beregning.adapter.KravgrunnlagPeriodeAdapter
+import no.nav.tilbakekreving.beregning.delperiode.Delperiode.Companion.oppsummer
+import no.nav.tilbakekreving.beregning.modell.Beregningsresultatsperiode
+import no.nav.tilbakekreving.februar
+import no.nav.tilbakekreving.januar
+import no.nav.tilbakekreving.kontrakter.periode.Datoperiode
+import no.nav.tilbakekreving.kontrakter.periode.til
+import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.AnnenVurdering
+import no.nav.tilbakekreving.mars
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class DelperiodeTest {
+    @Test
+    fun `slår sammen foreldet perioder`() {
+        val foreldelsesperiode = 1.januar til 31.mars
+        val foreldelser = listOf(
+            Foreldet.opprett(
+                foreldelsesperiode,
+                KravgrunnlagPeriode(1.januar til 31.januar),
+            ),
+            Foreldet.opprett(
+                foreldelsesperiode,
+                KravgrunnlagPeriode(1.februar til 28.februar),
+            ),
+            Foreldet.opprett(
+                foreldelsesperiode,
+                KravgrunnlagPeriode(1.mars til 31.mars),
+            ),
+        )
+
+        foreldelser.oppsummer() shouldBe listOf(
+            Beregningsresultatsperiode(
+                periode = foreldelsesperiode,
+                vurdering = AnnenVurdering.FORELDET,
+                feilutbetaltBeløp = 6000.kroner,
+                andelAvBeløp = 0.kroner,
+                renteprosent = null,
+                manueltSattTilbakekrevingsbeløp = null,
+                tilbakekrevingsbeløpUtenRenter = 0.kroner,
+                rentebeløp = 0.kroner,
+                tilbakekrevingsbeløp = 0.kroner,
+                skattebeløp = 0.kroner,
+                tilbakekrevingsbeløpEtterSkatt = 0.kroner,
+                utbetaltYtelsesbeløp = 60000.kroner,
+                riktigYtelsesbeløp = 54000.kroner,
+            ),
+        )
+    }
+
+    class KravgrunnlagPeriode(private val periode: Datoperiode) : KravgrunnlagPeriodeAdapter {
+        override fun periode(): Datoperiode = periode
+
+        override fun feilutbetaltYtelsesbeløp(): BigDecimal = 2000.kroner
+
+        override fun utbetaltYtelsesbeløp(): BigDecimal = 20000.kroner
+
+        override fun riktigYteslesbeløp(): BigDecimal = 18000.kroner
+
+        override fun beløpTilbakekreves(): List<KravgrunnlagPeriodeAdapter.BeløpTilbakekreves> = emptyList()
+    }
+}


### PR DESCRIPTION
Før fikk hver kravgrunnlagsperiode ulik dato for vurdert foreldelse. Dette gjorde at vi ikke klarte å slå sammen igjen periodenene for oppsummeringen. Denne endringen fører til at vedtaksoppsummering i vedtaksløsning og vedtaksbrev vises som en sammenhengende periode