### PR TITLE
Legger til guard clause så vi ikke iverksetter vedtak med feil beløp

### DIFF
--- a/modell/src/main/kotlin/no/nav/tilbakekreving/beregning/Beregning.kt
+++ b/modell/src/main/kotlin/no/nav/tilbakekreving/beregning/Beregning.kt
@@ -45,7 +45,10 @@ class Beregning(
 
     private val fordelt: List<Delperiode> = (foreldet + vilkårsvurdert).sortedBy { it.periode.fom }
 
-    fun beregn(): List<Delperiode> {
+    fun beregn(validerPerioder: Boolean = true): List<Delperiode> {
+        if (validerPerioder) {
+            fordelt.filterIsInstance<Vilkårsvurdert>().forEach { it.validerIkkeManueltBeløpOgUlikeKlassekoder() }
+        }
         return fordelt
             .fordelTilbakekrevingsbeløp()
             .fordelRentebeløp()
@@ -53,7 +56,7 @@ class Beregning(
     }
 
     fun oppsummer(): Beregningsresultat {
-        val delperioder = beregn()
+        val delperioder = beregn(validerPerioder = false)
         val beregningsresultater = delperioder.oppsummer()
         return Beregningsresultat(
             vedtaksresultat = bestemVedtaksresultat(delperioder),

--- a/modell/src/main/kotlin/no/nav/tilbakekreving/beregning/delperiode/Vilkårsvurdert.kt
+++ b/modell/src/main/kotlin/no/nav/tilbakekreving/beregning/delperiode/Vilkårsvurdert.kt
@@ -35,6 +35,12 @@ class Vilkårsvurdert(
 
     override fun feilutbetaltBeløp(): BigDecimal = kravgrunnlagPeriode.feilutbetaltYtelsesbeløp().setScale(0, RoundingMode.HALF_UP)
 
+    fun validerIkkeManueltBeløpOgUlikeKlassekoder() {
+        if (vurdering.reduksjon() is Reduksjon.ManueltBeløp && beløp.size > 1) {
+            throw RuntimeException("Fant periode med manuelt satt tilbakekrevingsbeløp og flere beløp i perioden. Denne koden har nå en bug som må fikses.")
+        }
+    }
+
     override fun beregningsresultat(): Beregningsresultatsperiode {
         return Beregningsresultatsperiode(
             periode = periode,

--- a/modell/src/test/kotlin/no/nav/tilbakekreving/beregning/BeregningTest.kt
+++ b/modell/src/test/kotlin/no/nav/tilbakekreving/beregning/BeregningTest.kt
@@ -1,5 +1,7 @@
 package no.nav.tilbakekreving.beregning
 
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import no.nav.tilbakekreving.behandling.saksbehandling.Vilkårsvurderingsteg
@@ -638,6 +640,47 @@ class BeregningTest {
             ),
             vedtaksresultat = Vedtaksresultat.DELVIS_TILBAKEBETALING,
         )
+    }
+
+    @Test
+    fun `fordeler manuelt satt beløp ut i fra relativ størrelse på tilbakekrevingsbeløp i periode`() {
+        val beregning = Beregning(
+            beregnRenter = true,
+            tilbakekrevLavtBeløp = false,
+            vilkårsvurdering = vurdering(
+                1.januar til 28.februar godTro medBeløpIBehold(4000.kroner),
+            ),
+            foreldetPerioder = emptyList(),
+            kravgrunnlag = perioder(
+                1.januar til 31.januar medBeløp beløp(tilbakekrevesBeløp = 4000.kroner, originaltUtbetaltBeløp = 10000.kroner, klassekode = "BATR"),
+                1.februar til 28.februar medBeløp beløp(tilbakekrevesBeløp = 4000.kroner, originaltUtbetaltBeløp = 10000.kroner, klassekode = "BATR")
+                    medBeløp beløp(2000.kroner, originaltUtbetaltBeløp = 10000.kroner, klassekode = "BAUTV-OP"),
+            ),
+        )
+
+        shouldNotThrow<Throwable> { beregning.oppsummer() }
+        shouldThrow<RuntimeException> { beregning.beregn() }
+        // TODO: Oppsummeringen under er riktig, men koden beregner seg frem til feil beløp.
+//        beregning.oppsummer() shouldBe Beregningsresultat(
+//            beregningsresultatsperioder = listOf(
+//                Beregningsresultatsperiode(
+//                    periode = 1.januar til 28.februar,
+//                    vurdering = AnnenVurdering.GOD_TRO,
+//                    feilutbetaltBeløp = 10000.kroner,
+//                    andelAvBeløp = null,
+//                    renteprosent = null,
+//                    manueltSattTilbakekrevingsbeløp = 4000.kroner,
+//                    tilbakekrevingsbeløpUtenRenter = 4000.kroner,
+//                    rentebeløp = 0.kroner,
+//                    tilbakekrevingsbeløp = 4000.kroner,
+//                    skattebeløp = 0.kroner,
+//                    tilbakekrevingsbeløpEtterSkatt = 4000.kroner,
+//                    utbetaltYtelsesbeløp = 30000.kroner,
+//                    riktigYtelsesbeløp = 20000.kroner,
+//                ),
+//            ),
+//            vedtaksresultat = Vedtaksresultat.DELVIS_TILBAKEBETALING,
+//        )
     }
 
     fun perioder(


### PR DESCRIPTION
Dersom en periode har flere klassekoder og manuelt satt beløp vil hvert beløp i perioden få satt beløpet. Dersom det er to beløp vil derfor beløpet dobbles.