### PR TITLE
Ikke sett tilordnetRessurs ved opprettelse av manuell oppgave

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask.kt
@@ -46,7 +46,7 @@ class FerdigstillEksisterendeOppgaverOgOpprettNyBehandleSakOppgaveTask(
             enhet = behandling.behandlendeEnhet,
             beskrivelse = payload.beskrivelse,
             fristForFerdigstillelse = payload.frist,
-            saksbehandler = behandling.ansvarligSaksbehandler,
+            saksbehandler = null,
             prioritet = prioritet,
             logContext = logContext,
         )


### PR DESCRIPTION
I tilfeller hvor ansvarlig saksbehandler ikke er medlem av den behandlende enheten har vi ikke mulighet til å manuelt opprette en oppgave. Dette er fordi den automatisk prøver å opprette en ny oppgave for en enhet saksbehandleren ikke har tilgang til