### PR TITLE
Bruk periode og beløp fra varsel i bigquery ved opprettelse av sak

### DIFF
--- a/src/main/kotlin/no/nav/familie/tilbake/api/baks/BAKSPorteføljejusteringController.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/api/baks/BAKSPorteføljejusteringController.kt
@@ -63,7 +63,7 @@ class BAKSPorteføljejusteringController(
                 behandlendeEnhetsNavn = nyEnhet.navn,
             ),
         )
-        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null)
+        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null, null)
 
         historikkService.lagHistorikkinnslag(
             behandlingId = behandling.id,

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingService.kt
@@ -186,7 +186,7 @@ class BehandlingService(
         val revurdering =
             BehandlingMapper.tilDomeneBehandlingRevurdering(originalBehandling, opprettRevurderingDto.årsakstype, logContext)
         behandlingRepository.insert(revurdering)
-        bigQueryAdapterService.oppdaterBigQuery(revurdering, null)
+        bigQueryAdapterService.oppdaterBigQuery(revurdering, null, null)
 
         val fagsystem = FagsystemUtil.hentFagsystemFraYtelsestype(opprettRevurderingDto.ytelsestype)
         historikkService.lagHistorikkinnslag(
@@ -383,7 +383,7 @@ class BehandlingService(
                 avsluttetDato = LocalDate.now(),
             ),
         )
-        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null)
+        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null, null)
 
         oppdaterAnsvarligSaksbehandler(behandlingId)
         behandlingTilstandService.opprettSendingAvBehandlingenHenlagt(behandlingId, logContext)
@@ -520,7 +520,7 @@ class BehandlingService(
                 behandlendeEnhetsNavn = enhet.navn,
             ),
         )
-        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null)
+        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null, null)
         oppdaterAnsvarligSaksbehandler(behandlingId)
 
         historikkService.lagHistorikkinnslag(
@@ -565,7 +565,7 @@ class BehandlingService(
                 avsluttetDato = LocalDate.now(),
             ),
         )
-        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null)
+        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null, null)
 
         behandlingskontrollService
             .oppdaterBehandlingsstegStatus(
@@ -676,7 +676,7 @@ class BehandlingService(
                 erAutomatiskOgFeatureTogglePå,
             )
         behandlingRepository.insert(behandling)
-        bigQueryAdapterService.oppdaterBigQuery(behandling, null)
+        bigQueryAdapterService.oppdaterBigQuery(behandling, null, opprettTilbakekrevingRequest.varsel)
         return behandling
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingsvedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/BehandlingsvedtakService.kt
@@ -40,7 +40,7 @@ class BehandlingsvedtakService(
                 behandlingsvedtak = behandlingsvedtak,
             )
         val oppdatertBehandling = behandlingRepository.update(behandling.copy(resultater = setOf(behandlingsresultat)))
-        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null)
+        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null, null)
 
         tellerService.tellVedtak(behandlingsresultatstype, behandling)
     }
@@ -58,7 +58,7 @@ class BehandlingsvedtakService(
             aktivBehandlingsresultat
                 .copy(behandlingsvedtak = behandlingsvedtak.copy(iverksettingsstatus = iverksettingsstatus))
         val oppdatertBehandling = behandlingRepository.update(behandling.copy(resultater = setOf(oppdatertBehandlingsresultat)))
-        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null)
+        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null, null)
         return oppdatertBehandling
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreldelsessteg.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandling/steg/Foreldelsessteg.kt
@@ -78,7 +78,7 @@ class Foreldelsessteg(
         foreldelseService.lagreVurdertForeldelse(behandlingId, (behandlingsstegDto as BehandlingsstegForeldelseDto), logContext)
         val harTilleggsfrist = behandlingsstegDto.foreldetPerioder
             .any { it.foreldelsesvurderingstype == Foreldelsesvurderingstype.TILLEGGSFRIST }
-        bigQueryAdapterService.oppdaterBigQuery(behandlingRepository.findByIdOrThrow(behandlingId), harTilleggsfrist)
+        bigQueryAdapterService.oppdaterBigQuery(behandlingRepository.findByIdOrThrow(behandlingId), harTilleggsfrist, null)
 
         oppgaveTaskService.oppdaterAnsvarligSaksbehandlerOppgaveTask(behandlingId, logContext)
 

--- a/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/behandlingskontroll/BehandlingskontrollService.kt
@@ -482,7 +482,7 @@ class BehandlingskontrollService(
         // Oppdaterer tilsvarende behandlingsstatus bortsett fra Avsluttet steg. Det håndteres separat av AvsluttBehandlingTask
         if (Behandlingssteg.AVSLUTTET != behandlingssteg) {
             val oppdatertBehandling = behandlingRepository.update(behandling.copy(status = behandlingssteg.behandlingsstatus))
-            bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null)
+            bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null, null)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/tilbake/bigQuery/BigQueryAdapterService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/bigQuery/BigQueryAdapterService.kt
@@ -5,6 +5,8 @@ import no.nav.familie.tilbake.behandling.domain.Behandling
 import no.nav.familie.tilbake.kravgrunnlag.KravgrunnlagRepository
 import no.nav.tilbakekreving.api.v1.dto.BigQueryBehandlingDataDto
 import no.nav.tilbakekreving.bigquery.BigQueryService
+import no.nav.tilbakekreving.kontrakter.Varsel
+import no.nav.tilbakekreving.kontrakter.periode.til
 import org.springframework.stereotype.Service
 
 @Service
@@ -16,6 +18,7 @@ class BigQueryAdapterService(
     fun oppdaterBigQuery(
         behandling: Behandling,
         harTilleggsfrist: Boolean?,
+        varsel: Varsel?,
     ) {
         val kravgrunnlag = kravgrunnlagRepository.findByBehandlingId(behandling.id).lastOrNull()
         val ytelsestype = fagsakService.finnFagsystemForBehandlingId(behandling.id).navn
@@ -23,10 +26,10 @@ class BigQueryAdapterService(
             BigQueryBehandlingDataDto(
                 behandlingId = behandling.id.toString(),
                 opprettetDato = behandling.opprettetTidspunkt,
-                periode = kravgrunnlag?.samletPeriode(),
+                periode = kravgrunnlag?.samletPeriode() ?: varsel?.perioder?.let { periode -> periode.minOf { it.fom } til periode.maxOf { it.tom } },
                 behandlingstype = behandling.type.name,
                 ytelse = ytelsestype,
-                beløp = kravgrunnlag?.sumFeilutbetaling()?.toLong(),
+                beløp = kravgrunnlag?.sumFeilutbetaling()?.toLong() ?: varsel?.sumFeilutbetaling?.toLong(),
                 enhetNavn = behandling.behandlendeEnhetsNavn,
                 enhetKode = behandling.behandlendeEnhet,
                 status = behandling.status.name,

--- a/src/main/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningService.kt
+++ b/src/main/kotlin/no/nav/familie/tilbake/forvaltning/ForvaltningService.kt
@@ -192,7 +192,7 @@ class ForvaltningService(
                 avsluttetDato = LocalDate.now(),
             ),
         )
-        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null)
+        bigQueryAdapterService.oppdaterBigQuery(oppdatertBehandling, null, null)
         behandlingTilstandService.opprettSendingAvBehandlingenHenlagt(behandlingId, logContext)
 
         historikkService.lagHistorikkinnslag(

--- a/src/test/kotlin/no/nav/familie/tilbake/api/baks/BAKSPorteføljejusteringControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/tilbake/api/baks/BAKSPorteføljejusteringControllerTest.kt
@@ -65,7 +65,7 @@ class BAKSPorteføljejusteringControllerTest {
             status = "Eksisterer",
         )
 
-        every { bigQueryAdapterService.oppdaterBigQuery(any(), any()) } just runs
+        every { bigQueryAdapterService.oppdaterBigQuery(any(), any(), any()) } just runs
     }
 
     @Test


### PR DESCRIPTION
Siden vi ikke har mottatt kravgrunnlag i gammel modell ved opprettelse så bruker vi informasjonen for forhåndsvarsel til periode og beløp.