### PR TITLE
Fikser i skrivefeil i `behandling_endret`-event

### DIFF
--- a/kontrakter-fagsystem/src/main/kotlin/no/nav/tilbakekreving/fagsystem/events/VenterEventDto.kt
+++ b/kontrakter-fagsystem/src/main/kotlin/no/nav/tilbakekreving/fagsystem/events/VenterEventDto.kt
@@ -5,4 +5,5 @@ import java.time.LocalDate
 data class VenterEventDto(
     val grunn: VentegrunnEventDto,
     val gjennoptas: LocalDate,
+    val gjenopptas: LocalDate,
 )

--- a/src/main/kotlin/no/nav/tilbakekreving/endring/EndringObservatørService.kt
+++ b/src/main/kotlin/no/nav/tilbakekreving/endring/EndringObservatørService.kt
@@ -111,6 +111,7 @@ class EndringObservatørService(
                                 Venter.Grunn.BRUKERUTTALELSE -> VentegrunnEventDto.AVVENTER_BRUKERUTTALELSE
                             },
                             gjennoptas = it.frist,
+                            gjenopptas = it.frist,
                         )
                     },
                     varselSendt = behandlingEndret.varselSendt,


### PR DESCRIPTION
Legger på gjenopptas i tillegg til skrivefeilen for å ikke brekke kompatibilitet