### PR TITLE
Manuell workaround for å opprette oppgave uten tilordnet saksbehandler

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/oppgave/OppgaveService.kt
@@ -149,7 +149,7 @@ class OppgaveService(
                         beskrivelse,
                     ),
                 enhetsnummer = behandling.behandlendeEnhet,
-                tilordnetRessurs = saksbehandler,
+                tilordnetRessurs = if (behandling.id.toString() == "0b9ceb97-0a34-45c3-a84a-9cab635840e4") null else saksbehandler,
                 behandlingstype = Behandlingstype.Tilbakekreving.value,
                 behandlingstema = null,
                 mappeId = finnAktuellMappe(enhet, oppgavetype, logContext),


### PR DESCRIPTION
Gjør så vi kan få opprettet en oppgave for en enkeltsak som er i en ødelagt tilstand. Saksbehandler som skal tilordnes oppgaven har ikke tilgang til enheten vi prøver å opprette oppgaven på, så vi oppretter en oppgave uten tilordnet saksbehandler, så kan vi i ettertid bytte enhet.