### PR TITLE
Feilmelding ved uferdige periodevurderinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/api/BeregningController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/BeregningController.kt
@@ -12,7 +12,6 @@ import no.nav.tilbakekreving.TilbakekrevingService
 import no.nav.tilbakekreving.api.v1.dto.BeregnetPerioderDto
 import no.nav.tilbakekreving.api.v1.dto.BeregningsresultatDto
 import no.nav.tilbakekreving.kontrakter.periode.Datoperiode
-import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -32,8 +31,6 @@ class BeregningController(
     private val tilgangskontrollService: TilgangskontrollService,
     private val tilbakekrevingService: TilbakekrevingService,
 ) {
-    private val logger = LoggerFactory.getLogger(this::class.java)
-
     @Operation(summary = "Beregn feilutbetalt beløp for nye delte perioder")
     @PostMapping(
         path = ["{behandlingId}/beregn/v1"],
@@ -91,7 +88,6 @@ class BeregningController(
             auditLoggerEvent = AuditLoggerEvent.ACCESS,
             handling = "Henter beregningsresultat",
         )
-        logger.info("======>>>> Controller hent beregningsresultat: $behandlingId")
         return Ressurs.success(tilbakekrevingsberegningService.hentBeregningsresultat(behandlingId))
     }
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/api/BeregningController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/BeregningController.kt
@@ -12,6 +12,7 @@ import no.nav.tilbakekreving.TilbakekrevingService
 import no.nav.tilbakekreving.api.v1.dto.BeregnetPerioderDto
 import no.nav.tilbakekreving.api.v1.dto.BeregningsresultatDto
 import no.nav.tilbakekreving.kontrakter.periode.Datoperiode
+import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -31,6 +32,8 @@ class BeregningController(
     private val tilgangskontrollService: TilgangskontrollService,
     private val tilbakekrevingService: TilbakekrevingService,
 ) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
     @Operation(summary = "Beregn feilutbetalt beløp for nye delte perioder")
     @PostMapping(
         path = ["{behandlingId}/beregn/v1"],
@@ -88,6 +91,7 @@ class BeregningController(
             auditLoggerEvent = AuditLoggerEvent.ACCESS,
             handling = "Henter beregningsresultat",
         )
+        logger.info("======>>>> Controller hent beregningsresultat: $behandlingId")
         return Ressurs.success(tilbakekrevingsberegningService.hentBeregningsresultat(behandlingId))
     }
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/beregning/GammelVilkårsvurderingAdapter.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/beregning/GammelVilkårsvurderingAdapter.kt
@@ -1,13 +1,15 @@
 package no.nav.familie.tilbake.beregning
 
+import no.nav.familie.tilbake.log.SecureLog
 import no.nav.familie.tilbake.vilkårsvurdering.domain.Vilkårsvurdering
 import no.nav.tilbakekreving.beregning.adapter.VilkårsvurderingAdapter
 import no.nav.tilbakekreving.beregning.adapter.VilkårsvurdertPeriodeAdapter
 
 class GammelVilkårsvurderingAdapter(
     private val vilkårsvurdering: Vilkårsvurdering?,
+    private val logContext: SecureLog.Context,
 ) : VilkårsvurderingAdapter {
     override fun perioder(): Set<VilkårsvurdertPeriodeAdapter> {
-        return vilkårsvurdering?.perioder?.map(::VilkårsvurderingsperiodeAdapter)?.toSet() ?: emptySet()
+        return vilkårsvurdering?.perioder?.map { VilkårsvurderingsperiodeAdapter(it, logContext) }?.toSet() ?: emptySet()
     }
 }

--- a/src/main/kotlin/no/nav/familie/tilbake/beregning/VilkårsvurderingsperiodeAdapter.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/beregning/VilkårsvurderingsperiodeAdapter.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.tilbake.beregning
 
+import no.nav.familie.tilbake.common.exceptionhandler.Feil
+import no.nav.familie.tilbake.log.SecureLog
 import no.nav.familie.tilbake.vilkårsvurdering.domain.VilkårsvurderingAktsomhet
 import no.nav.familie.tilbake.vilkårsvurdering.domain.Vilkårsvurderingsperiode
 import no.nav.tilbakekreving.beregning.Reduksjon
@@ -9,7 +11,10 @@ import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.Aktsomhet
 import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.AnnenVurdering
 import no.nav.tilbakekreving.kontrakter.vilkårsvurdering.Vurdering
 
-class VilkårsvurderingsperiodeAdapter(private val vurdering: Vilkårsvurderingsperiode) : VilkårsvurdertPeriodeAdapter {
+class VilkårsvurderingsperiodeAdapter(
+    private val vurdering: Vilkårsvurderingsperiode,
+    private val logContext: SecureLog.Context,
+) : VilkårsvurdertPeriodeAdapter {
     override fun periode(): Datoperiode {
         return vurdering.periode.toDatoperiode()
     }
@@ -28,11 +33,11 @@ class VilkårsvurderingsperiodeAdapter(private val vurdering: Vilkårsvurderings
             }
             vurdering.godTro != null -> {
                 when (vurdering.godTro.beløpErIBehold) {
-                    true -> Reduksjon.ManueltBeløp(vurdering.godTro.beløpTilbakekreves ?: error("Beløp er i behold, men beløp som skal tilbakekreves er ikke satt."))
+                    true -> Reduksjon.ManueltBeløp(vurdering.godTro.beløpTilbakekreves ?: throw Feil(logContext = logContext, message = "Beløp er i behold, men beløp som skal tilbakekreves er ikke satt. Gjelder periode fra ${periode().fom} til ${periode().tom}", frontendFeilmelding = "Beløp er i behold, men beløp som skal tilbakekreves er ikke satt. Gjelder periode fra ${periode().fom} til ${periode().tom}"))
                     false -> Reduksjon.IngenTilbakekreving()
                 }
             }
-            else -> error("Vurdering mangler vurdering av aktsomhet og god tro. Kan ikke beregne reduksjon.")
+            else -> throw Feil(logContext = logContext, message = "Vurdering mangler vurdering av aktsomhet og god tro. Kan ikke beregne reduksjon. Gjelder periode fra ${periode().fom} til ${periode().tom}", frontendFeilmelding = "Vurdering mangler vurdering av aktsomhet og god tro. Kan ikke beregne reduksjon. Gjelder periode fra ${periode().fom} til ${periode().tom}")
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/tilbake/beregning/TilbakekrevingsberegningVilkårTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/beregning/TilbakekrevingsberegningVilkårTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.tilbake.beregning
 
+import no.nav.familie.tilbake.log.SecureLog
 import no.nav.familie.tilbake.vilkårsvurdering.domain.VilkårsvurderingAktsomhet
 import no.nav.familie.tilbake.vilkårsvurdering.domain.VilkårsvurderingGodTro
 import no.nav.familie.tilbake.vilkårsvurdering.domain.Vilkårsvurderingsperiode
@@ -527,7 +528,7 @@ class TilbakekrevingsberegningVilkårTest {
         tilbakekrevingsbeløp: BigDecimal = BigDecimal.valueOf(10000),
     ): Beregningsresultatsperiode {
         return Vilkårsvurdert.opprett(
-            VilkårsvurderingsperiodeAdapter(vurdering = vilkårVurdering),
+            VilkårsvurderingsperiodeAdapter(logContext = SecureLog.Context.tom(), vurdering = vilkårVurdering),
             listOf(
                 object : KravgrunnlagPeriodeAdapter {
                     override fun periode(): Datoperiode = vilkårVurdering.periode.toDatoperiode()


### PR DESCRIPTION
Sender logContext videre til VilkårsvurderingsperiodeAdapter for å sende riktig feilmelding til frontend.